### PR TITLE
Add CommanderAgent, which controls other agents on a schedule or incoming event.

### DIFF
--- a/app/models/agents/commander_agent.rb
+++ b/app/models/agents/commander_agent.rb
@@ -1,0 +1,47 @@
+module Agents
+  class CommanderAgent < Agent
+    include AgentControllerConcern
+
+    cannot_create_events!
+
+    description <<-MD
+      This agent is triggered by schedule or an incoming event and commands other agents ("targets") to run, disable or enable themselves.
+
+      # Action types
+
+      Set `action` to one of the action types below:
+
+      * `run`: Target Agents are run when this agent is triggered.
+
+      * `disable`: Target Agents are disabled (if not) when this agent is triggered.
+
+      * `enable`: Target Agents are enabled (if not) when this agent is triggered.
+
+      Here's a tip: you can use Liquid templating to dynamically determine the action type.  For example:
+
+      - To create a CommanderAgent that receives an event from WeatherAgent every morning to kick an agent flow that is only useful in a nice weather, try this: `{% if conditions contains 'Sunny' or conditions contains 'Cloudy' %}run{% endif %}`
+
+      - Likewise, if you have a scheduled agent flow specially crafted for rainy days, try this: `{% if conditions contains 'Rain' %}enable{% else %}disabled{% endif %}`
+
+      # Targets
+
+      Select Agents that you want to control from this CommanderAgent.
+    MD
+
+    def working?
+      true
+    end
+
+    def check!
+      control!
+    end
+
+    def receive(incoming_events)
+      incoming_events.each do |event|
+        interpolate_with(event) do
+          control!
+        end
+      end
+    end
+  end
+end

--- a/spec/models/agents/commander_agent_spec.rb
+++ b/spec/models/agents/commander_agent_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Agents::CommanderAgent do
+  let(:valid_params) {
+    {
+      name: 'Example',
+      schedule: 'every_1h',
+      options: {
+        'action' => 'run',
+      },
+    }
+  }
+
+  let(:agent) {
+    described_class.create!(valid_params) { |agent|
+      agent.user = users(:bob)
+    }
+  }
+
+  it_behaves_like AgentControllerConcern
+
+  describe "check!" do
+    it "should command targets" do
+      stub(agent).control!.once { nil }
+      agent.check!
+    end
+  end
+
+  describe "receive_events" do
+    it "should command targets" do
+      stub(agent).control!.once { nil }
+
+      event = Event.new
+      event.agent = agents(:bob_rain_notifier_agent)
+      event.payload = {
+        'url' => 'http://xkcd.com',
+        'link' => 'Random',
+      }
+      agent.receive([event])
+    end
+  end
+end


### PR DESCRIPTION
This is something I called AgentRunnerAgent with a shorter name.

As suggested in [this thread](https://github.com/cantino/huginn/issues/353#issuecomment-57111976), there would be many use cases for it.
