### PR TITLE
Removing one of two instances of 'rake' in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,5 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'rr'
   gem 'webmock', :require => false
-  gem 'rake'
   gem 'coveralls', :require => false
 end


### PR DESCRIPTION
I was getting weary of seeing this message every time I ran Bundler:

```
Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

Rake is included both in the main list of gems and in the development group. I opted to remove it from the development group since I believe admins as well as developers will want to be able to run some Rake tasks.
