### PR TITLE
Supress logging for requests to the /worker_status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem 'mqtt'
 group :development do
   gem 'binding_of_caller'
   gem 'better_errors'
+  gem 'quiet_assets'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -347,6 +349,7 @@ DEPENDENCIES
   nokogiri (~> 1.6.1)
   protected_attributes (~> 1.0.7)
   pry
+  quiet_assets
   rack
   rails (= 4.1.1)
   rr

--- a/config/initializers/silence_worker_status_logger.rb
+++ b/config/initializers/silence_worker_status_logger.rb
@@ -1,0 +1,10 @@
+Rails::Rack::Logger.class_eval do
+  def call_with_silence_worker_status(env)
+    previous_level = Rails.logger.level
+    Rails.logger.level = Logger::ERROR if env['PATH_INFO'] =~ %r{^/worker_status}
+    call_without_silence_worker_status(env)
+  ensure
+    Rails.logger.level = previous_level
+  end
+  alias_method_chain :call, :silence_worker_status
+end


### PR DESCRIPTION
As suggested by @alias1 discussed in #365, I also added the 'quiet_assets' gem to remove the noisy asset logging.
