### PR TITLE
Add an environment variable to set a global default User-Agent value.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,10 @@ AWS_SANDBOX=false
 # require you to bundle a corresponding gem via Gemfile.
 FARADAY_HTTP_BACKEND=typhoeus
 
+# Specify the default User-Agent header value for HTTP requests made
+# by Agents that allow overriding the User-Agent header value.
+DEFAULT_HTTP_USER_AGENT="Huginn - https://github.com/cantino/huginn"
+
 # Allow JSONPath eval expresions. i.e., $..price[?(@ < 20)]
 # You should not allow this on a shared Huginn box because it is not secure.
 ALLOW_JSONPATH_EVAL=false

--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -21,9 +21,7 @@ module WebRequestConcern
     @faraday ||= Faraday.new { |builder|
       builder.headers = headers if headers.length > 0
 
-      if (user_agent = interpolated['user_agent']).present?
-        builder.headers[:user_agent] = user_agent
-      end
+      builder.headers[:user_agent] = user_agent
 
       builder.use FaradayMiddleware::FollowRedirects
       builder.request :url_encoded
@@ -57,5 +55,10 @@ module WebRequestConcern
 
   def faraday_backend
     ENV.fetch('FARADAY_HTTP_BACKEND', 'typhoeus').to_sym
+  end
+
+  def user_agent
+    interpolated['user_agent'].presence ||
+      ENV.fetch('DEFAULT_HTTP_USER_AGENT', Faraday.new.headers[:user_agent])
   end
 end

--- a/spec/support/shared_examples/web_request_concern.rb
+++ b/spec/support/shared_examples/web_request_concern.rb
@@ -63,4 +63,29 @@ shared_examples_for WebRequestConcern do
       agent.should_not be_valid
     end
   end
+
+  describe "User-Agent" do
+    before do
+      @default_http_user_agent = ENV['DEFAULT_HTTP_USER_AGENT']
+      ENV['DEFAULT_HTTP_USER_AGENT'] = nil
+    end
+
+    after do
+      ENV['DEFAULT_HTTP_USER_AGENT'] = @default_http_user_agent
+    end
+
+    it "should have the default value set by Faraday" do
+      agent.user_agent.should == Faraday.new.headers[:user_agent]
+    end
+
+    it "should be overridden by the environment variable if present" do
+      ENV['DEFAULT_HTTP_USER_AGENT'] = 'Huginn - https://github.com/cantino/huginn'
+      agent.user_agent.should == 'Huginn - https://github.com/cantino/huginn'
+    end
+
+    it "should be overriden by the value in options if present" do
+      agent.options['user_agent'] = 'Override'
+      agent.user_agent.should == 'Override'
+    end
+  end
 end


### PR DESCRIPTION
I think it would be nice to have a global default value for the User-Agent header commonly used by Agents that make HTTP requests.
It can be used by Agents other than those based on WebRequestConcern if it makes sense for them to set an alternate User-Agent value.

The environment variable name (DEFAULT_HTTP_USER_AGENT) may look verbose, but this is because names starting with HTTP_ should be avoided in the context of Web app.
