### PR TITLE
Rails 4 deprecated find_by fix

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 
-user = User.find_or_initialize_by_email("admin@example.com")
+user = User.find_or_initialize_by(:email => "admin@example.com")
 user.username = "admin"
 user.password = "password"
 user.password_confirmation = "password"


### PR DESCRIPTION
Rails 4 deprecated find_by fix. `bundle exec rake db:seed` throws an error for me without this. -> #232

I hope I'm doing this pull request correctly, but I am unsure if it is conventional since it is only one line.
