### PR TITLE
Set default ruby and gem versions to 1.9.1 in huginn_production

### DIFF
--- a/deployment/site-cookbooks/huginn_production/recipes/default.rb
+++ b/deployment/site-cookbooks/huginn_production/recipes/default.rb
@@ -14,8 +14,15 @@ group "huginn" do
   members ["huginn"]
 end
 
-%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libshadow-ruby1.8" "libmysqlclient-dev" "libffi-dev" "libssl-dev").each do |pkg|
+%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libshadow-ruby1.8" "libmysqlclient-dev" "libffi-dev" "libssl-dev" "rubygems").each do |pkg|
   package("#{pkg}")
+end
+
+bash "Setting default ruby version to 1.9" do
+  code <<-EOH
+    update-alternatives --set ruby /usr/bin/ruby1.9.1
+    update-alternatives --set gem /usr/bin/gem1.9.1
+  EOH
 end
 
 gem_package("rake")


### PR DESCRIPTION
If ruby is set to default system version, the environment
provisioned with huginn_production fails to process events.

Also, the default environment misses rubygems. Here is what
I see in dj-1.log:

`require': no such file to load -- rubygems (LoadError)

This changeset will update the default system ruby to 1.9.1 and
install rubygems package.
