### PR TITLE
Cleanup event references on AgentLogs when Events are deleted

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -13,7 +13,7 @@ module Agents
       You can implement `Agent.check` and `Agent.receive` as you see fit.  The following methods will be available on Agent in the JavaScript environment:
 
       * `this.createEvent(payload)`
-      * `this.incomingEvents()`
+      * `this.incomingEvents()` (the returned event objects will each have a `payload` property)
       * `this.memory()`
       * `this.memory(key)`
       * `this.memory(keyToSet, valueToSet)`

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,9 @@ class Event < ActiveRecord::Base
   belongs_to :user
   belongs_to :agent, :counter_cache => true, :touch => :last_event_at
 
+  has_many :agent_logs_as_inbound_event, :class_name => "AgentLog", :foreign_key => :inbound_event_id, :dependent => :nullify
+  has_many :agent_logs_as_outbound_event, :class_name => "AgentLog", :foreign_key => :outbound_event_id, :dependent => :nullify
+
   scope :recent, lambda { |timespan = 12.hours.ago|
     where("events.created_at > ?", timespan)
   }
@@ -36,6 +39,7 @@ class Event < ActiveRecord::Base
   end
 
   protected
+
   def possibly_propagate
     #immediately schedule agents that want immediate updates
     propagate_ids = agent.receivers.where(:propagate_immediately => true).pluck(:id)

--- a/spec/fixtures/agent_logs.yml
+++ b/spec/fixtures/agent_logs.yml
@@ -1,9 +1,11 @@
 log_for_jane_website_agent:
   agent: jane_website_agent
+  outbound_event: jane_website_agent_event
   message: "fetching some website data"
 
 log_for_bob_website_agent:
   agent: bob_website_agent
+  outbound_event: bob_website_agent_event
   message: "fetching some other website data"
 
 first_log_for_bob_weather_agent:

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -75,6 +75,18 @@ describe Event do
       Event.find_by_id(event.id).should_not be_nil
     end
   end
+
+  describe "after destroy" do
+    it "nullifies any dependent AgentLogs" do
+      agent_logs(:log_for_jane_website_agent).outbound_event_id.should be_present
+      agent_logs(:log_for_bob_website_agent).outbound_event_id.should be_present
+
+      agent_logs(:log_for_bob_website_agent).outbound_event.destroy
+
+      agent_logs(:log_for_jane_website_agent).reload.outbound_event_id.should be_present
+      agent_logs(:log_for_bob_website_agent).reload.outbound_event_id.should be_nil
+    end
+  end
 end
 
 describe EventDrop do


### PR DESCRIPTION
AgentLogs were erroring after referenced events were deleted.
