### PR TITLE
FileDownloadAgent added

### DIFF
--- a/app/models/agents/file_download_agent.rb
+++ b/app/models/agents/file_download_agent.rb
@@ -1,0 +1,88 @@
+
+require "tempfile"
+require "faraday"
+require "uri"
+require "securerandom"
+module Agents
+  class FileDownloadAgent < Agent
+    cannot_be_scheduled!
+
+    description <<-MD
+      File download agent is designed to download things and write the content to files. Right now it blocks, so you should be very careful what are you downloading.
+      # Required parameters
+      * url: url to get
+
+      # Optional parameters
+      * destination: where to save the file, if omitted tempfile will be created.
+      * merge: it will keep the original event and it will add the destination where we saved the file, by default it is false
+    MD
+
+    def default_options
+      {
+          'expected_update_period_in_days' => 10,
+          'url' => '{{ url }}',
+          'destination' => '{{ destination }}',
+          'merge' => false
+      }
+    end
+
+    def validate_options
+      errors.add(:base, "expected_update_period_in_days is required") unless options['expected_update_period_in_days'].present?
+      errors.add(:base, "url is required") unless options['url'].present?
+    end
+
+    def working?
+      event_created_within?(interpolated['expected_update_period_in_days']) && most_recent_event && most_recent_event.payload['destination'] && !recent_error_logs?
+    end
+
+    def receive(incoming_events)
+      incoming_events.each do |event|
+        timeout = interpolated(event)['timeout'] || 10
+        merge = interpolated(event)['merge']
+        destination = interpolated(event)['destination']
+        url = interpolated(event)['url']
+        begin
+          response = download(url)
+          path = save(destination, response.body)
+
+          if merge == "true"
+            create_event :payload => event.payload.dup.merge({
+              "destination" => path
+            })
+          else
+            create_event :payload => {
+              "destination" => path
+            }
+          end
+        rescue => e
+          log("Failed to download #{url} to #{destination || '<tmp>'}: #{e}")
+        end
+      end
+    end
+    def save(destination, content)
+      begin
+        if !destination
+          handle = Tempfile.new(SecureRandom.hex, :encoding => 'ascii-8bit')
+          destination = handle.path
+        else
+          handle = File.open(destination, 'wb')
+        end
+        handle.write(content)
+        handle.path
+      rescue => e
+        raise e
+      ensure
+        handle.close unless handle.nil?
+      end
+    end
+
+    def download(url)
+      uri = URI.parse(url)
+      conn = Faraday.new "#{uri.scheme}://#{uri.host}" do |f|
+        f.adapter :em_http
+      end
+
+      conn.get "#{uri.path}?#{uri.query}"
+    end
+  end
+end

--- a/app/models/agents/file_download_agent.rb
+++ b/app/models/agents/file_download_agent.rb
@@ -1,4 +1,3 @@
-
 require "tempfile"
 require "faraday"
 require "uri"
@@ -14,15 +13,15 @@ module Agents
 
       # Optional parameters
       * destination: where to save the file, if omitted tempfile will be created.
-      * merge: it will keep the original event and it will add the destination where we saved the file, by default it is false
+      * mode: if you set to `merge` it will keep the original event and it will add the destination where we saved the file, by default it is `clean`
     MD
 
     def default_options
       {
-          'expected_update_period_in_days' => 10,
-          'url' => '{{ url }}',
-          'destination' => '{{ destination }}',
-          'merge' => false
+          "expected_update_period_in_days" => 10,
+          "url" => "{{ url }}",
+          "destination" => "{{ destination }}",
+          "mode" => "clean"
       }
     end
 
@@ -38,14 +37,14 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         timeout = interpolated(event)['timeout'] || 10
-        merge = interpolated(event)['merge']
+        mode = interpolated(event)['mode']
         destination = interpolated(event)['destination']
         url = interpolated(event)['url']
         begin
           response = download(url)
           path = save(destination, response.body)
 
-          if merge == "true"
+          if mode == "merge"
             create_event :payload => event.payload.dup.merge({
               "destination" => path
             })

--- a/spec/models/agents/file_download_agent_spec.rb
+++ b/spec/models/agents/file_download_agent_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Agents::FileDownloadAgent do
   describe "validate" do
-
+    # TODO
   end
 
   describe "#receive" do
