### PR TITLE
Fixed path in docker image to .env.example

### DIFF
--- a/docker/scripts/init
+++ b/docker/scripts/init
@@ -19,10 +19,10 @@ elif [ -n "${POSTGRESQL_PORT_5432_TCP_ADDR}" ]; then
   HUGINN_DATABASE_PORT=${HUGINN_DATABASE_PORT:-${POSTGRESQL_PORT_5432_TCP_PORT}}
 fi
 
-grep = /app/.env.example | sed -e 's/^#//' | grep -v -e '^#' | cut -d= -f1 | \
+grep = /app/.env.example | sed -e 's/^#[^ ]//' | grep -v -e '^#' | cut -d= -f1 | \
   while read var ; do
-    echo "$var=\${HUGINN_$var:-\$$var}"
-  done > /app/.env
+    eval "echo \"$var=\\\"\${HUGINN_$var:-\$$var}\\\"\""
+  done | grep -v -e ^= > /app/.env
 
 chmod ugo+r /app/.env
 source /app/.env


### PR DESCRIPTION
This is an inexcusable oversight on my part. There were issues parsing the .env.example file, and an outright failure to eval the generated .env lines to make dotenv happy.

After building this script locally in vagrant:
    docker$ docker build -t cantino/huginn .

This now runs a functional self-standing huginn correctly:
    docker run --rm -i -t cantino/huginn

The script seems to work for me now. This PR should fix it. My apologies.
