### PR TITLE
Adds doorkeeper to allow application to authenticate against huginn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem 'string-scrub'	# for ruby <2.1
 gem 'therubyracer', '~> 0.12.1'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '>= 1.3.0'
+gem 'doorkeeper', '~> 1.4.0'
 
 group :development do
   gem 'better_errors', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    doorkeeper (1.4.0)
+      railties (>= 3.1)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
@@ -274,7 +276,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.7)
       sprockets-rails (~> 2.0)
-    rails_12factor (0.0.2)
+    rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
@@ -456,6 +458,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.0.0)
   delorean
   devise (~> 3.4.0)
+  doorkeeper (~> 1.4.0)
   dotenv-deployment
   dotenv-rails
   dropbox-api

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,24 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
 
-  before_action :authenticate_user!
+  alias_method :deivse_current_user, :current_user
+  before_action :custom_authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   helper :all
 
+  def current_user
+    @current_user ||= if doorkeeper_token
+      User.find(doorkeeper_token.resource_owner_id)
+    else
+      deivse_current_user
+    end
+  end
+
   protected
+  def custom_authenticate_user!
+    authenticate_user! if current_user.nil?
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation, :remember_me, :invitation_code) }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
 
-  alias_method :deivse_current_user, :current_user
+  alias_method :devise_current_user, :current_user
   before_action :custom_authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
     @current_user ||= if doorkeeper_token
       User.find(doorkeeper_token.resource_owner_id)
     else
-      deivse_current_user
+      devise_current_user
     end
   end
 

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,6 +1,6 @@
 class ScenariosController < ApplicationController
   include SortableTable
-  skip_before_action :authenticate_user!, only: :export
+  skip_before_action :custom_authenticate_user!, only: :export
 
   def index
     set_table_sort sorts: %w[name public], default: { name: :asc }

--- a/app/controllers/web_requests_controller.rb
+++ b/app/controllers/web_requests_controller.rb
@@ -17,7 +17,7 @@
 
 class WebRequestsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  skip_before_action :authenticate_user!
+  skip_before_action :custom_authenticate_user!
 
   def handle_request
     user = User.find_by_id(params[:user_id])

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -74,6 +74,9 @@
           <li>
             <%= link_to 'Job Management', jobs_path, :tabindex => '-1' %>
           </li>
+          <li>
+            <%= link_to 'OAuth Applications', oauth_applications_path, tabindex: '-1' %>
+          </li>
         <% end %>
         <li>
           <%= link_to 'About', 'https://github.com/cantino/huginn', :tabindex => "-1" %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,87 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use.
+  # Currently supported options are :active_record, :mongoid2, :mongoid3, :mongo_mapper
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    current_user || warden.authenticate!(:scope => :user)
+  end
+
+  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  admin_authenticator do
+    redirect_to(root_path, alert: 'Admin access required to view that page.') unless current_user && current_user.admin?
+  end
+
+  # Authorization Code expiration time (default 10 minutes).
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
+  access_token_expires_in nil
+
+  # Reuse access token for the same resource owner within an application (disabled by default)
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  # reuse_access_token
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # a registered application
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  # enable_application_owner :confirmation => false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the native redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  #
+  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables all the four grant flows.
+  #
+  # grant_flows %w(authorization_code implicit password client_credentials)
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with trusted a application.
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+
+  # Allow dynamic query parameters (disabled by default)
+  # Some applications require dynamic query parameters on their request_uri
+  # set to true if you want this to be allowed
+  # wildcard_redirect_uri false
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,71 @@
+en:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongoid:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongo_mapper:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  doorkeeper:
+    errors:
+      messages:
+        # Common error messages
+        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_redirect_uri: 'The redirect uri included is not valid.'
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        #configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfiged.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        # Password Access token errors
+        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Huginn::Application.routes.draw do
+  use_doorkeeper
+
   resources :agents do
     member do
       post :run

--- a/db/migrate/20141108230925_create_doorkeeper_tables.rb
+++ b/db/migrate/20141108230925_create_doorkeeper_tables.rb
@@ -1,0 +1,41 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         null: false
+      t.string  :uid,          null: false
+      t.string  :secret,       null: false
+      t.text    :redirect_uri, null: false
+      t.timestamps
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, null: false
+      t.integer  :application_id,    null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.integer  :application_id
+      t.string   :token,             null: false
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,        null: false
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140906030139) do
+ActiveRecord::Schema.define(version: 20141108230925) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "agent_logs", force: true do |t|
     t.integer  "agent_id",                      null: false
-    t.text     "message",                       null: false, charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.text     "message",                       null: false
     t.integer  "level",             default: 3, null: false
     t.integer  "inbound_event_id"
     t.integer  "outbound_event_id"
@@ -25,25 +28,25 @@ ActiveRecord::Schema.define(version: 20140906030139) do
 
   create_table "agents", force: true do |t|
     t.integer  "user_id"
-    t.text     "options",                                                               charset: "utf8mb4", collation: "utf8mb4_bin"
-    t.string   "type",                                                                                      collation: "utf8_bin"
-    t.string   "name",                                                                  charset: "utf8mb4", collation: "utf8mb4_bin"
-    t.string   "schedule",                                                                                  collation: "utf8_bin"
-    t.integer  "events_count",                             default: 0,     null: false
+    t.text     "options"
+    t.string   "type"
+    t.string   "name"
+    t.string   "schedule"
+    t.integer  "events_count",          default: 0,     null: false
     t.datetime "last_check_at"
     t.datetime "last_receive_at"
     t.integer  "last_checked_event_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "memory",                limit: 2147483647,                              charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.text     "memory"
     t.datetime "last_web_request_at"
