### PR TITLE
Added link to novice setup guide and corrected localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ If you just want to play around, you can simply clone this repository, then perf
 
 * Copy `.env.example` to `.env` (`cp .env.example .env`) and edit `.env`, at least updating the `APP_SECRET_TOKEN` variable.
 * Run `rake db:create`, `rake db:migrate`, and then `rake db:seed` to create a development MySQL database with some example seed data.
-* Run `foreman start`, visit `http://localhost:5000`, and login with the username of `admin` and the password of `password`.
+* Run `foreman start`, visit [http://localhost:3000/][localhost], and login with the username of `admin` and the password of `password`.
 * Setup some Agents!
+
+If you need more detailed instructions, see the [Novice setup guide][novice-setup-guide].
+
+[localhost]: http://localhost:3000/
+[novice-setup-guide]: https://github.com/cantino/huginn/wiki/Novice-setup-guide
 
 ### Real Start
 
@@ -97,6 +102,6 @@ Huginn is provided under the MIT License.
 
 Huginn is a work in progress and is hopefully just getting started.  Please get involved!  You can [add new Agents](https://github.com/cantino/huginn/wiki/Creating-a-new-agent), expand the [Wiki](https://github.com/cantino/huginn/wiki), or help us simplify and strengthen the Agent API or core application.
 
-Please fork, add specs, and send pull requests!  
+Please fork, add specs, and send pull requests!
 
 [![Build Status](https://travis-ci.org/cantino/huginn.png)](https://travis-ci.org/cantino/huginn)


### PR DESCRIPTION
In this pull request, I have added a link to the newly created Wiki page, [Novice setup guide](https://github.com/cantino/huginn/wiki/Novice-setup-guide) and corrected the documentation in the Quick Start to point to [http://localhost:3000/](http://localhost:3000/).

The localhost previously pointed to port `3000` which is contradictory to the [.env](https://github.com/cantino/huginn/blob/master/.env.example#L6-L8).

I apologize for combining these two into a single pull request. However, they were so simple I buckled in to the anti-pattern.
