### PR TITLE
Changed the notification format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ notifications:
     channels:
       - "chat.freenode.net#huginn"
     template:
-      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "<%{author}> %{branch} - %{commit} (%{commit_message}): %{message}"
       - "Change view : %{compare_url}"
       - "Build details : %{build_url}"


### PR DESCRIPTION
I think the most important part, the commit message, was missing previously.
I also removed some less important parts, the repository will probably stay
the same and the travis build number is included in the build details link.

Before:
cantino/huginn#533 (master - 079b02f : Andrew Cantino): The build passed.
After:
<Andrew Cantino> master - 079b02f (Some random commit message): The build passed.
