### PR TITLE
Disable the CSRF warning in WebRequestsController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
 
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   helper :all

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  before_filter :load_event, :except => :index
+  before_action :load_event, except: :index
 
   def index
     if params[:agent_id]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
-  skip_before_filter :authenticate_user!
+  skip_before_action :authenticate_user!
 
-  before_filter :upgrade_warning, only: :index
+  before_action :upgrade_warning, only: :index
 
   def index
   end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,5 +1,5 @@
 class JobsController < ApplicationController
-  before_filter :authenticate_admin!
+  before_action :authenticate_admin!
 
   def index
     @jobs = Delayed::Job.order("coalesce(failed_at,'1000-01-01'), run_at asc").page(params[:page])

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,5 +1,5 @@
 class LogsController < ApplicationController
-  before_filter :load_agent
+  before_action :load_agent
 
   def index
     @logs = @agent.logs.all

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,6 +1,6 @@
 class ScenariosController < ApplicationController
   include SortableTable
-  skip_before_filter :authenticate_user!, :only => :export
+  skip_before_action :authenticate_user!, only: :export
 
   def index
     set_table_sort sorts: %w[name public], default: { name: :asc }

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,7 +1,7 @@
 class ServicesController < ApplicationController
   include SortableTable
 
-  before_filter :upgrade_warning, only: :index
+  before_action :upgrade_warning, only: :index
 
   def index
     set_table_sort sorts: %w[provider name global], default: { provider: :asc }

--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -16,8 +16,8 @@
 #   ["not found", 404, 'text/plain']
 
 class WebRequestsController < ApplicationController
-  skip_before_filter :authenticate_user!
   skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
 
   def handle_request
     user = User.find_by_id(params[:user_id])


### PR DESCRIPTION
I see this warning every time WebRequestsController processes a POST request.

```
I, [2014-10-10T12:23:45.629681 #31902]  INFO -- : [1c31109c-237e-4db8-b5c2-f63832b4864f] Started POST "/users/1/web_requests/27/***" for ***.***.***.*** at 2014-10-10 12:23:45 +0900
I, [2014-10-10T12:23:45.631097 #31902]  INFO -- : [1c31109c-237e-4db8-b5c2-f63832b4864f] Processing by WebRequestsController#handle_request as */*
I, [2014-10-10T12:23:45.631215 #31902]  INFO -- : [1c31109c-237e-4db8-b5c2-f63832b4864f]   Parameters: {...}, "user_id"=>"1", "agent_id"=>"27", "secret"=>"***", "web_request"=>{...}}}
W, [2014-10-10T12:23:45.631523 #31902]  WARN -- : [1c31109c-237e-4db8-b5c2-f63832b4864f] Can't verify CSRF token authenticity
I, [2014-10-10T12:23:45.663737 #31902]  INFO -- : [1c31109c-237e-4db8-b5c2-f63832b4864f]   Rendered text template (0.0ms)
I, [2014-10-10T12:23:45.663929 #31902]  INFO -- : [1c31109c-237e-4db8-b5c2-f63832b4864f] Completed 201 Created in 33ms (Views: 0.4ms | ActiveRecord: 15.0ms)
```

Seems the warning is just a warning and harmless, but I'd rather not see it all the time.
