### PR TITLE
Quick'n'dirty patch to address touchscreen issues

### DIFF
--- a/vendor/assets/javascripts/bootstrap.js
+++ b/vendor/assets/javascripts/bootstrap.js
@@ -2023,3 +2023,5 @@
 
 
 }(window.jQuery);
+
+$('body').on('touchstart.dropdown', '.dropdown-menu', function (e) { e.stopPropagation(); });


### PR DESCRIPTION
The code taken from here:

https://github.com/twbs/bootstrap/pull/5067#issuecomment-8604323

It fixes a problem that may be present on certain Android (and other) browsers whereby pop-up menus like Huginn's `Account` one on the menu bar do not open on touch.

The problem and fix is also [summarised in this blog post](http://alittlecode.com/fix-twitter-bootstraps-dropdown-menus-in-touch-screens/).
