### PR TITLE
Add sub menu of diagram page

### DIFF
--- a/app/assets/javascripts/diagram.js.coffee
+++ b/app/assets/javascripts/diagram.js.coffee
@@ -16,7 +16,7 @@ $ ->
       badge.css
         left: tl.x - badge.outerWidth()  * (2/3)
         top:  tl.y - badge.outerHeight() * (1/3)
-        'background-color': badge.find('.label').css('background-color')
+        position: "absolute"
       .show()
       return
     return

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -244,6 +244,8 @@ class AgentsController < ApplicationController
       end
     when /\A#{Regexp::escape scenarios_path}\/\d+\z/, agents_path
       path = ret
+    when "diagram"
+      path = diagram_path
     end
 
     if path

--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -219,7 +219,13 @@ module DotHelper
             btn['class'] = 'btn btn-default dropdown-toggle'
             btn['data-toggle'] = 'dropdown'
             btn['aria-expanded'] = 'false'
-            btn['style'] = 'width: 17px; height: 17px; background-color: #60C0F5'
+            if agent.unavailable?
+              btn['style'] = 'width: 17px; height: 17px; background-color: #F0AD4E'
+            elsif agent.working?
+              btn['style'] = 'width: 17px; height: 17px; background-color: #5CB85C'
+            else
+              btn['style'] = 'width: 17px; height: 17px; background-color: #D9534F'
+            end
             btn.content = ""
 
             btn << Nokogiri::XML::Node.new('span', doc) { |caret|
@@ -232,9 +238,9 @@ module DotHelper
             ultag['class'] = 'dropdown-menu'
             ultag['role'] = 'menu'
             ultag << Nokogiri::XML::Node.new('li', doc) { |litag|
-              litag<< Nokogiri::XML::Node.new('a', doc) { |atag|
+              litag << Nokogiri::XML::Node.new('a', doc) { |atag|
                 atag['href'] = agent_path(agent)
-                atag<< Nokogiri::XML::Node.new('span', doc) { |spantag|
+                atag << Nokogiri::XML::Node.new('span', doc) { |spantag|
                   spantag['class'] = 'glyphicon glyphicon-eye-open'
                   spantag.content = ' Show All'
                 }
@@ -244,20 +250,20 @@ module DotHelper
               litag['class'] = 'divider'
             }
             ultag << Nokogiri::XML::Node.new('li', doc) { |litag|
-              litag<< Nokogiri::XML::Node.new('a', doc) { |atag|
+              litag << Nokogiri::XML::Node.new('a', doc) { |atag|
                 atag['href'] = '#'
                 atag['data-toggle'] = 'modal'
                 atag['data-target'] = '#diagramEditAgent%d' % agent_id
-                atag<< Nokogiri::XML::Node.new('span', doc) { |spantag|
+                atag << Nokogiri::XML::Node.new('span', doc) { |spantag|
                   spantag['class'] = 'glyphicon glyphicon-pencil'
                   spantag.content = ' Edit agent name'
                 }
               }
             }
             ultag << Nokogiri::XML::Node.new('li', doc) { |litag|
-              litag<< Nokogiri::XML::Node.new('a', doc) { |atag|
+              litag << Nokogiri::XML::Node.new('a', doc) { |atag|
                 atag['href'] = edit_agent_path(agent)
-                atag<< Nokogiri::XML::Node.new('span', doc) { |spantag|
+                atag << Nokogiri::XML::Node.new('span', doc) { |spantag|
                   spantag['class'] = 'glyphicon glyphicon-pencil'
                   spantag.content = ' Edit agent settings'
                 }
@@ -267,11 +273,11 @@ module DotHelper
               litag['class'] = 'divider'
             }
             ultag << Nokogiri::XML::Node.new('li', doc) { |litag|
-              litag<< Nokogiri::XML::Node.new('a', doc) { |atag|
+              litag << Nokogiri::XML::Node.new('a', doc) { |atag|
                 atag['href'] = '#'
                 atag['data-toggle'] = 'modal'
                 atag['data-target'] = '#diagramEnableAgent%d' % agent_id
-                atag<< Nokogiri::XML::Node.new('span', doc) { |spantag|
+                atag << Nokogiri::XML::Node.new('span', doc) { |spantag|
                   if agent.disabled?
                     spantag['class'] = 'glyphicon glyphicon-play'
                     spantag.content = ' Enable agent'
@@ -283,18 +289,18 @@ module DotHelper
               }
             }
             ultag << Nokogiri::XML::Node.new('li', doc) { |litag|
-              litag<< Nokogiri::XML::Node.new('a', doc) { |atag|
+              litag << Nokogiri::XML::Node.new('a', doc) { |atag|
                 atag['href'] = '#'
                 atag['data-toggle'] = 'modal'
                 atag['data-target'] = '#diagramSrcAgent%d' % agent_id
-                atag<< Nokogiri::XML::Node.new('span', doc) { |spantag|
+                atag << Nokogiri::XML::Node.new('span', doc) { |spantag|
                   spantag['class'] = 'glyphicon glyphicon-road'
                   spantag.content = ' Set Source Agent'
                 }
               }
             }
           }
-          #modal for setting source agent
+          # modal for setting source agent
           root << Nokogiri::XML::Node.new('div', doc) { |div|
             div['class'] = 'confirm-agent modal'
             div['id'] = 'diagramSrcAgent%d' % agent_id
@@ -408,8 +414,8 @@ module DotHelper
               }
             }
           }
-          #End of #modal for setting source agent
-          #modal for edit agent name
+          # End of #modal for setting source agent
+          # modal for edit agent name
           root << Nokogiri::XML::Node.new('div', doc) { |div|
             div['class'] = 'confirm-agent modal'
             div['id'] = 'diagramEditAgent%d' % agent_id
@@ -505,8 +511,8 @@ module DotHelper
               }
             }
           }
-          #End of modal for edit agent name
-          #Modal for enable/disable agent
+          # End of modal for edit agent name
+          # Modal for enable/disable agent
           root << Nokogiri::XML::Node.new('div', doc) { |div|
             div['class'] = 'confirm-agent modal'
             div['id'] = 'diagramEnableAgent%d' % agent_id
@@ -601,7 +607,7 @@ module DotHelper
               }
             }
           }
-          #Modal for enable/disable agent
+          # End of Modal for enable/disable agent
         }
       }
       # See also: app/assets/diagram.js.coffee


### PR DESCRIPTION
It looks that huginn needs the convenient web UI for user.
So I attached sub menu on each agent on diagram page.
I hope It make users check/change agent settings easily.
If it will be merged, I will add additional function to sub menu later.

![image](https://cloud.githubusercontent.com/assets/9605660/9733690/5fb60882-5668-11e5-8c89-5199ea725486.png)
