### PR TITLE
Allow HipchatAgent to use a shared credential

### DIFF
--- a/app/models/agents/hipchat_agent.rb
+++ b/app/models/agents/hipchat_agent.rb
@@ -31,7 +31,7 @@ module Agents
     end
 
     def validate_options
-      errors.add(:base, "you need to specify a hipchat auth_token") unless options['auth_token'].present?
+      errors.add(:base, "you need to specify a hipchat auth_token or provide a credential named hipchat_auth_token") unless options['auth_token'].present? || credential('hipchat_auth_token').present?
       errors.add(:base, "you need to specify a room_name or a room_name_path") if options['room_name'].blank? && options['room_name_path'].blank?
     end
 
@@ -40,7 +40,7 @@ module Agents
     end
 
     def receive(incoming_events)
-      client = HipChat::Client.new(interpolated[:auth_token])
+      client = HipChat::Client.new(interpolated[:auth_token] || credential('hipchat_auth_token'))
       incoming_events.each do |event|
         mo = interpolated(event)
         client[mo[:room_name]].send(mo[:username], mo[:message], :notify => mo[:notify].to_s == 'true' ? 1 : 0, :color => mo[:color])

--- a/spec/models/agents/hipchat_agent_spec.rb
+++ b/spec/models/agents/hipchat_agent_spec.rb
@@ -42,6 +42,12 @@ describe Agents::HipchatAgent do
       @checker.should be_valid
     end
 
+    it "should also allow a credential" do
+      @checker.options['auth_token'] = nil
+      @checker.should_not be_valid
+      @checker.user.user_credentials.create :credential_name => 'hipchat_auth_token', :credential_value => 'something'
+      @checker.reload.should be_valid
+    end
   end
 
   describe "#receive" do


### PR DESCRIPTION
This allows HipChat to use a shared credential named `hipchat_auth_token` instead of having to specify a token on each agent instance.
