### PR TITLE
Small fix for the AddEventIdAtCreationToLinks migration

### DIFF
--- a/db/migrate/20140213053001_add_event_id_at_creation_to_links.rb
+++ b/db/migrate/20140213053001_add_event_id_at_creation_to_links.rb
@@ -1,8 +1,11 @@
 class AddEventIdAtCreationToLinks < ActiveRecord::Migration
+  class Link < ActiveRecord::Base; end
+  class Event < ActiveRecord::Base; end
+
   def up
     add_column :links, :event_id_at_creation, :integer, :null => false, :default => 0
 
-    Link.all.each do |link|
+    Link.all.find_each do |link|
       last_event_id = execute(
         <<-SQL
           SELECT #{ActiveRecord::Base.connection.quote_column_name('id')}


### PR DESCRIPTION
Noticed that this migration fails if there are links to an agent that doesn't have any events. This makes it slightly safer to run.
