### PR TITLE
#141 change delayed_job.handler to mediumtext (16MB) like event.payload

### DIFF
--- a/db/migrate/20140127164931_change_handler_to_medium_text.rb
+++ b/db/migrate/20140127164931_change_handler_to_medium_text.rb
@@ -1,0 +1,19 @@
+# Increase handler size to 16MB (consistent with events.payload)
+
+class ChangeHandlerToMediumText < ActiveRecord::Migration
+  def up
+    if mysql?
+      change_column :delayed_jobs, :handler, :text, :limit => 16777215
+    end
+  end
+
+  def down
+    if mysql?
+      change_column :delayed_jobs, :handler, :text, :limit => 65535
+    end
+  end
+
+  def mysql?
+    ActiveRecord::Base.connection.adapter_name =~ /mysql/i
+  end
+end


### PR DESCRIPTION
This isn't a complete fix because if the event.payload is (say) exactly
16MB then the handler will be >16MB and the same problem will occur.

I'll push this in for now though, in practice it means it's much less
likely to occur.
