### PR TITLE
Add non-intrusive support for AWS to Vagrantfile

### DIFF
--- a/deployment/Vagrantfile
+++ b/deployment/Vagrantfile
@@ -21,4 +21,20 @@ Vagrant.configure("2") do |config|
   config.vm.provider :parallels do |prl, override|
     override.vm.box = "parallels/ubuntu-12.04"
   end
+
+  config.vm.provider :aws do |aws, override|
+    aws.ami = ENV['AWS_AMI'] || "ami-828675f5"
+    aws.region = ENV['AWS_REGION'] || "eu-west-1"
+    aws.instance_type = "t1.micro"
+
+    override.vm.box = "dummy"
+    override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+    override.ssh.private_key_path = ENV["AWS_SSH_PRIVKEY"]
+    override.ssh.username = ENV['AWS_SSH_USER'] || "ubuntu"
+
+    aws.access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+    aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+    aws.keypair_name = ENV["AWS_KEYPAIR_NAME"]
+    aws.security_groups = [ ENV["AWS_SECURITY_GROUP"] ]
+  end
 end


### PR DESCRIPTION
This changeset adds support for AWS provisioning to
Vagrantfile. It won't get in the way of regular users
who want to just use Virtualbox.

The AWS provider will be required only if the user does:

vagrant up --provider=aws
