### PR TITLE
Fixes rename_digest_email_to_email_digest migration for PostgreSQL

### DIFF
--- a/db/migrate/20140603104211_rename_digest_email_to_email_digest.rb
+++ b/db/migrate/20140603104211_rename_digest_email_to_email_digest.rb
@@ -2,8 +2,8 @@ class RenameDigestEmailToEmailDigest < ActiveRecord::Migration
   def up
     sql = <<-SQL
       UPDATE #{ActiveRecord::Base.connection.quote_table_name('agents')}
-      SET #{ActiveRecord::Base.connection.quote_column_name('type')} = "Agents::EmailDigestAgent"
-      WHERE #{ActiveRecord::Base.connection.quote_column_name('type')} = "Agents::DigestEmailAgent"
+      SET #{ActiveRecord::Base.connection.quote_column_name('type')} = 'Agents::EmailDigestAgent'
+      WHERE #{ActiveRecord::Base.connection.quote_column_name('type')} = 'Agents::DigestEmailAgent'
     SQL
 
     execute sql
@@ -12,8 +12,8 @@ class RenameDigestEmailToEmailDigest < ActiveRecord::Migration
   def down
     sql = <<-SQL
       UPDATE #{ActiveRecord::Base.connection.quote_table_name('agents')}
-      SET #{ActiveRecord::Base.connection.quote_column_name('type')} = "Agents::DigestEmailAgent"
-      WHERE #{ActiveRecord::Base.connection.quote_column_name('type')} = "Agents::EmailDigestAgent"
+      SET #{ActiveRecord::Base.connection.quote_column_name('type')} = 'Agents::DigestEmailAgent'
+      WHERE #{ActiveRecord::Base.connection.quote_column_name('type')} = 'Agents::EmailDigestAgent'
     SQL
 
     execute sql


### PR DESCRIPTION
PostgreSQL uses double quotes to quote columns and expects strings to be
quoted with single quotes. Single quoted strings work both for MySQL and
PostgreSQL.
