### PR TITLE
Take care of the case where most_recent_event is nil.

### DIFF
--- a/app/models/agents/twitter_publish_agent.rb
+++ b/app/models/agents/twitter_publish_agent.rb
@@ -25,7 +25,7 @@ module Agents
     end
 
     def working?
-      event_created_within?(options['expected_update_period_in_days']) && most_recent_event.payload['success'] == true && !recent_error_logs?
+      event_created_within?(options['expected_update_period_in_days']) && most_recent_event && most_recent_event.payload['success'] == true && !recent_error_logs?
     end
 
     def default_options


### PR DESCRIPTION
If you use TwitterPublishAgent for the first time and there is no preceding event, `working?` fails.
