### PR TITLE
Shuffling events in DelayAgent before emitting them

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -311,4 +311,17 @@ module LiquidInterpolatable
   end
   Liquid::Template.register_tag('credential', LiquidInterpolatable::Tags::Credential)
   Liquid::Template.register_tag('line_break', LiquidInterpolatable::Tags::LineBreak)
+
+  class Random < Liquid::Tag
+    def initialize(tag_name, max, tokens)
+       super
+       @max = max.to_i
+    end
+
+    def render(context)
+      rand(@max).to_s
+    end
+  end
+
+  Liquid::Template.register_tag('random', Random)
 end

--- a/app/concerns/sortable_events.rb
+++ b/app/concerns/sortable_events.rb
@@ -144,6 +144,7 @@ module SortableEvents
       events.map.with_index { |event, index|
         interpolate_with(event) {
           interpolation_context['_index_'] = index
+          interpolation_context['event_id'] = event.id
           order_by.map { |expression, type, _|
             string = interpolate_string(expression)
             begin

--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -70,7 +70,7 @@ module Agents
 
     def reorder(events, shuffle)
       if shuffle == true
-        events.reorder('rand()')
+        events.shuffle
       else
         events.reorder('events.id asc')
       end

--- a/spec/models/agents/delay_agent_spec.rb
+++ b/spec/models/agents/delay_agent_spec.rb
@@ -113,17 +113,17 @@ describe Agents::DelayAgent do
     end
 
     it "re-emits Events in random order and clears the memory" do
-      agent.options['shuffle'] = true
+      # agent.options['shuffle'] = true
+      agent.options['events_order'] = [["{% random 5 %}", "number"]]
       agent.receive([first_event, second_event, third_event])
       expect(agent.memory['event_ids']).to eq [second_event.id, third_event.id]
-
-      stub.proxy(agent).reorder(anything, true)
 
       expect {
         agent.check
       }.to change { agent.events.count }.by(2)
 
       # do not reorder since we are trying to prove it is random order
+
       events = agent.events
       expect(events.first.payload).to eq( third_event.payload).or eq(second_event.payload)
       expect(events.second.payload).to eq(third_event.payload).or eq(second_event.payload)

--- a/spec/models/agents/delay_agent_spec.rb
+++ b/spec/models/agents/delay_agent_spec.rb
@@ -98,14 +98,36 @@ describe Agents::DelayAgent do
       agent.receive([first_event, second_event, third_event])
       expect(agent.memory['event_ids']).to eq [second_event.id, third_event.id]
 
+      stub.proxy(agent).reorder(anything, false)
+
       expect {
         agent.check
       }.to change { agent.events.count }.by(2)
 
       events = agent.events.reorder('events.id desc')
+
       expect(events.first.payload).to eq third_event.payload
       expect(events.second.payload).to eq second_event.payload
 
+      expect(agent.memory['event_ids']).to eq []
+    end
+
+    it "re-emits Events in random order and clears the memory" do
+      agent.options['shuffle'] = true
+      agent.receive([first_event, second_event, third_event])
+      expect(agent.memory['event_ids']).to eq [second_event.id, third_event.id]
+
+      stub.proxy(agent).reorder(anything, true)
+
+      expect {
+        agent.check
+      }.to change { agent.events.count }.by(2)
+
+      # do not reorder since we are trying to prove it is random order
+      events = agent.events
+      expect(events.first.payload).to eq( third_event.payload).or eq(second_event.payload)
+      expect(events.second.payload).to eq(third_event.payload).or eq(second_event.payload)
+      expect(events.second.payload).not_to eq(events.first.payload)
       expect(agent.memory['event_ids']).to eq []
     end
   end


### PR DESCRIPTION
Sometimes you don't want to keep the original order of events in `DelayAgent`, set `shuffle` true and it will shuffle the events.

Btw it works great with https://github.com/cantino/huginn/pull/1118
