### PR TITLE
TwitterStream bugfixes

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -55,6 +55,8 @@ class Agent < ActiveRecord::Base
   has_many :scenario_memberships, :dependent => :destroy, :inverse_of => :agent
   has_many :scenarios, :through => :scenario_memberships, :inverse_of => :agents
 
+  scope :active, -> { where(disabled: false) }
+
   scope :of_type, lambda { |type|
     type = case type
              when String, Symbol, Class


### PR DESCRIPTION
- do not run disabled `TwitterStreamAgents`
- calling `sleep` within the EM loop blocks the EM thread and thereby
  blocks the reload callback and proper shutdown of the threaded worker
- stopping the EM loop from outside of the `EM.run` blocks does not seem
  to work reliably, using a timer and checking if shutdown was requested
  works as expected
- removed unnecessary sleep at the end of the EM loop which would delay
  the shutdown of the thread