@@ -11,13 +11,9 @@ describe Agents::FileDownloadAgent do
         @opts = {
           :url => "{{ url }}",
           :expected_update_period_in_days => 10,
-          :merge => "{{ merge }}",
+          :mode => "{{ mode }}",
           :destination => "/tmp/video.mp4"
         }
-
-
-
-        #stub.instance_of(Agents::FileDownloadAgent) do |klass|
 
         instance_of(Agents::FileDownloadAgent) do
           save("/tmp/video.mp4", "response from get") {
@@ -31,7 +27,6 @@ describe Agents::FileDownloadAgent do
             resp
           }
         end
-        #end
         @checker = Agents::FileDownloadAgent.new(
           :name => "TestFileDownloader",
           :options => @opts
@@ -46,7 +41,7 @@ describe Agents::FileDownloadAgent do
         event.agent = agents(:bob_weather_agent)
         event.payload = {
           :url => "http://example.org/video.mp4?secret=pssst",
-          :merge => "false"
+          :mode => "clean"
         }
         event.save!
         Agents::FileDownloadAgent.async_receive(@checker.id, [event.id])
@@ -62,7 +57,7 @@ describe Agents::FileDownloadAgent do
         event.payload = {
           :url => "http://example.org/video.mp4?secret=pssst",
           :my_special_prop => "my_special_value",
-          :merge => true
+          :mode => "merge"
         }
         event.save!
         Agents::FileDownloadAgent.async_receive(@checker.id, [event.id])
@@ -132,7 +127,7 @@ describe Agents::FileDownloadAgent do
         @opts = {
           :url => "{{ url }}",
           :expected_update_period_in_days => 10,
-          :merge => "{{ merge }}",
+          :mode => "{{ mode }}",
           :destination => "/tmp/video.mp4"
         }
 
@@ -158,7 +153,7 @@ describe Agents::FileDownloadAgent do
         @opts = {
           :url => "{{ url }}",
           :expected_update_period_in_days => 10,
-          :merge => "{{ merge }}",
+          :mode => "{{ mode }}",
           :destination => "/tmp/video.mp4"
         }
 
@@ -191,7 +186,7 @@ describe Agents::FileDownloadAgent do
         @opts = {
           :url => "{{ url }}",
           :expected_update_period_in_days => 10,
-          :merge => "{{ merge }}",
+          :mode => "{{ mode }}",
           :destination => "/tmp/video.mp4"
         }
 
@@ -212,7 +207,7 @@ describe Agents::FileDownloadAgent do
       @opts = {
         :url => "{{ url }}",
         :expected_update_period_in_days => 10,
-        :merge => "{{ merge }}",
+        :mode => "{{ mode }}",
         :destination => "/tmp/video.mp4"
       }
 
@@ -236,32 +231,4 @@ describe Agents::FileDownloadAgent do
       expect(response.body).to eq("response from get")
     end
   end
-  # before do
-  #   @opts = {
-  #
-  #   }
-  #
-  #   @checker = Agents::FileDownloadAgent.new(@opts)
-  #   @checker.service = services(:generic)
-  #   @checker.user = users(:bob)
-  #   @checker.save!
-  #
-  #   @event = Event.new
-  #   @event.agent = agents(:bob_weather_agent)
-  #   @event.payload = { :title => "Gonna rain...", :body => 'San Francisco is gonna get wet' }
-  #   @event.save!
-  #
-  #   stub.any_instance_of(Agents::TumblrPublishAgent).tumblr {
-  #     stub!.text(anything, anything) { { "id" => "5" } }
-  #   }
-  # end
-  #
-  # describe '#receive' do
-  #   it 'should publish any payload it receives' do
-  #     Agents::TumblrPublishAgent.async_receive(@checker.id, [@event.id])
-  #     expect(@checker.events.count).to eq(1)
-  #     expect(@checker.events.first.payload['post_id']).to eq('5')
-  #     expect(@checker.events.first.payload['published_post']).to eq('[huginnbot.tumblr.com] text')
-  #   end
-  # end
 end

--- a/spec/models/agents/file_download_agent_spec.rb
+++ b/spec/models/agents/file_download_agent_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Agents::FileDownloadAgent do
   describe "validate" do

--- a/spec/models/agents/file_download_agent_spec.rb
+++ b/spec/models/agents/file_download_agent_spec.rb
@@ -1,0 +1,267 @@
+require 'spec_helper'
+
+describe Agents::FileDownloadAgent do
+  describe "validate" do
+
+  end
+
+  describe "#receive" do
+    describe "should receive and" do
+      before do
+        @opts = {
+          :url => "{{ url }}",
+          :expected_update_period_in_days => 10,
+          :merge => "{{ merge }}",
+          :destination => "/tmp/video.mp4"
+        }
+
+
+
+        #stub.instance_of(Agents::FileDownloadAgent) do |klass|
+
+        instance_of(Agents::FileDownloadAgent) do
+          save("/tmp/video.mp4", "response from get") {
+            "/tmp/video.mp4"
+          }
+        end
+        instance_of(Agents::FileDownloadAgent) do
+          download("http://example.org/video.mp4?secret=pssst") {
+            resp = OpenStruct.new
+            resp.body = "response from get"
+            resp
+          }
+        end
+        #end
+        @checker = Agents::FileDownloadAgent.new(
+          :name => "TestFileDownloader",
+          :options => @opts
+        )
+        @checker.service = services(:generic)
+        @checker.user = users(:bob)
+        @checker.save!
+      end
+
+      it "should download the file and save it" do
+        event = Event.new
+        event.agent = agents(:bob_weather_agent)
+        event.payload = {
+          :url => "http://example.org/video.mp4?secret=pssst",
+          :merge => "false"
+        }
+        event.save!
+        Agents::FileDownloadAgent.async_receive(@checker.id, [event.id])
+        expect(@checker.events.count).to eq(1)
+        expect(@checker.events.first.payload).to eq({
+          "destination" => "/tmp/video.mp4"
+        })
+      end
+
+      it "should download the file and save it using merge" do
+        event = Event.new
+        event.agent = agents(:bob_weather_agent)
+        event.payload = {
+          :url => "http://example.org/video.mp4?secret=pssst",
+          :my_special_prop => "my_special_value",
+          :merge => true
+        }
+        event.save!
+        Agents::FileDownloadAgent.async_receive(@checker.id, [event.id])
+        expect(@checker.events.count).to eq(1)
+        expect(@checker.events.first.payload["destination"]).to start_with("/tmp/video.mp4")
+        expect(@checker.events.first.payload["my_special_prop"]).to eq("my_special_value")
+      end
+    end
+
+    describe "should handle error" do
+      before do
+        @opts = {
+          :url => "{{url}}",
+          :expected_update_period_in_days => 10,
+        }
+
+        @checker = Agents::FileDownloadAgent.new(
+          :name => "TestFileDownloader",
+          :options => @opts
+        )
+        @checker.service = services(:generic)
+        @checker.user = users(:bob)
+        @checker.save!
+
+        @event = Event.new
+        @event.agent = agents(:bob_weather_agent)
+        @event.payload = {
+          :url => "http://example.org/video.mp4?secret=pssst",
+          :destination => "/tmp/video.mp4",
+        }
+        @event.save!
+
+        instance_of(Agents::FileDownloadAgent) do
+          download("http://example.org/video.mp4?secret=pssst") {
+            raise "Dummy error"
+          }
+
+          log("Failed to download http://example.org/video.mp4?secret=pssst to <tmp>: Dummy error")
+        end
+      end
+
+      it "should download the file and save it" do
+        Agents::FileDownloadAgent.async_receive(@checker.id, [@event.id])
+        expect(@checker.events.count).to eq(0)
+      end
+    end
+
+  end
+
+  describe "#save" do
+    describe "no destination" do
+      before do
+        instance_of(Tempfile) do
+          new(anything, {:encoding => 'ascii-8bit'}) {
+
+          }
+          path {
+            '/tmp/file'
+          }
+          write("content") {
+            true
+          }
+          close {
+
+          }
+        end
+        @opts = {
+          :url => "{{ url }}",
+          :expected_update_period_in_days => 10,
+          :merge => "{{ merge }}",
+          :destination => "/tmp/video.mp4"
+        }
+
+        @checker = Agents::FileDownloadAgent.new(
+          :name => "TestFileDownloader",
+          :options => @opts
+        )
+      end
+      it "should create tmpfile, write and return the path" do
+        expect(@checker.save(nil, "content")).to eq('/tmp/file')
+      end
+    end
+
+    describe "has destination" do
+      before do
+        stub(File).open("/tmp/video.mp4", "wb") {
+          obj = Object.new
+          stub(obj).write("content") { true }
+          stub(obj).close() { true }
+          stub(obj).path { "/tmp/video.mp4" }
+          obj
+        }
+        @opts = {
+          :url => "{{ url }}",
+          :expected_update_period_in_days => 10,
+          :merge => "{{ merge }}",
+          :destination => "/tmp/video.mp4"
+        }
+
+        @checker = Agents::FileDownloadAgent.new(
+          :name => "TestFileDownloader",
+          :options => @opts
+        )
+      end
+      it "should save there and return the path" do
+        expect(@checker.save("/tmp/video.mp4", "content")).to eq('/tmp/video.mp4')
+      end
+    end
+
+    describe "when io throws" do
+      before(:each) do
+        instance_of(Tempfile) do
+          new(anything, {:encoding => 'ascii-8bit'}) {
+
+          }
+          path {
+            "/tmp/file"
+          }
+          write("content") {
+            raise "dummy error"
+          }
+          close {
+          }
+        end
+
+        @opts = {
+          :url => "{{ url }}",
+          :expected_update_period_in_days => 10,
+          :merge => "{{ merge }}",
+          :destination => "/tmp/video.mp4"
+        }
+
+        @checker = Agents::FileDownloadAgent.new(
+          :name => "TestFileDownloader",
+          :options => @opts
+        )
+      end
+      it "should close the handle and rethrow" do
+        expect{@checker.save(nil, "content")}.to raise_error /dummy/
+      end
+    end
+
+  end
+
+  describe "#download" do
+    before do
+      @opts = {
+        :url => "{{ url }}",
+        :expected_update_period_in_days => 10,
+        :merge => "{{ merge }}",
+        :destination => "/tmp/video.mp4"
+      }
+
+      @checker = Agents::FileDownloadAgent.new(
+        :name => "TestFileDownloader",
+        :options => @opts
+      )
+
+      @url = "http://example.org/video.mp4?secret=psst"
+      stub.proxy(Faraday).new("http://example.org") { |obj|
+        stub(obj).get("/video.mp4?secret=psst") {
+          resp =  OpenStruct.new
+          resp.body = "response from get"
+          resp
+        }
+        obj
+      }
+    end
+    it "should download the file and return the value" do
+      response = @checker.download(@url)
+      expect(response.body).to eq("response from get")
+    end
+  end
+  # before do
+  #   @opts = {
+  #
+  #   }
+  #
+  #   @checker = Agents::FileDownloadAgent.new(@opts)
+  #   @checker.service = services(:generic)
+  #   @checker.user = users(:bob)
+  #   @checker.save!
+  #
+  #   @event = Event.new
+  #   @event.agent = agents(:bob_weather_agent)
+  #   @event.payload = { :title => "Gonna rain...", :body => 'San Francisco is gonna get wet' }
+  #   @event.save!
+  #
+  #   stub.any_instance_of(Agents::TumblrPublishAgent).tumblr {
+  #     stub!.text(anything, anything) { { "id" => "5" } }
+  #   }
+  # end
+  #
+  # describe '#receive' do
+  #   it 'should publish any payload it receives' do
+  #     Agents::TumblrPublishAgent.async_receive(@checker.id, [@event.id])
+  #     expect(@checker.events.count).to eq(1)
+  #     expect(@checker.events.first.payload['post_id']).to eq('5')
+  #     expect(@checker.events.first.payload['published_post']).to eq('[huginnbot.tumblr.com] text')
+  #   end
+  # end
+end


### PR DESCRIPTION
Just created a new agent which allows you to download files to the disk.

If you omit the destination it will download to a tempfile.

First I though this should be integrated into `WebsiteAgent` but that's for scraping and parsing.

There's a lot of room for improvement:
- use threads to download files
- timeout handling
- following redirect

ps: it would be amazing if the agent could get notified when its events got expired so the agent could cleanup those which were associated with the event (and the user could use the `Keep events` option for controlling the files which were created by this agent), right now this is what happens: https://github.com/cantino/huginn/blob/9c5847451b2f084f82796aff1243d01d410bc04a/app/models/event.rb#L74-L80
