### PR TITLE
Google calendar quickadd

### DIFF
--- a/app/models/agents/google_calendar_publish_agent.rb
+++ b/app/models/agents/google_calendar_publish_agent.rb
@@ -103,7 +103,7 @@ module Agents
         calendar = GoogleCalendar.new(options, Rails.logger)
 
         # publish using quickadd or insert; default insert
-        if event.payload.key?("method") && event.payload["method"] == "quickadd"
+        if event.payload["method"] == "quickadd" || interpolated["method"] == "quickadd"
           log "publish - quickadd "+event.payload["message"]
           response = calendar.quickadd_as(options['calendar_id'], event.payload["message"])
         else

--- a/app/models/agents/trigger_agent.rb
+++ b/app/models/agents/trigger_agent.rb
@@ -96,10 +96,9 @@ module Agents
           else
             payload = { 'message' => opts['message'] }
           end
-          for key in opts.keys
-            if not(reserved.include? key)
-              payload[key] = opts[key]
-            end
+
+          opts.each do |key, value|
+            payload[key] = value unless reserved.include?(key.to_s)
           end
 
           create_event :payload => payload

--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -42,6 +42,22 @@ class GoogleCalendar
     ret
   end
 
+  # who - String: email of user to add event
+  # text - String: what, where, and when (only what and when are required)
+  def quickadd_as(who, text)
+    auth_as
+
+    @logger.info("Attempting to quickAdd event for " + who + ": " + text)
+
+    ret = @client.execute(
+      api_method: @calendar.events.quick_add,
+      parameters: {'calendarId' => who, 'sendNotifications' => true, 'text' => text, 'sendNotifications' => true },
+      headers: {'Content-Type' => 'application/json'}
+    )
+    @logger.debug ret.to_yaml
+    ret
+  end
+
   def events_as(who, date)
     auth_as
 


### PR DESCRIPTION
- Add option to use quickadd method with Google calendar API 
- Allow Trigger Agent to pass additional fields from the incoming event to the outgoing event, instead of only outputting `message`
