### PR TITLE
Fix chef cookbooks to work with ubuntu 14.04

### DIFF
--- a/deployment/site-cookbooks/huginn_development/recipes/default.rb
+++ b/deployment/site-cookbooks/huginn_development/recipes/default.rb
@@ -16,16 +16,23 @@ group "huginn" do
   action :create
 end
 
-%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libmysqlclient-dev" "rubygems").each do |pkg|
+%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libmysqlclient-dev" "libffi-dev" "libssl-dev").each do |pkg|
   package pkg do
     action :install
   end
 end
 
-bash "Setting default ruby version to 1.9" do
+bash "Setting default ruby and gem versions to 1.9" do
   code <<-EOH
-    update-alternatives --set ruby /usr/bin/ruby1.9.1
-    update-alternatives --set gem /usr/bin/gem1.9.1
+    if [ $(readlink /usr/bin/ruby) != "ruby1.9.1" ]
+    then
+      update-alternatives --set ruby /usr/bin/ruby1.9.1
+    fi
+
+    if [ $(readlink /usr/bin/gem) != "gem1.9.1" ]
+    then
+      update-alternatives --set gem /usr/bin/gem1.9.1
+    fi
   EOH
 end
 

--- a/deployment/site-cookbooks/huginn_production/recipes/default.rb
+++ b/deployment/site-cookbooks/huginn_production/recipes/default.rb
@@ -14,14 +14,21 @@ group "huginn" do
   members ["huginn"]
 end
 
-%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libshadow-ruby1.8" "libmysqlclient-dev" "libffi-dev" "libssl-dev" "rubygems").each do |pkg|
+%w("ruby1.9.1" "ruby1.9.1-dev" "libxslt-dev" "libxml2-dev" "curl" "libmysqlclient-dev" "libffi-dev" "libssl-dev").each do |pkg|
   package("#{pkg}")
 end
 
-bash "Setting default ruby version to 1.9" do
+bash "Setting default ruby and gem versions to 1.9" do
   code <<-EOH
-    update-alternatives --set ruby /usr/bin/ruby1.9.1
-    update-alternatives --set gem /usr/bin/gem1.9.1
+    if [ $(readlink /usr/bin/ruby) != "ruby1.9.1" ]
+    then
+      update-alternatives --set ruby /usr/bin/ruby1.9.1
+    fi
+
+    if [ $(readlink /usr/bin/gem) != "gem1.9.1" ]
+    then
+      update-alternatives --set gem /usr/bin/gem1.9.1
+    fi
   EOH
 end
 


### PR DESCRIPTION
The primary issue was that libshadow-ruby1.8 is not
present in 14.04. The secondary one is that default
ruby in 14.04 is 1.9, so update-alternatives step
fails.

Fix:
- drop the requirement of libshadow-ruby1.8, since
  we set 1.9 by default.
- see if 'ruby' points to 1.9 and update symlinks only
  in case it doesn't
