### PR TITLE
Add :xpath support to WebsiteAgent.

### DIFF
--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -114,6 +114,19 @@ describe Agents::WebsiteAgent do
         event.payload['hovertext'].should =~ /^Biologists play reverse/
       end
 
+      it "parses XPath" do
+        @site['extract'].each { |key, value|
+          value.delete('css')
+          value['xpath'] = "//*[@id='comic']//img"
+        }
+        @checker.options = @site
+        @checker.check
+        event = Event.last
+        event.payload['url'].should == "http://imgs.xkcd.com/comics/evolving.png"
+        event.payload['title'].should == "Evolving"
+        event.payload['hovertext'].should =~ /^Biologists play reverse/
+      end
+
       it "should turn relative urls to absolute" do
         rel_site = {
           'name' => "XKCD",


### PR DESCRIPTION
Sometimes the CSS selector notation is not enough to extract desired data from a complex DOM structure.

It would be nice if you could use XPath (1.0) expressions just like you do in Yahoo! Pipes.
