### PR TITLE
Add a hover menu to the "Agents" nav link.

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -98,6 +98,12 @@ span.not-applicable:after {
   right: 1px;
 }
 
+.navbar {
+  .dropdown.dropdown-hover:hover .dropdown-menu {
+    display: block;
+  }
+}
+
 // Flash
 
 .flash {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,28 @@
 module ApplicationHelper
-  def nav_link(name, path, options = {})
-    content_tag :li, link_to(name, path), class: current_page?(path) ? 'active' : ''
+  def nav_link(name, path, options = {}, &block)
+    if glyphicon = options[:glyphicon]
+      name = "<span class='glyphicon glyphicon-#{glyphicon}'></span> ".html_safe + name
+    end
+    content = link_to(name, path)
+    active = current_page?(path)
+    if block
+      # Passing a block signifies that the link is a header of a hover
+      # menu which contains what's in the block.
+      begin
+        @nav_in_menu = true
+        @nav_link_active = active
+        content += capture(&block)
+        class_name = "dropdown dropdown-hover #{@nav_link_active ? 'active' : ''}"
+      ensure
+        @nav_in_menu = @nav_link_active = false
+      end
+    else
+      # Mark the menu header active if it contains the current page
+      @nav_link_active ||= active if @nav_in_menu
+      # An "active" menu item may be an eyesore, hence `!@nav_in_menu &&`.
+      class_name = !@nav_in_menu && active ? 'active' : ''
+    end
+    content_tag :li, content, class: class_name
   end
 
   def yes_no(bool)

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -12,7 +12,13 @@
   
   <% if user_signed_in? %>
     <ul class='nav navbar-nav'>
-      <%= nav_link "Agents", agents_path %>
+      <%= nav_link "Agents", agents_path do %>
+        <ul class='dropdown-menu' role='menu'>
+          <%= nav_link "New Agent", new_agent_path, glyphicon: "plus" %>
+          <%= nav_link "Run event propagation", propagate_agents_path, glyphicon: "refresh" %>
+          <%= nav_link "View Diagram", diagram_path, glyphicon: 'random' %>
+        </ul>
+      <% end %>
       <%= nav_link "Scenarios", scenarios_path %>
       <%= nav_link "Events", events_path %>
       <%= nav_link "Credentials", user_credentials_path %>


### PR DESCRIPTION
I found myself tired of performing a click on "Agents", scroll down and then one more click every time I create a new agent or view the diagram, so I decided to add a hover dropdown menu to the "Agents" nav link.

![agents_hover_menu](https://cloud.githubusercontent.com/assets/10236/3889645/5dcd9822-2212-11e4-81ce-afeb656f87e9.png)

What do you think?  Should it require a click for the menu to open?  In that case, the "Agents" nav link becomes a menu opener and an item "Your Agents" should be added to the menu.
