### PR TITLE
Fixes vagrant's development mode rake bootstrap.

### DIFF
--- a/deployment/roles/huginn_development.json
+++ b/deployment/roles/huginn_development.json
@@ -23,6 +23,7 @@
              "recipe[git]",
              "recipe[apt]",
              "recipe[mysql::server]",
+             "recipe[mysql::client]",
              "recipe[nodejs::install_from_binary]",
              "recipe[huginn_development]"
            ]

--- a/deployment/site-cookbooks/huginn_development/recipes/default.rb
+++ b/deployment/site-cookbooks/huginn_development/recipes/default.rb
@@ -55,7 +55,7 @@ bash "huginn dependencies" do
     export LANG="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
     sudo bundle install
-    sed s/REPLACE_ME_NOW\!/$(sudo rake secret)/ .env.example > .env
+    sed s/REPLACE_ME_NOW\!/$(sudo bundle exec rake secret)/ .env.example > .env
     sudo bundle exec rake db:create
     sudo bundle exec rake db:migrate
     sudo bundle exec rake db:seed


### PR DESCRIPTION
When running vagrant in dev mode, my install complained that the mysql dev libraries weren't installed, and none of the rake commands would run unless `bundle exec` was prepended to the command.
