### PR TITLE
Upgrade slack-notifier to 1.0.0; use webhook URLs instead of tokens.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'weibo_2', '~> 0.1.4'         # Weibo Agents
 gem 'hipchat', '~> 1.2.0'         # HipchatAgent
 gem 'xmpp4r',  '~> 0.5.6'         # JabberAgent
 gem 'mqtt'                        # MQTTAgent
-gem 'slack-notifier', '~> 0.5.0'  # SlackAgent
+gem 'slack-notifier', '~> 1.0.0'  # SlackAgent
 
 # GoogleCalendarPublishAgent
 gem "google-api-client", require: 'google/api_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    slack-notifier (0.5.0)
+    slack-notifier (1.0.0)
     slop (3.6.0)
     spectrum-rails (1.3.4)
       railties (>= 3.1)
@@ -509,7 +509,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.0)
   select2-rails (~> 3.5.4)
   shoulda-matchers
-  slack-notifier (~> 0.5.0)
+  slack-notifier (~> 1.0.0)
   spectrum-rails
   spring
   spring-commands-rspec

--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -1,6 +1,5 @@
 module Agents
   class SlackAgent < Agent
-    DEFAULT_WEBHOOK = 'incoming-webhook'
     DEFAULT_USERNAME = 'Huginn'
 
     cannot_be_scheduled!
@@ -10,15 +9,13 @@ module Agents
 
     description <<-MD
       #{'## Include `slack-notifier` in your Gemfile to use this Agent!' if dependencies_missing?}
-      The SlackAgent lets you receive events and send notifications to [slack](https://slack.com/).
+      The SlackAgent lets you receive events and send notifications to [Slack](https://slack.com/).
 
       To get started, you will first need to setup an incoming webhook.
-      Go to, https://`your_team_name`.slack.com/services/new/incoming-webhook,
+      Go to, <code>https://<em>your_team_name</em>.slack.com/services/new/incoming-webhook</code>,
       choose a default channel and add the integration.
 
-      Your webhook URL will look like:
-
-      https://`your_team_name`.slack.com/services/hooks/incoming-webhook?token=`your_auth_token`
+      Your webhook URL will look like: <code>https://hooks.slack.com/services/<em>random1</em>/<em>random2</em>/<em>token</em></code>
 
       Once the webhook has been setup it can be used to post to other channels or ping team members.
       To send a private message to team-mate, assign his username as `@username` to the channel option.
@@ -28,18 +25,19 @@ module Agents
 
     def default_options
       {
-        'team_name' => 'your_team_name',
-        'auth_token' => 'your_auth_token',
+        'webhook_url' => 'https://hooks.slack.com/services/...',
         'channel' => '#general',
         'username' => DEFAULT_USERNAME,
         'message' => "Hey there, It's Huginn",
-        'webhook' => DEFAULT_WEBHOOK
       }
     end
 
     def validate_options
-      errors.add(:base, "auth_token is required") unless options['auth_token'].present?
-      errors.add(:base, "team_name is required") unless options['team_name'].present?
+      unless options['webhook_url'].present? ||
+             (options['auth_token'].present? && options['team_name'].present?)  # compatibility
+        errors.add(:base, "webhook_url is required")
+      end
+
       errors.add(:base, "channel is required") unless options['channel'].present?
     end
 
@@ -47,8 +45,15 @@ module Agents
       received_event_without_error?
     end
 
-    def webhook
-      interpolated[:webhook].presence || DEFAULT_WEBHOOK
+    def webhook_url
+      case
+      when url = interpolated[:webhook_url].presence
+        url
+      when (team = interpolated[:team_name].presence) && (token = interpolated[:auth_token])
+        webhook = interpolated[:webhook].presence || 'incoming-webhook'
+        # old style webhook URL
+        "https://#{Rack::Utils.escape_path(team)}.slack.com/services/hooks/#{Rack::Utils.escape_path(webhook)}?token=#{Rack::Utils.escape(token)}"
+      end
     end
 
     def username
@@ -56,7 +61,7 @@ module Agents
     end
 
     def slack_notifier
-      @slack_notifier ||= Slack::Notifier.new(interpolated[:team_name], interpolated[:auth_token], webhook, username: username)
+      @slack_notifier ||= Slack::Notifier.new(webhook_url, username: username)
     end
 
     def receive(incoming_events)

--- a/spec/models/agents/slack_agent_spec.rb
+++ b/spec/models/agents/slack_agent_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe Agents::SlackAgent do
   before(:each) do
     @valid_params = {
-                      'auth_token' => 'token',
-                      'team_name' => 'testteam',
+                      'webhook_url' => 'https://hooks.slack.com/services/random1/random2/token',
                       'channel' => '#random',
                       'username' => "{{username}}",
                       'message' => "{{message}}"
@@ -25,8 +24,8 @@ describe Agents::SlackAgent do
       expect(@checker).to be_valid
     end
 
-    it "should require a auth_token" do
-      @checker.options['auth_token'] = nil
+    it "should require a webhook_url" do
+      @checker.options['webhook_url'] = nil
       expect(@checker).not_to be_valid
     end
 
@@ -34,12 +33,8 @@ describe Agents::SlackAgent do
       @checker.options['channel'] = nil
       expect(@checker).not_to be_valid
     end
-
-    it "should require a team_name" do
-      @checker.options['team_name'] = 'nil'
-      expect(@checker).to be_valid
-    end
   end
+
   describe "#receive" do
     it "receive an event without errors" do
       any_instance_of(Slack::Notifier) do |obj|


### PR DESCRIPTION
Slack's service integration instructions now only show Webhook URL, so this should be reasonable for new users.

For compatibility, allow an existing pair of `team_name` and `auth_token` to still work.
