### PR TITLE
Handle rufus_scheduler v3 also

### DIFF
--- a/bin/schedule.rb
+++ b/bin/schedule.rb
@@ -11,22 +11,26 @@ end
 require 'rufus/scheduler'
 
 def run_schedule(time, mutex)
-  mutex.synchronize do
-    puts "Queuing schedule for #{time}"
-    Agent.delay.run_schedule(time)
+  ActiveRecord::Base.connection_pool.with_connection do
+    mutex.synchronize do
+      puts "Queuing schedule for #{time}"
+      Agent.delay.run_schedule(time)
+    end
   end
 end
 
 def propogate!(mutex)
-  mutex.synchronize do
-    puts "Queuing event propagation"
-    Agent.delay.receive!
+  ActiveRecord::Base.connection_pool.with_connection do
+    mutex.synchronize do
+      puts "Queuing event propagation"
+      Agent.delay.receive!
+    end
   end
 end
 
 mutex = Mutex.new
 
-scheduler = Rufus::Scheduler.start_new
+scheduler = Rufus::Scheduler.new
 
 # Schedule event propagation.
 


### PR DESCRIPTION
Stop rufus_scheduler v3 leaking ActiveRecord handles. See [this StackOverflow answer for details](http://stackoverflow.com/a/19380690/1270789).

rufus_scheduler v3 [deprecated `start_new`](https://github.com/jmettraux/rufus-scheduler/blob/master/lib/rufus/scheduler.rb#L120), so instead I call `new`. In [v2.0.22 this creates a `PlainScheduler`](https://github.com/jmettraux/rufus-scheduler/blob/82b70feeb28b2aa778d1d869aba12b580966a786/lib/rufus/scheduler.rb#L33), but fortunately the defaults that Huginn uses means that `start_new` in v3.0.x also creates a `PlainScheduler`.
