### PR TITLE
Allow PostAgents to specify a default hash of data to be POSTed, as well as to be run periodically.

### DIFF
--- a/app/models/agents/post_agent.rb
+++ b/app/models/agents/post_agent.rb
@@ -57,7 +57,7 @@ module Agents
 
     def generate_uri(params = nil)
       uri = URI options[:post_url]
-      uri.query = URI.encode_www_form(Hash[URI.decode_www_form(uri.query)].merge(params)) if params
+      uri.query = URI.encode_www_form(Hash[URI.decode_www_form(uri.query || '')].merge(params)) if params
       uri
     end
 

--- a/spec/models/agents/post_agent_spec.rb
+++ b/spec/models/agents/post_agent_spec.rb
@@ -152,6 +152,12 @@ describe Agents::PostAgent do
       uri.request_uri.should == "/a/path?existing_param=existing_value&some_param=some_value&another_param=another_value"
     end
 
+    it "works fine with urls that do not have a query" do
+      @checker.options['post_url'] = "http://example.com/a/path"
+      uri = @checker.generate_uri("some_param" => "some_value", "another_param" => "another_value")
+      uri.request_uri.should == "/a/path?some_param=some_value&another_param=another_value"
+    end
+
     it "just returns the post_uri when no params are given" do
       @checker.options['post_url'] = "http://example.com/a/path?existing_param=existing_value"
       uri = @checker.generate_uri


### PR DESCRIPTION
PostAgent can now
- accept a hash of default data to send, into which event payloads are merged
- make GET requests (somewhat incongruently; name change may be forthcoming)
