### PR TITLE
moving mail config into an initializer and a config/smtp.yml file

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,13 +39,5 @@ Huginn::Application.configure do
   config.action_mailer.perform_deliveries = false # Enable when testing!
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-      address: ENV['SMTP_SERVER'] || 'smtp.gmail.com',
-      port: ENV['SMTP_PORT'] || 587,
-      domain: ENV['SMTP_DOMAIN'],
-      authentication: ENV['SMTP_AUTHENTICATION'] || 'plain',
-      enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false,
-      user_name: ENV['SMTP_USER_NAME'],
-      password: ENV['SMTP_PASSWORD']
-  }
+  # smtp_settings moved to config/initializers/action_mailer.rb
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,16 +66,11 @@ Huginn::Application.configure do
 
   config.action_mailer.default_url_options = { :host => ENV['DOMAIN'] }
   config.action_mailer.asset_host = ENV['DOMAIN']
+  if ENV['ASSET_HOST']
+    config.action_mailer.asset_host = ENV['ASSET_HOST']
+  end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-      address: ENV['SMTP_SERVER'] || 'smtp.gmail.com',
-      port: ENV['SMTP_PORT'] || 587,
-      domain: ENV['SMTP_DOMAIN'],
-      authentication: ENV['SMTP_AUTHENTICATION'] || 'plain',
-      enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false,
-      user_name: ENV['SMTP_USER_NAME'],
-      password: ENV['SMTP_PASSWORD']
-  }
+  # smtp_settings moved to config/initializers/action_mailer.rb
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -66,16 +66,11 @@ Huginn::Application.configure do
 
   config.action_mailer.default_url_options = { :host => ENV['DOMAIN'] }
   config.action_mailer.asset_host = ENV['DOMAIN']
+  if ENV['ASSET_HOST']
+    config.action_mailer.asset_host = ENV['ASSET_HOST']
+  end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-      address: ENV['SMTP_SERVER'] || 'smtp.gmail.com',
-      port: ENV['SMTP_PORT'] || 587,
-      domain: ENV['SMTP_DOMAIN'],
-      authentication: ENV['SMTP_AUTHENTICATION'] || 'plain',
-      enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false,
-      user_name: ENV['SMTP_USER_NAME'],
-      password: ENV['SMTP_PASSWORD']
-  }
+  # smtp_settings moved to config/initializers/action_mailer.rb
 end

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,0 +1,16 @@
+# Read smtp config out of a config/smtp.yml file
+
+smtp_config = YAML::load(ERB.new(File.read(Rails.root.join('config', 'smtp.yml'))).result)
+if smtp_config.keys.include? Rails.env
+  Huginn::Application.config.action_mailer.smtp_settings = smtp_config[Rails.env].symbolize_keys
+end
+
+# Huginn::Application.config.action_mailer.smtp_settings = {
+#   address: ENV['SMTP_SERVER'] || 'smtp.gmail.com',
+#   port: ENV['SMTP_PORT'] || 587,
+#   domain: ENV['SMTP_DOMAIN'],
+#   authentication: ENV['SMTP_AUTHENTICATION'] || 'plain',
+#   enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false,
+#   user_name: ENV['SMTP_USER_NAME'],
+#   password: ENV['SMTP_PASSWORD']
+# }

--- a/config/smtp.yml
+++ b/config/smtp.yml
@@ -1,0 +1,26 @@
+development:
+  address: <%= ENV['SMTP_SERVER'] || "smtp.gmail.com" %>
+  port: <%= ENV['SMTP_PORT'] || 587 %>
+  domain: <%= ENV['SMTP_DOMAIN'] %>
+  authentication: <%= ENV['SMTP_AUTHENTICATION'] || "plain" %>
+  enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
+  user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
+  password: <%= ENV['SMTP_PASSWORD'] || "" %>
+
+staging:
+  address: <%= ENV['SMTP_SERVER'] || "smtp.gmail.com" %>
+  port: <%= ENV['SMTP_PORT'] || 587 %>
+  domain: <%= ENV['SMTP_DOMAIN'] %>
+  authentication: <%= ENV['SMTP_AUTHENTICATION'] || "plain" %>
+  enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
+  user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
+  password: <%= ENV['SMTP_PASSWORD'] || "" %>
+
+production:
+  address: <%= ENV['SMTP_SERVER'] || "smtp.gmail.com" %>
+  port: <%= ENV['SMTP_PORT'] || 587 %>
+  domain: <%= ENV['SMTP_DOMAIN'] %>
+  authentication: <%= ENV['SMTP_AUTHENTICATION'] || "plain" %>
+  enable_starttls_auto: <%= ENV['SMTP_ENABLE_STARTTLS_AUTO'] == 'true' ? true : false %>
+  user_name: <%= ENV['SMTP_USER_NAME'] || "" %>
+  password: <%= ENV['SMTP_PASSWORD'] || "" %>


### PR DESCRIPTION
This is another deployment related pull request.

This ones moves the action_mailer's smtp config into a separate `config/smtp.yml` file which is then loaded by an initializer.

That way the `config/smtp.yml` file can be template out by other deployment processes just like the `database.yml` file instead of relying on setting environment variables.
