### PR TITLE
RSSAgent: Include `url` in addition to `urls` in each event.

### DIFF
--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -41,6 +41,7 @@ module Agents
             "id": "829f845279611d7925146725317b868d",
             "date_published": "2014-09-11 01:30:00 -0700",
             "last_updated": "Thu, 11 Sep 2014 01:30:00 -0700",
+            "url": "http://example.com/...",
             "urls": [ "http://example.com/..." ],
             "description": "Some description",
             "content": "Some content",
@@ -75,16 +76,17 @@ module Agents
           entry_id = get_entry_id(entry)
           if check_and_track(entry_id)
             created_event_count += 1
-            create_event(:payload => {
-              :id => entry_id,
-              :date_published => entry.date_published,
-              :last_updated => entry.last_updated,
-              :urls => entry.urls,
-              :description => entry.description,
-              :content => entry.content,
-              :title => entry.title,
-              :authors => entry.authors,
-              :categories => entry.categories
+            create_event(payload: {
+              id: entry_id,
+              date_published: entry.date_published,
+              last_updated: entry.last_updated,
+              url: entry.url,
+              urls: entry.urls,
+              description: entry.description,
+              content: entry.content,
+              title: entry.title,
+              authors: entry.authors,
+              categories: entry.categories
             })
           end
         end

--- a/spec/models/agents/rss_agent_spec.rb
+++ b/spec/models/agents/rss_agent_spec.rb
@@ -55,6 +55,10 @@ describe Agents::RssAgent do
       expect {
         agent.check
       }.to change { agent.events.count }.by(20)
+
+      event = agent.events.last
+      expect(event.payload['url']).to eq("https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0")
+      expect(event.payload['urls']).to eq(["https://github.com/cantino/huginn/commit/d0a844662846cf3c83b94c637c1803f03db5a5b0"])
     end
 
     it "should track ids and not re-emit the same item when seen again" do


### PR DESCRIPTION
An Atom/RSS entry usually has just one URL, and even if it has many only the first of those is likely to be of interest.

Emitting an event with `url` also helps downstream agents like WebsiteAgent that uses the key name to get a URL to crawl.
