### PR TITLE
use .env db settings for test environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,14 +14,14 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: mysql2
-  database: huginn_test
-  username: root
-  password:
-  socket: <%= ["/var/run/mysqld/mysqld.sock", "/opt/local/var/run/mysql5/mysqld.sock", "/tmp/mysql.sock"].find{ |path| File.exist? path } %>
-  encoding: utf8
-  reconnect: true
-  pool: 5
+  adapter: <%= ENV['DATABASE_ADAPTER'] || "mysql2" %>
+  database: <%= ENV['TEST_DATABASE_NAME'] || "huginn_test" %>
+  username: <%= ENV['DATABASE_USERNAME'] || "root" %>
+  password:  <%= ENV['DATABASE_PASSWORD'] || "" %>
+  socket: <%= ENV['DATABASE_SOCKET'] || ["/var/run/mysqld/mysqld.sock", "/opt/local/var/run/mysql5/mysqld.sock", "/tmp/mysql.sock"].find{ |path| File.exist? path } %>
+  encoding: <%= ENV['DATABASE_ENCODING'] || "utf8" %>
+  reconnect: <%= ENV['DATABASE_RECONNECT'] || "true" %>
+  pool: <%= ENV['DATABASE_POOL'] || "5" %>
 
 production:
   adapter: <%= ENV['DATABASE_ADAPTER'] || "mysql2" %>


### PR DESCRIPTION
Our default MySQL setup has a root password and we needed it for the Rails test environment.
