### PR TITLE
Fix "heroku git:clone" to work on any folder

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,7 +19,7 @@
 
               <li>Run the following commands:<br />
                 <%= content_tag :pre do -%>
-heroku git:clone <%= content_tag :var, app_name %>
+heroku git:clone -a <%= content_tag :var, app_name %>
 cd <%= content_tag :var, app_name %>
 bundle
 bin/setup_heroku


### PR DESCRIPTION
When running "heroku git:clone app-name" outside an app folder, heroku outputs:

> Cloning from app 'app-name'...
>  !    No app specified.
>  !    Run this command from an app folder or specify which app to use with --app APP.

To fix this, we simply need to explictly add the app name by using "heroku git:clone -a app-name".
