### PR TITLE
 Add a setting for using locally installed Graphviz for generating diagrams.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,8 @@ AWS_ACCESS_KEY="your aws access key"
 
 # Set AWS_SANDBOX to true if you're developing Huginn code.
 AWS_SANDBOX=false
+
+# Use Graphviz for generating diagrams instead of using Google Chart
+# Tools.  Specify a dot(1) command path built with SVG support
+# enabled.
+#USE_GRAPHVIZ_DOT=dot

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,19 @@ module ApplicationHelper
       link_to '<span class="label label-warning">No</span>'.html_safe, agent_path(agent, :tab => (agent.recent_error_logs? ? 'logs' : 'details'))
     end
   end
+
+  def render_dot(dot_format_string)
+    if (command = ENV['USE_GRAPHVIZ_DOT']) &&
+       (svg = IO.popen([command, *%w[-Tsvg -q1 -o/dev/stdout /dev/stdin]], 'w+') { |dot|
+          dot.print dot_format_string
+          dot.close_write
+          dot.read
+        } rescue false)
+      svg.html_safe
+    else
+      tag('img', src: URI('https://chart.googleapis.com/chart').tap { |uri|
+            uri.query = URI.encode_www_form(cht: 'gv', chl: dot_format_string)
+          })
+    end
+  end
 end

--- a/app/views/agents/diagram.html.erb
+++ b/app/views/agents/diagram.html.erb
@@ -19,8 +19,7 @@
            end
            dot_format_string = dot_format_string + "}"
         %>
-
-        <img src="https://chart.googleapis.com/chart?cht=gv&chl=<%= CGI::escape dot_format_string %>" />
+        <%= render_dot(dot_format_string) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The Google Charts service is only capable of rendering a limited range
of characters, so if you name your agents in an exotic language
generated diagrams are virtually useless being unable to make out.

With this change, Huginn embeds a locally generated SVG diagram instead
of relying on a third-party API if config.use_graphviz_dot is set to a
command name/path of dot(1).

For example, Google Charts API does not support kanji characters in its Graphviz generator.
