### PR TITLE
Added list option to TriggerAgent

### DIFF
--- a/app/models/agents/trigger_agent.rb
+++ b/app/models/agents/trigger_agent.rb
@@ -2,7 +2,7 @@ module Agents
   class TriggerAgent < Agent
     cannot_be_scheduled!
 
-    VALID_COMPARISON_TYPES = %w[regex !regex field<value field<=value field==value field!=value field>=value field>value]
+    VALID_COMPARISON_TYPES = %w[regex !regex field<value field<=value field==value list field!=value field>=value field>value]
 
     description <<-MD
       Use a TriggerAgent to watch for a specific value in an Event payload.
@@ -66,6 +66,14 @@ module Agents
               value_at_path.to_s == rule['value'].to_s
             when "field!=value"
               value_at_path.to_s != rule['value'].to_s
+            when "list"
+              list_match = false
+              rule['value'].each do |value|
+                if value_at_path.to_s == value.to_s 
+                  list_match = true;
+                end
+              end
+              list_match
             else
               raise "Invalid type of #{rule['type']} in TriggerAgent##{id}"
           end

--- a/spec/models/agents/trigger_agent_spec.rb
+++ b/spec/models/agents/trigger_agent_spec.rb
@@ -124,6 +124,21 @@ describe Agents::TriggerAgent do
       }.should change { Event.count }.by(1)
     end
 
+    it "handles list comparisons" do
+      @event.payload['foo']['bar']['baz'] = "hello world"
+      @checker.options['rules'].first['type'] = "list"
+
+      @checker.options['rules'].first['value'] = ["hello there", "hello again"]
+      lambda {
+        @checker.receive([@event])
+      }.should_not change { Event.count }
+
+      @checker.options['rules'].first['value'] = ["hello there", "hello again", "hello world"]
+      lambda {
+        @checker.receive([@event])
+      }.should change { Event.count }.by(1)
+    end
+
     it "handles negated comparisons" do
       @event.payload['foo']['bar']['baz'] = "hello world"
       @checker.options['rules'].first['type'] = "field!=value"


### PR DESCRIPTION
Hi,

I added a "list" option to the TriggerAgent where you can match against an array of words/phrases. This is more of a convenience than new functionality (you can do the same thing with the right regex). It's just much easier to see on the show/edit pages the list of words that the TriggerAgent is matching against when it's in the form of an array.

Cheers
