### PR TITLE
Allow Agents' detail views to POST to the server; add a new ManualEventAgent for testing

### DIFF
--- a/app/assets/javascripts/application.js.coffee.erb
+++ b/app/assets/javascripts/application.js.coffee.erb
@@ -8,13 +8,14 @@
 #= require ./worker-checker
 #= require_self
 
-setupJsonEditor = ->
+window.setupJsonEditor = ($editor = $(".live-json-editor")) ->
   JSONEditor.prototype.ADD_IMG = '<%= image_path 'json-editor/add.png' %>'
   JSONEditor.prototype.DELETE_IMG = '<%= image_path 'json-editor/delete.png' %>'
-  if $(".live-json-editor").length
-    window.jsonEditor = new JSONEditor($(".live-json-editor"), 400, 500)
-    window.jsonEditor.doTruncation true
-    window.jsonEditor.showFunctionButtons()
+  if $editor.length
+    jsonEditor = new JSONEditor($editor, $editor.data('width') || 400, $editor.data('height') || 500)
+    jsonEditor.doTruncation true
+    jsonEditor.showFunctionButtons()
+    return jsonEditor
 
 hideSchedule = ->
   $(".schedule-region select").hide()
@@ -45,7 +46,7 @@ showEventDescriptions = ->
 
 $(document).ready ->
   # JSON Editor
-  setupJsonEditor()
+  window.jsonEditor = setupJsonEditor()
 
   # Select2 Selects
   $(".select2").select2(width: 'resolve')

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -8,6 +8,16 @@ class AgentsController < ApplicationController
     end
   end
 
+  def handle_details_post
+    @agent = current_user.agents.find(params[:id])
+    if @agent.respond_to?(:handle_details_post)
+      render :json => @agent.handle_details_post(params) || {}
+    else
+      @agent.error "#handle_details_post called on an instance of #{@agent.class} that does not define it."
+      head 500
+    end
+  end
+
   def run
     agent = current_user.agents.find(params[:id])
     Agent.async_check(agent.id)

--- a/app/models/agents/manual_event_agent.rb
+++ b/app/models/agents/manual_event_agent.rb
@@ -1,0 +1,32 @@
+module Agents
+  class ManualEventAgent < Agent
+    cannot_be_scheduled!
+    cannot_receive_events!
+
+    description <<-MD
+      Use this Agent to manually create Events for testing or other purposes.
+    MD
+
+    event_description "User determined"
+
+    def default_options
+      { "no options" => "are needed" }
+    end
+
+    def handle_details_post(params)
+      if params[:payload]
+        create_event(:payload => params[:payload])
+        { :success => true }
+      else
+        { :success => false, :error => "You must provide a JSON payload" }
+      end
+    end
+
+    def working?
+      true
+    end
+
+    def validate_options
+    end
+  end
+end

--- a/app/views/agents/agent_views/manual_event_agent/_show.html.erb
+++ b/app/views/agents/agent_views/manual_event_agent/_show.html.erb
@@ -1,0 +1,42 @@
+<h3>Manually Create Events</h3>
+
+<h4 id='event-creation-status'></h4>
+
+<%= form_tag handle_details_post_agent_path(@agent), :id => "create-event-form" do %>
+  <div class="control-group">
+    <textarea rows="10" id="payload" name="payload" class="span8 payload-editor" data-height="200">
+      {}
+    </textarea>
+  </div>
+
+  <div class='form-actions' style='clear: both'>
+    <%= submit_tag "Submit", :class => "btn btn-primary" %>
+  </div>
+<% end %>
+
+<script>
+  $(function () {
+    var payloadJsonEditor = window.setupJsonEditor($(".payload-editor"));
+    $("#create-event-form").submit(function (e) {
+      e.preventDefault();
+      var $form = $("#create-event-form");
+      var $status = $("#event-creation-status");
+      $.ajax({
+        url: $form.attr('action'),
+        method: "post",
+        data: { payload: JSON.parse($form.find("textarea").val()) },
+        dataType: "JSON",
+        success: function(json) {
+          if (json.success) {
+            $status.text("Success!");
+          } else {
+            $status.text("An error occurred: " + json.error);
+          }
+        },
+        error: function(response) {
+          $status.text("An error occurred: " + response.responseText)
+        }
+      });
+    });
+  });
+</script>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -132,12 +132,12 @@
 
             <p>
               <b>Options:</b>
-              <pre><%= JSON.pretty_generate @agent.options %></pre>
+              <pre><%= JSON.pretty_generate @agent.options || {} %></pre>
             </p>
 
             <p>
               <b>Memory:</b>
-              <pre><%= JSON.pretty_generate @agent.memory %></pre>
+              <pre><%= JSON.pretty_generate @agent.memory || {} %></pre>
             </p>
           </div>
         </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -16,6 +16,7 @@
         </tr>
 
       <% @events.each do |event| %>
+        <% next unless event.agent %>
         <tr>
           <td><%= link_to event.agent.name, agent_path(event.agent) %></td>
           <td><%= time_ago_in_words event.created_at %> ago</td>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -7,7 +7,7 @@
 
       <p>
         <b>Payload:</b>
-        <pre><%= JSON.pretty_generate @event.payload %></pre>
+        <pre><%= JSON.pretty_generate @event.payload || {} %></pre>
       </p>
 
       <% if @event.lat && @event.lng %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Huginn::Application.routes.draw do
   resources :agents do
     member do
       post :run
+      post :handle_details_post
       delete :remove_events
     end
 

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -18,6 +18,22 @@ describe AgentsController do
     end
   end
 
+  describe "POST handle_details_post" do
+    it "passes control to handle_details_post on the agent" do
+      sign_in users(:bob)
+      post :handle_details_post, :id => agents(:bob_manual_event_agent).to_param, :payload => { :foo => "bar" }
+      JSON.parse(response.body).should == { "success" => true }
+      agents(:bob_manual_event_agent).events.last.payload.should == { :foo => "bar" }
+    end
+
+    it "can only be accessed by the Agent's owner" do
+      sign_in users(:jane)
+      lambda {
+        post :handle_details_post, :id => agents(:bob_manual_event_agent).to_param, :payload => { :foo => :bar }
+      }.should raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   describe "GET show" do
     it "only shows Agents for the current user" do
       sign_in users(:bob)

--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -92,3 +92,8 @@ bob_twitter_user_agent:
       :oauth_token => "---",
       :oauth_token_secret => "---"
     }.to_yaml.inspect %>
+
+bob_manual_event_agent:
+  type: Agents::ManualEventAgent
+  user: bob
+  name: "Bob's event testing agent"

--- a/spec/models/agents/peak_detector_agent_spec.rb
+++ b/spec/models/agents/peak_detector_agent_spec.rb
@@ -69,10 +69,6 @@ describe Agents::PeakDetectorAgent do
                                   :pattern => { :filter => "something" })
       @agent.memory[:peaks][:something].length.should == 2
     end
-
-    it "works on real world data" do
-      pending "need examples"
-    end
   end
 
   describe "validation" do


### PR DESCRIPTION
Add a POST endpoint called handle_details_post that Agents' details views can use to send data to the Agent from the UI.  Add a new ManualEventAgent that uses the handle_details_post functionality to create simple events on demand for testing / debugging.
