### PR TITLE
Upgrade Rails and use pessimistic versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,6 @@ gem 'weibo_2', '~> 0.1.4'
 
 gem 'therubyracer', '~> 0.12.1'
 
-platforms :ruby_18 do
-  gem 'system_timer'
-  gem 'fastercsv'
-end
-
 group :development do
   gem 'binding_of_caller'
   gem 'better_errors'
@@ -64,6 +59,6 @@ group :development, :test do
   gem 'rspec'
   gem 'shoulda-matchers'
   gem 'rr'
-  gem 'webmock', :require => false
-  gem 'coveralls', :require => false
+  gem 'webmock', require: false
+  gem 'coveralls', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,6 @@ GEM
     execjs (2.0.2)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    fastercsv (1.5.5)
     ffi (1.9.3)
     forecast_io (2.0.0)
       faraday
@@ -248,7 +247,6 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    system_timer (1.2.4)
     systemu (2.6.4)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
@@ -316,7 +314,6 @@ DEPENDENCIES
   devise (~> 3.0.0)
   dotenv-rails
   em-http-request (~> 1.1.2)
-  fastercsv
   forecast_io (~> 2.0.0)
   foreman (~> 0.63.0)
   geokit (~> 1.6.7)
@@ -339,7 +336,6 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   select2-rails (~> 3.4.3)
   shoulda-matchers
-  system_timer
   therubyracer (~> 0.12.1)
   twilio-ruby (~> 3.10.0)
   twitter (~> 5.7.1)


### PR DESCRIPTION
As promised! There still are outdated dependencies, but at least Rails is updated now.

By the way, can we remove support for Ruby 1.8? Doesn't seem to be tested on Travis.
