### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ Huginn is a work in progress and is hopefully just getting started.  Please get 
 
 Please fork, add specs, and send pull requests!
 
-[![Build Status](https://travis-ci.org/cantino/huginn.png)](https://travis-ci.org/cantino/huginn)
+[![Build Status](https://travis-ci.org/cantino/huginn.png)](https://travis-ci.org/cantino/huginn) [![Code Climate](https://codeclimate.com/github/cantino/huginn.png)](https://codeclimate.com/github/cantino/huginn)


### PR DESCRIPTION
Hey,

First off, Huginn looks pretty cool. Really interesting approach.

Anyways, I just wanted to drop you a note to let you know that someone added Huginn to Code Climate a while back.

I'm the guy who built Code Climate (automated quality metrics for Ruby) and it's free for OSS. The Huggin code quality reports live here:

https://codeclimate.com/github/cantino/huginn

This PR adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA so that contributors can use the information.

Let me know if you have any questions, or I can help with anything.

Hope you find Code Climate useful.

Best,
Bryan
