### PR TITLE
Include zoneinfo only for freebsd, window

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ case RUBY_PLATFORM
 when /freebsd/i
   # Seems FreeBSD's zoneinfo is not exactly what tzinfo expects
   gem 'tzinfo-data'
-else
+when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
   # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 end


### PR DESCRIPTION
Fix following error when using MAC OSX:

`x64_mingw` is not a valid platform. The available options are: [:ruby,
:ruby_18, :ruby_19, :ruby_20, :mri, :mri_18, :mri_19, :mri_20, :rbx,
:jruby,
:mswin, :mingw, :mingw_18, :mingw_19, :mingw_20]
