### PR TITLE
Assume an uploaded scenario file (JSON) is encoded in UTF-8.

### DIFF
--- a/app/models/scenario_import.rb
+++ b/app/models/scenario_import.rb
@@ -111,7 +111,7 @@ class ScenarioImport
 
   def parse_file
     if data.blank? && file.present?
-      self.data = file.read
+      self.data = file.read.force_encoding(Encoding::UTF_8)
     end
   end
 


### PR DESCRIPTION
When uploading a file, web browsers do not specify a charset in Content-Type because it is usually unknown and you cannot assume it matches the form encoding.  Here's a fragment of multipart headers Firefox will send:

```
Content-Disposition: form-data; name="scenario_import[file]"; filename="example.json"
Content-Type: application/json
```

This causes the scenario import to fail with the following error because of an uploaded blob being treated as ASCII-8BIT:

```
ActionView::Template::Error (incompatible character encodings: ASCII-8BIT and UTF-8):
    18:     <% if @scenario_import.step_one? %>
    19:       <%= render 'step_one', :f => f %>
    20:     <% elsif @scenario_import.step_two? %>
    21:       <%= render 'step_two', :f => f %>
    22:     <% end %>
    23:   <% end %>
    24:
  app/views/scenario_imports/new.html.erb:21:in `block in _app_views_scenario_imports_new_html_erb___4262128004129331542_17292895160'
  app/views/scenario_imports/new.html.erb:15:in `_app_views_scenario_imports_new_html_erb___4262128004129331542_17292895160'
  app/controllers/scenario_imports_controller.rb:17:in `create'
  config/initializers/silence_worker_status_logger.rb:5:in `call_with_silence_worker_status'
```

@cantino Is the file upload working for you?  I get the error on any of Firefox, Chrome and Safari.
