### PR TITLE
Fixes #38.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ DATABASE_USERNAME=root
 DATABASE_PASSWORD=
 #DATABASE_HOST=your-domain-here.com
 #DATABASE_PORT=3306
-DATABASE_SOCKET=/tmp/mysql.sock
+#DATABASE_SOCKET=/tmp/mysql.sock
 
 # ==== Additional required production settings ====
 


### PR DESCRIPTION
Commenting out socket under .env.example since that may not be the socket always used to connect to mysql. 
