### PR TITLE
Basecamp: ensure url encoding of http parameters

### DIFF
--- a/app/models/agents/basecamp_agent.rb
+++ b/app/models/agents/basecamp_agent.rb
@@ -64,8 +64,7 @@ module Agents
     end
 
     def check
-      log "Requesting events from #{request_url}"
-      reponse = HTTParty.get request_url, auth_options.merge(:headers => {"User-Agent" => "Huginn (https://github.com/cantino/huginn)"})
+      reponse = HTTParty.get request_url, request_options.merge(query_parameters)
       memory[:last_run] = Time.now.utc.iso8601
       if last_check_at != nil
         JSON.parse(reponse.body).each do |event|
@@ -76,17 +75,16 @@ module Agents
     end
 
   private
-    def first_run?
-      memory[:first_run].nil?
-    end
-
     def request_url
-      since = memory[:last_run] ? "?since=#{memory[:last_run]}" : ''
-      "https://basecamp.com/#{URI.encode(options[:user_id].to_s)}/api/v1/projects/#{URI.encode(options[:project_id].to_s)}/events.json#{since}"
+      "https://basecamp.com/#{URI.encode(options[:user_id].to_s)}/api/v1/projects/#{URI.encode(options[:project_id].to_s)}/events.json"
     end
 
-    def auth_options
-      {:basic_auth => {:username =>options[:username], :password=>options[:password]}}
+    def request_options
+      {:basic_auth => {:username =>options[:username], :password=>options[:password]}, :headers => {"User-Agent" => "Huginn (https://github.com/cantino/huginn)"}}
+    end
+
+    def query_parameters
+      memory[:last_run].present? ? { :query => {:since => memory[:last_run]} } : {}
     end
   end
 end

--- a/spec/models/agents/basecamp_agent_spec.rb
+++ b/spec/models/agents/basecamp_agent_spec.rb
@@ -44,19 +44,24 @@ describe Agents::BasecampAgent do
   end
 
   describe "helpers" do
-    it "should generate a correct auth hash" do
-      @checker.send(:auth_options).should == {:basic_auth=>{:username=>"user", :password=>"pass"}}
+    it "should generate a correct request options hash" do
+      @checker.send(:request_options).should == {:basic_auth=>{:username=>"user", :password=>"pass"}, :headers => {"User-Agent" => "Huginn (https://github.com/cantino/huginn)"}}
     end
 
-    it "should not provide the since attribute on first run" do
+    it "should generate the currect request url" do
       @checker.send(:request_url).should == "https://basecamp.com/12345/api/v1/projects/6789/events.json"
+    end
+
+
+    it "should not provide the since attribute on first run" do
+      @checker.send(:query_parameters).should == {}
     end
 
     it "should provide the since attribute after the first run" do
       time = (Time.now-1.minute).iso8601
       @checker.memory[:last_run] = time
       @checker.save
-      @checker.reload.send(:request_url).should == "https://basecamp.com/12345/api/v1/projects/6789/events.json?since=#{time}"
+      @checker.reload.send(:query_parameters).should == {:query => {:since => time}}
     end
   end
   describe "#check" do


### PR DESCRIPTION
The since paramter is now passed to HTTParty which takes care of encoding it properly
