### PR TITLE
Move the Save button right under the options.

### DIFF
--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -86,6 +86,10 @@
               <%= Utils.jsonify((@agent.new_record? && @agent.options == {}) ? @agent.default_options : @agent.options) %>
             </textarea>
           </div>
+
+          <div class="form-group">
+            <%= f.submit "Save", :class => "btn btn-primary" %>
+          </div>
         </div>
       </div>
     </div>
@@ -106,11 +110,4 @@
       </div>
     </div>
   </div>
-
-  <div class='row'>
-    <div class="col-md-12">
-      <%= f.submit "Save", :class => "btn btn-primary" %>
-    </div>
-  </div>
-      
 <% end %>


### PR DESCRIPTION
It's nice for each Agent to have a good, detailed description, but
currently the Save button will be gone too far below when the
description is very long in height.
