### PR TITLE
add AWS support via Vagrant

### DIFF
--- a/deployment/Vagrantfile
+++ b/deployment/Vagrantfile
@@ -21,4 +21,22 @@ Vagrant.configure("2") do |config|
   config.vm.provider :parallels do |prl, override|
     override.vm.box = "parallels/ubuntu-12.04"
   end
+
+  config.vm.define "aws" do |remote|
+    remote.vm.box     = "dummy"
+    remote.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+
+    remote.vm.provider :aws do |aws, override|
+      aws.access_key_id             = ENV["AWS_ACCESS_KEY_ID"]
+      aws.secret_access_key         = ENV["AWS_SECRET_ACCESS_KEY"]
+      aws.keypair_name              = ENV["AWS_KEYPAIR_NAME"]
+      aws.security_groups           = [ ENV["AWS_SECURITY_GROUP"] ]
+      override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
+      override.ssh.username         = ENV['AWS_SSH_USER'] || "ubuntu"
+      aws.region                    = ENV['AWS_REGION']   || "eu-west-1"
+      # ami-828675f5 == precise32
+      aws.ami                       = ENV['AWS_AMI']      || "ami-828675f5"
+      aws.instance_type             = "t1.micro"
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds AWS support via Vagrant.

Since the docs aren't in code (but in wiki), I'll add the relevant doc once this pull request has been accepted.

For the impatient:

Firstly, install the vagrant-aws plugin, and/or the dummy box:

```
vagrant plugin install vagrant-aws
vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
```

Then:

```
AWS_ACCESS_KEY_ID="your-aws-access-key" \
AWS_SECRET_ACCESS_KEY="your-aws-secret-key" \
AWS_KEYPAIR_NAME="keypair-name" \
AWS_SSH_PRIVKEY="~/.ssh/keypair-name.pem" \
AWS_SECURITY_GROUP="name (not ID) of security group that opens ports 22 and 3000 " \
vagrant up --provider=aws aws
```

The service will be available at the public DNS for your server, obtainable via the AWS console.
