### PR TITLE
WebsiteAgent: Add support for using HTTPClient as backend.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'geokit-rails3', '~> 0.1.5'
 gem 'kramdown', '~> 1.1.0'
 gem 'typhoeus', '~> 0.6.3'
 gem 'nokogiri', '~> 1.6.0'
+gem 'httpclient'
 
 gem 'wunderground', '~> 1.1.0'
 gem 'forecast_io', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
+    httpclient (2.3.4.1)
     i18n (0.6.9)
     journey (1.0.4)
     jquery-rails (3.0.4)
@@ -321,6 +322,7 @@ DEPENDENCIES
   geokit (~> 1.6.7)
   geokit-rails3 (~> 0.1.5)
   hipchat (~> 1.1.0)
+  httpclient
   jquery-rails (~> 3.0.4)
   json (>= 1.7.7)
   jsonpath (~> 0.5.3)


### PR DESCRIPTION
I'm having a problem with typhoeus/ethon described in typhoeus/typhoeus#137, and it doesn't seem to be addressed unless it is reproducible by the authors.

In the meantime, I don't need the extreme parallelism that typhoeus offers, so here's a patch to make it possible for WebsiteAgent to use an alternative HTTP library.
