### PR TITLE
Enable Graphviz on Heroku.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/cantino/heroku-selectable-procfile.git
 https://github.com/heroku/heroku-buildpack-ruby.git
+https://github.com/weibeld/heroku-buildpack-graphviz-src.git

--- a/.graphviz
+++ b/.graphviz
@@ -1,0 +1,1 @@
+http://www.graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz

--- a/bin/setup_heroku
+++ b/bin/setup_heroku
@@ -99,6 +99,7 @@ set_value 'PROCFILE_PATH', "deployment/heroku/Procfile.heroku", force: false
 set_value 'ON_HEROKU', "true"
 set_value 'FORCE_SSL', "true"
 set_value 'DOMAIN', "#{app_name}.herokuapp.com", force: false
+set_value 'USE_GRAPHVIZ_DOT', 'dot'
 
 unless $config['INVITATION_CODE']
   puts "You need to set an invitation code for your Huginn instance.  If you plan to share this instance, you will"


### PR DESCRIPTION
Graphviz is installed via heroku-buildpack-graphviz-src and the location
of dot(1) is automatically added to PATH.

There is also heroku-buildpack-graphviz-deb which should be easier to
install, but the Debian package installed has a font style problem.
