### PR TITLE
Make `destroy` redirect to agents list

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -148,7 +148,7 @@ class AgentsController < ApplicationController
     @agent.destroy
 
     respond_to do |format|
-      format.html { redirect_to agents_path, notice: "'#{@agent.name}' deleted."}
+      format.html { redirect_back "'#{@agent.name}' deleted."}
       format.json { head :no_content }
     end
   end


### PR DESCRIPTION
Before this, the `destroy` action was attempting to redirect the user back to the `show` action of the controller, which resulted in an error.

Fixes #531