-    t.integer  "keep_events_for",                          default: 0,     null: false
+    t.integer  "keep_events_for",       default: 0,     null: false
     t.datetime "last_event_at"
     t.datetime "last_error_log_at"
-    t.boolean  "propagate_immediately",                    default: false, null: false
-    t.boolean  "disabled",                                 default: false, null: false
+    t.boolean  "propagate_immediately", default: false, null: false
+    t.boolean  "disabled",              default: false, null: false
+    t.string   "guid",                                  null: false
     t.integer  "service_id"
-    t.string   "guid",                                                     null: false
   end
 
   add_index "agents", ["guid"], name: "index_agents_on_guid", using: :btree
@@ -62,10 +65,10 @@ ActiveRecord::Schema.define(version: 20140906030139) do
   add_index "control_links", ["controller_id", "control_target_id"], name: "index_control_links_on_controller_id_and_control_target_id", unique: true, using: :btree
 
   create_table "delayed_jobs", force: true do |t|
-    t.integer  "priority",                    default: 0
-    t.integer  "attempts",                    default: 0
-    t.text     "handler",    limit: 16777215,             charset: "utf8mb4", collation: "utf8mb4_bin"
-    t.text     "last_error",                              charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.integer  "priority",   default: 0
+    t.integer  "attempts",   default: 0
+    t.text     "handler"
+    t.text     "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
@@ -80,9 +83,9 @@ ActiveRecord::Schema.define(version: 20140906030139) do
   create_table "events", force: true do |t|
     t.integer  "user_id"
     t.integer  "agent_id"
-    t.decimal  "lat",                         precision: 15, scale: 10
-    t.decimal  "lng",                         precision: 15, scale: 10
-    t.text     "payload",    limit: 16777215,                           charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.decimal  "lat",        precision: 15, scale: 10
+    t.decimal  "lng",        precision: 15, scale: 10
+    t.text     "payload"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "expires_at"
@@ -103,6 +106,45 @@ ActiveRecord::Schema.define(version: 20140906030139) do
   add_index "links", ["receiver_id", "source_id"], name: "index_links_on_receiver_id_and_source_id", using: :btree
   add_index "links", ["source_id", "receiver_id"], name: "index_links_on_source_id_and_receiver_id", using: :btree
 
+  create_table "oauth_access_grants", force: true do |t|
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "revoked_at"
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+
+  create_table "oauth_access_tokens", force: true do |t|
+    t.integer  "resource_owner_id"
+    t.integer  "application_id"
+    t.string   "token",             null: false
+    t.string   "refresh_token"
+    t.integer  "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+
+  create_table "oauth_applications", force: true do |t|
+    t.string   "name",         null: false
+    t.string   "uid",          null: false
+    t.string   "secret",       null: false
+    t.text     "redirect_uri", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+
   create_table "scenario_memberships", force: true do |t|
     t.integer  "agent_id",    null: false
     t.integer  "scenario_id", null: false
@@ -114,13 +156,13 @@ ActiveRecord::Schema.define(version: 20140906030139) do
   add_index "scenario_memberships", ["scenario_id"], name: "index_scenario_memberships_on_scenario_id", using: :btree
 
   create_table "scenarios", force: true do |t|
-    t.string   "name",                         null: false, charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.string   "name",                         null: false
     t.integer  "user_id",                      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "description",                               charset: "utf8mb4", collation: "utf8mb4_bin"
+    t.text     "description"
     t.boolean  "public",       default: false, null: false
-    t.string   "guid",                         null: false, charset: "ascii",   collation: "ascii_bin"
+    t.string   "guid",                         null: false
     t.string   "source_url"
     t.string   "tag_bg_color"
     t.string   "tag_fg_color"
@@ -153,31 +195,31 @@ ActiveRecord::Schema.define(version: 20140906030139) do
     t.text     "credential_value",                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "mode",             default: "text", null: false, collation: "utf8_bin"
+    t.string   "mode",             default: "text", null: false
   end
 
   add_index "user_credentials", ["user_id", "credential_name"], name: "index_user_credentials_on_user_id_and_credential_name", unique: true, using: :btree
 
   create_table "users", force: true do |t|
-    t.string   "email",                              default: "",    null: false,                     collation: "utf8_bin"
-    t.string   "encrypted_password",                 default: "",    null: false, charset: "ascii",   collation: "ascii_bin"
-    t.string   "reset_password_token",                                                                collation: "utf8_bin"
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "admin",                              default: false, null: false
-    t.integer  "failed_attempts",                    default: 0
+    t.boolean  "admin",                  default: false, null: false
+    t.integer  "failed_attempts",        default: 0
     t.string   "unlock_token"
     t.datetime "locked_at"
-    t.string   "username",               limit: 191,                 null: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
-    t.string   "invitation_code",                                    null: false,                     collation: "utf8_bin"
-    t.integer  "scenario_count",                     default: 0,     null: false
+    t.string   "username",                               null: false
+    t.string   "invitation_code",                        null: false
+    t.integer  "scenario_count",         default: 0,     null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
This should help with #626, it also has the benefit that users do not need to share their username and password with any third party application that needs to access the huginn instance.

Since we probably can not keep the application `secret` secret I think we should automatically add every known application that is able to use huginn via a migration.

At the moment you need to access `<your huginn instance>/oauth/applications` and add the application manually.
