### PR TITLE
Add EventDrop#created_at and drop (skip_)created_at from EventFormattingAgent.

### DIFF
--- a/app/models/agents/event_formatting_agent.rb
+++ b/app/models/agents/event_formatting_agent.rb
@@ -25,8 +25,13 @@ module Agents
 
           "instructions": {
             "message": "Today's conditions look like {{conditions}} with a high temperature of {{high.celsius}} degrees Celsius.",
-            "subject": "{{data}}"
+            "subject": "{{data}}",
+            "created_at": "{{created_at}}"
           }
+
+      Names here like `conditions`, `high` and `data` refer to the corresponding values in the Event hash.
+
+      The special key `created_at` refers to the timestamp of the Event, which can be reformatted by the `date` filter, like `{{created_at | date:"at %I:%M %p" }}`.
 
       The upstream agent of each received event is accessible via the key `agent`, which has the following attributes: #{''.tap { |s| s << AgentDrop.instance_methods(false).map { |m| "`#{m}`" }.join(', ') }}.
 
@@ -68,8 +73,6 @@ module Agents
 
       If you want to retain original contents of events and only add new keys, then set `mode` to `merge`, otherwise set it to `clean`.
 
-      By default, the output event will have a `created_at` field added as well, reflecting the original Event creation time.  You can skip this output by setting `skip_created_at` to `true`.
-
       To CGI escape output (for example when creating a link), use the Liquid `uri_escape` filter, like so:
 
           {
@@ -82,7 +85,7 @@ module Agents
     after_save :clear_matchers
 
     def validate_options
-      errors.add(:base, "instructions, mode, and skip_created_at all need to be present.") unless options['instructions'].present? && options['mode'].present? && options['skip_created_at'].present?
+      errors.add(:base, "instructions and mode need to be present.") unless options['instructions'].present? && options['mode'].present?
 
       validate_matchers
     end
@@ -92,11 +95,11 @@ module Agents
         'instructions' => {
           'message' =>  "You received a text {{text}} from {{fields.from}}",
           'agent' => "{{agent.type}}",
-          'some_other_field' => "Looks like the weather is going to be {{fields.weather}}"
+          'some_other_field' => "Looks like the weather is going to be {{fields.weather}}",
+          'created_at' => "{{created_at}}"
         },
         'matchers' => [],
         'mode' => "clean",
-        'skip_created_at' => "false"
       }
     end
 
@@ -110,7 +113,6 @@ module Agents
         opts = interpolated(event.to_liquid(payload))
         formatted_event = opts['mode'].to_s == "merge" ? event.payload.dup : {}
         formatted_event.merge! opts['instructions']
-        formatted_event['created_at'] = event.created_at unless opts['skip_created_at'].to_s == "true"
         create_event :payload => formatted_event
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -56,6 +56,8 @@ class EventDrop
       case key
       when 'agent'
         @object.agent
+      when 'created_at'
+        @object.created_at
       end
     end
   end

--- a/db/migrate/20140730005210_convert_efa_skip_created_at.rb
+++ b/db/migrate/20140730005210_convert_efa_skip_created_at.rb
@@ -1,0 +1,21 @@
+class ConvertEfaSkipCreatedAt < ActiveRecord::Migration
+  def up
+    Agent.where(type: 'Agents::EventFormattingAgent').each do |agent|
+      agent.options_will_change!
+      unless agent.options.delete('skip_created_at').to_s == 'true'
+        agent.options['instructions'] = {
+          'created_at' => '{{created_at}}'
+        }.update(agent.options['instructions'] || {})
+      end
+      agent.save!
+    end
+  end
+
+  def down
+    Agent.where(type: 'Agents::EventFormattingAgent').each do |agent|
+      agent.options_will_change!
+      agent.options['skip_created_at'] = (agent.options['instructions'] || {})['created_at'] == '{{created_at}}'
+      agent.save!
+    end
+  end
+end

--- a/spec/models/agents/event_formatting_agent_spec.rb
+++ b/spec/models/agents/event_formatting_agent_spec.rb
@@ -9,6 +9,8 @@ describe Agents::EventFormattingAgent do
                 :message => "Received {{content.text}} from {{content.name}} .",
                 :subject => "Weather looks like {{conditions}} according to the forecast at {{pretty_date.time}}",
                 :agent => "{{agent.type}}",
+                :created_at => "{{created_at}}",
+                :created_at_iso => "{{created_at | date:'%FT%T%:z'}}",
             },
             :mode => "clean",
             :matchers => [
@@ -18,7 +20,6 @@ describe Agents::EventFormattingAgent do
                     :to => "pretty_date",
                 },
             ],
-            :skip_created_at => "false"
         }
     }
     @checker = Agents::EventFormattingAgent.new(@valid_params)
@@ -53,18 +54,12 @@ describe Agents::EventFormattingAgent do
       Event.last.payload[:content].should_not == nil
     end
 
-    it "should accept skip_created_at" do
-      @checker.receive([@event])
-      Event.last.payload[:created_at].should_not == nil
-      @checker.options[:skip_created_at] = "true"
-      @checker.receive([@event])
-      Event.last.payload[:created_at].should == nil
-    end
-
     it "should handle Liquid templating in instructions" do
       @checker.receive([@event])
       Event.last.payload[:message].should == "Received Some Lorem Ipsum from somevalue ."
       Event.last.payload[:agent].should == "WeatherAgent"
+      Event.last.payload[:created_at].should == @event.created_at.to_s
+      Event.last.payload[:created_at_iso].should == @event.created_at.iso8601
     end
 
     it "should handle matchers and Liquid templating in instructions" do
@@ -142,11 +137,6 @@ describe Agents::EventFormattingAgent do
 
     it "should validate presence of mode" do
       @checker.options[:mode] = ""
-      @checker.should_not be_valid
-    end
-
-    it "should validate presence of skip_created_at" do
-      @checker.options[:skip_created_at] = ""
       @checker.should_not be_valid
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -85,6 +85,7 @@ describe EventDrop do
   before do
     @event = Event.new
     @event.agent = agents(:jane_weather_agent)
+    @event.created_at = Time.at(1400000000)
     @event.payload = {
       'title' => 'some title',
       'url' => 'http://some.site.example.org/',
@@ -110,5 +111,10 @@ describe EventDrop do
   it 'should have agent' do
     t = '{{agent.name}}'
     interpolate(t, @event).should eq('SF Weather')
+  end
+
+  it 'should have created_at' do
+    t = '{{created_at | date:"%FT%T%z" }}'
+    interpolate(t, @event).should eq('2014-05-13T09:53:20-0700')
   end
 end


### PR DESCRIPTION
As mentioned in [#410](https://github.com/cantino/huginn/pull/410#issuecomment-50548617), this PR adds EventDrop#created_at which is universally available in Liquid interpolation and obsoletes the skip_created_at option from EventFormattngAgent, leaving `"created_at" => "{{created_at}}"` in the default `instruction` setting to keep compatibility for users.
