### PR TITLE
Fixed navigation bar when many events are pending

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -86,6 +86,11 @@ span.not-applicable:after {
 .nav > li {
   &.job-indicator, &#event-indicator {
     display: none;
+
+    a {
+      padding-right: 5px;
+      padding-left: 5px;
+    }
   }
 }
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -28,29 +28,29 @@
   
   <ul class="nav navbar-nav navbar-right">
     <% if user_signed_in? %>
-      <form class="navbar-form navbar-left" role="search">
+      <form class="navbar-form navbar-left visible-lg" role="search">
         <div class="form-group">
           <input type="text" class="form-control" id='agent-navigate' autocomplete="off" placeholder="Search">
           <%= image_tag "spinner-arrows.gif", :class => "spinner" %>
         </div>
       </form>
       
-      <li class='job-indicator' role='pending'>
+      <li class='job-indicator visible-lg' role='pending'>
         <%= link_to current_user.admin? ? jobs_path : '#' do %>
           <span class="badge"><span class="glyphicon glyphicon-refresh icon-white"></span> <span class='number'>0</span></span>
         <% end %>
       </li>
-      <li class='job-indicator' role='awaiting_retry'>
+      <li class='job-indicator visible-lg' role='awaiting_retry'>
         <%= link_to current_user.admin? ? jobs_path : '#' do %>
           <span class="badge"><span class="glyphicon glyphicon-question-sign icon-yellow"></span> <span class='number'>0</span></span>
         <% end %>
       </li>
-      <li class='job-indicator' role='recent_failures'>
+      <li class='job-indicator hidden-sm hidden-xs' role='recent_failures'>
         <%= link_to current_user.admin? ? jobs_path : '#' do %>
           <span class="badge"><span class="glyphicon glyphicon-exclamation-sign icon-white"></span> <span class='number'>0</span></span>
         <% end %>
       </li>
-      <li id='event-indicator'>
+      <li id='event-indicator' class='hidden-sm hidden-xs'>
         <a href="#">
           <span class="badge"><span class="glyphicon glyphicon-random icon-white"></span> <span class='number'>0</span> new events</span>
         </a>


### PR DESCRIPTION
It also works better in various resolutions.
![screenshot 2014-09-23 21 57 27](https://cloud.githubusercontent.com/assets/20943/4379015/f6a0ecc8-435c-11e4-9782-646e4c9ab0f8.png)
![screenshot 2014-09-23 21 57 38](https://cloud.githubusercontent.com/assets/20943/4379019/f8bc74b4-435c-11e4-9f77-5b45f35b7b40.png)
![screenshot 2014-09-23 21 57 47](https://cloud.githubusercontent.com/assets/20943/4379021/fab1bf68-435c-11e4-82f1-a5a6054fe81a.png)
![screenshot 2014-09-23 21 57 54](https://cloud.githubusercontent.com/assets/20943/4379027/fed04ee8-435c-11e4-96ba-6b11282386e3.png)

Fixes #498 
