### PR TITLE
Added DeDuplicationAgent

### DIFF
--- a/app/models/agents/de_duplication_agent.rb
+++ b/app/models/agents/de_duplication_agent.rb
@@ -1,0 +1,87 @@
+module Agents
+  class DeDuplicationAgent < Agent
+    include FormConfigurable
+    cannot_be_scheduled!
+
+    description <<-MD
+      The DeDuplicationAgent receives a stream of events and remits the event if it is not a duplicate.
+
+      `property` the value that should be used to determine the uniqueness of the event (empty to use the whole payload)
+
+      `lookback` amount of past Events to compare the value to (0 for unlimited)
+
+      `expected_update_period_in_days` is used to determine if the Agent is working.
+    MD
+
+    event_description <<-MD
+      The DeDuplicationAgent just reemits events it received.
+    MD
+
+    def default_options
+      {
+        'property' => '{{value}}',
+        'lookback' => 100,
+        'expected_update_period_in_days' => 1
+      }
+    end
+
+    form_configurable :property
+    form_configurable :lookback
+    form_configurable :expected_update_period_in_days
+
+    before_create :initialize_memory
+
+    def initialize_memory
+      memory['properties'] = []
+    end
+
+    def validate_options
+      unless options['lookback'].present? && options['expected_update_period_in_days'].present?
+        errors.add(:base, "The lookback and expected_update_period_in_days fields are all required.")
+      end
+    end
+
+    def working?
+      event_created_within?(interpolated['expected_update_period_in_days']) && !recent_error_logs?
+    end
+
+    def receive(incoming_events)
+      incoming_events.each do |event|
+        handle(interpolated(event), event)
+      end
+    end
+
+    private
+
+    def handle(opts, event = nil)
+      property = get_hash(options['property'].blank? ? JSON.dump(event.payload) : opts['property'])
+      if is_unique?(property)
+        created_event = create_event :payload => event.payload
+
+        log("Propagating new event as '#{property}' is a new unique property.", :inbound_event => event )
+        update_memory(property, opts['lookback'].to_i)
+      else
+        log("Not propagating as incoming event is a duplicate.", :inbound_event => event )
+      end
+    end
+
+    def get_hash(property)
+      if property.to_s.length > 10
+        Zlib::crc32(property).to_s
+      else
+        property
+      end
+    end
+
+    def is_unique?(property)
+      !memory['properties'].include?(property)
+    end
+
+    def update_memory(property, amount)
+      if amount != 0 && memory['properties'].length == amount
+        memory['properties'].shift
+      end
+      memory['properties'].push(property)
+    end
+  end
+end

--- a/spec/models/agents/de_duplication_agent_spec.rb
+++ b/spec/models/agents/de_duplication_agent_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe Agents::DeDuplicationAgent do
+  def create_event(output=nil)
+    event = Event.new
+    event.agent = agents(:jane_weather_agent)
+    event.payload = {
+      :output => output
+    }
+    event.save!
+
+    event
+  end
+
+  before do
+    @valid_params = {
+      :property  => "{{output}}",
+      :lookback => 3,
+      :expected_update_period_in_days => "1",
+    }
+
+    @checker = Agents::DeDuplicationAgent.new(:name => "somename", :options => @valid_params)
+    @checker.user = users(:jane)
+    @checker.save!
+  end
+
+  describe "validation" do
+    before do
+      expect(@checker).to be_valid
+    end
+
+    it "should validate presence of lookback" do
+      @checker.options[:lookback] = nil
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of property" do
+      @checker.options[:expected_update_period_in_days] = nil
+      expect(@checker).not_to be_valid
+    end
+  end
+
+  describe "#working?" do
+    before :each do
+      # Need to create an event otherwise event_created_within? returns nil
+      event = create_event
+      @checker.receive([event])
+    end
+
+    it "is when event created within :expected_update_period_in_days" do
+      @checker.options[:expected_update_period_in_days] = 2
+      expect(@checker).to be_working
+    end
+
+    it "isnt when event created outside :expected_update_period_in_days" do
+      @checker.options[:expected_update_period_in_days] = 2
+
+      time_travel_to 2.days.from_now do
+          expect(@checker).not_to be_working
+      end
+    end
+  end
+
+  describe "#receive" do
+    before :each do
+      @event = create_event("2014-07-01")
+    end
+
+    it "creates events when memory is empty" do
+      @event.payload[:output] = "2014-07-01"
+      expect {
+        @checker.receive([@event])
+      }.to change(Event, :count).by(1)
+      expect(Event.last.payload[:command]).to eq(@event.payload[:command])
+      expect(Event.last.payload[:output]).to eq(@event.payload[:output])
+    end
+
+    it "creates events when new event is unique" do
+      @event.payload[:output] = "2014-07-01"
+      @checker.receive([@event])
+
+      event = create_event("2014-08-01")
+
+      expect {
+        @checker.receive([event])
+      }.to change(Event, :count).by(1)
+    end
+
+    it "does not create event when event is a duplicate" do
+      @event.payload[:output] = "2014-07-01"
+      @checker.receive([@event])
+
+      expect {
+        @checker.receive([@event])
+      }.to change(Event, :count).by(0)
+    end
+
+    it "should respect the lookback value" do
+      3.times do |i|
+        @event.payload[:output] = "2014-07-0#{i}"
+        @checker.receive([@event])
+      end
+      @event.payload[:output] = "2014-07-05"
+      expect {
+        @checker.receive([@event])
+      }.to change(Event, :count).by(1)
+      expect(@checker.memory['properties'].length).to eq(3)
+      expect(@checker.memory['properties']).to eq(["2014-07-01", "2014-07-02", "2014-07-05"])
+    end
+
+    it "should hash the value if its longer then 10 chars" do
+      @event.payload[:output] = "01234567890"
+      expect {
+        @checker.receive([@event])
+      }.to change(Event, :count).by(1)
+      expect(@checker.memory['properties'].last).to eq('2256157795')
+    end
+
+    it "should use the whole event if :property is blank" do
+      @checker.options['property'] = ''
+      expect {
+        @checker.receive([@event])
+      }.to change(Event, :count).by(1)
+      expect(@checker.memory['properties'].last).to eq('3023526198')
+    end
+  end
+end


### PR DESCRIPTION
A simple approach that should work for #600 and #555, even though it will be get slow if you want to de-duplicate against every event ever checked, as the checked properties (or the CRC32 hash of the payload) are stored in the agents memory.

My initial plan to use postgresql's JSON type kind of conflicts with liquid interpolation. We can not really be sure the value is just a 'JSONPath' to the property, the user could also use a liquid filter which has to be interpolated and thus can not be compared to the values in the database directly.

Maybe using a [bloomfilter](http://en.wikipedia.org/wiki/Bloom_filter) would be an option for de-duplicating a _lot_ (10,000+) events.
