### PR TITLE
Refactor OmniAuth configuration and fix it with 37Signals.

### DIFF
--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -14,7 +14,7 @@
       <% if has_oauth_configuration_for?('twitter') %>
         <p><%= link_to "Authenticate with Twitter", "/auth/twitter" %></p>
       <% end %>
-      <% if has_oauth_configuration_for?('thirty_seven_signals') %>
+      <% if has_oauth_configuration_for?('37signals') %>
         <p><%= link_to "Authenticate with 37Signals (Basecamp)", "/auth/37signals" %></p>
       <% end -%>
       <% if has_oauth_configuration_for?('github') %>


### PR DESCRIPTION
I happened to find a bug in our OmniAuth provider configuration for 37Signals.

I'm not a user of 37Signals/Basecamp, so I'd appreciate if someone else can confirm it is currently broken and this PR fixes it.
