### PR TITLE
Try to guess RSS encodings

### DIFF
--- a/app/models/agent_log.rb
+++ b/app/models/agent_log.rb
@@ -14,6 +14,8 @@ class AgentLog < ActiveRecord::Base
   before_validation :scrub_message
   before_save :truncate_message
 
+  scope :errors, lambda { where('level > 3') }
+
   def self.log_for_agent(agent, message, options = {})
     puts "Agent##{agent.id}: #{message}" unless Rails.env.test?
 

--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -100,7 +100,15 @@ module Agents
         begin
           response = faraday.get(url)
           if response.success?
-            feed = FeedNormalizer::FeedNormalizer.parse(response.body, loose: true)
+            body = response.body
+
+            unless body.valid_encoding?
+              guessed_encoding = body.force_encoding('BINARY')[/\A[^\n]+? encoding="([\w-]+)"/, 1]
+              encoding = Encoding.find(guessed_encoding.presence || 'UTF-8') rescue 'UTF-8'
+              body = body.force_encoding(encoding).encode('UTF-8', undef: :replace, invalid: :replace)
+            end
+
+            feed = FeedNormalizer::FeedNormalizer.parse(body, loose: true)
             feed.clean! if boolify(interpolated['clean'])
             new_events.concat feed_to_events(feed)
           else

--- a/spec/data_fixtures/arnaldo-jabor-o-comentario-de-arnaldo-jabor.xml
+++ b/spec/data_fixtures/arnaldo-jabor-o-comentario-de-arnaldo-jabor.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+	<channel>
+		<title>CBN - Arnaldo Jabor - O Comentário de Arnaldo Jabor</title>
+		<link>http://cbn.globoradio.globo.com/comentaristas/arnaldo-jabor/ARNALDO-JABOR-O-COMENTARIO-DE-ARNALDO-JABOR.htm</link>
+		<description>Comentários do cineasta e jornalista Arnaldo Jabor sobre política, economia, cultura e comportamento: no Jornal da CBN, às 8h05.</description>
+		<itunes:author>CBN - Arnaldo Jabor - O Comentário de Arnaldo Jabor</itunes:author>
+		<language>pt-br</language>
+		<copyright>Sistema Globo de Radio 2015 </copyright>
+		<lastBuildDate>Sun, 01 Nov 2015 19:35:04 -0300</lastBuildDate>
+		<docs>http://blogs.law.harvard.edu/tech/rss</docs>
+		<webMaster>sitecbn@cbn.com.br</webMaster>
+		<ttl>2</ttl>
+		<itunes:image href="http://cbn.globoradio.globo.com/estaticos/img/CBN_1400x1400.jpg"/>
+		<pubDate>Sun, 01 Nov 2015 19:35:04 -0300</pubDate>
+		<itunes:category text="News"/>
+		<itunes:keywords>arnaldo jabor, sardenberg, carlos alberto sardenberg, miriam leitao, mauro halfeld, halfeld</itunes:keywords>
+		<itunes:explicit>No</itunes:explicit>
+		<item id="1229087">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 29/10/2015 08h</title>
+			<description>Peço cianureto ou taça de champanhe?</description>
+			<titleApp>Peço cianureto ou taça de champanhe?</titleApp>
+			<descriptionApp>Pra que escrever ou falar se nada adianta?</descriptionApp>
+			<itunes:subtitle>Peço cianureto ou taça de champanhe?</itunes:subtitle>
+			<itunes:summary>Peço cianureto ou taça de champanhe?</itunes:summary>
+			<pubDate>Thu, 29 Oct 2015 08:17:52 -0300</pubDate>
+			<itunes:duration>2:50</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/29/PECO-CIANURETO-OU-TACA-DE-CHAMPANHE.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160" length="1361984" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160" fileSize="1361984" type="audio/mpeg" expression="full" duration="170.232" bitrate="64000"/>
+		</item>
+		<item id="1228555">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 28/10/2015 08h</title>
+			<description>Como essa coisa toda vai acabar?</description>
+			<titleApp>Como essa coisa toda vai acabar?</titleApp>
+			<descriptionApp>Talvez seja preciso criar um novo Ministério Público para dar conta desse latifúndio de roubalheiras.</descriptionApp>
+			<itunes:subtitle>Como essa coisa toda vai acabar?</itunes:subtitle>
+			<itunes:summary>Como essa coisa toda vai acabar?</itunes:summary>
+			<pubDate>Wed, 28 Oct 2015 08:24:57 -0300</pubDate>
+			<itunes:duration>3:12</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/28/COMO-ESSA-COISA-TODA-VAI-ACABAR.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160" length="1538432" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160" fileSize="1538432" type="audio/mpeg" expression="full" duration="192.288" bitrate="64000"/>
+		</item>
+		<item id="1228011">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 27/10/2015 08h</title>
+			<description>PT está arrasando o país</description>
+			<titleApp>PT está arrasando o país</titleApp>
+			<descriptionApp>Causador disso tudo que nos acontece foi o Lula. Esse homem que nunca viu nada e que não sabia de nada é o grande culpado por nossa transformação.</descriptionApp>
+			<itunes:subtitle>PT está arrasando o país</itunes:subtitle>
+			<itunes:summary>PT está arrasando o país</itunes:summary>
+			<pubDate>Tue, 27 Oct 2015 08:18:08 -0300</pubDate>
+			<itunes:duration>2:29</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/27/PT-ESTA-ARRASANDO-O-PAIS.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160" length="1194752" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160" fileSize="1194752" type="audio/mpeg" expression="full" duration="149.328" bitrate="64000"/>
+		</item>
+		<item id="1227511">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 26/10/2015 08h</title>
+			<description>Brasil está sendo chantageado</description>
+			<titleApp>Brasil está sendo chantageado</titleApp>
+			<descriptionApp>No Congresso, ninguém liga. E pensam: dane-se o país que eu quero o meu.</descriptionApp>
+			<itunes:subtitle>Brasil está sendo chantageado</itunes:subtitle>
+			<itunes:summary>Brasil está sendo chantageado</itunes:summary>
+			<pubDate>Mon, 26 Oct 2015 08:17:52 -0300</pubDate>
+			<itunes:duration>2:42</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/26/BRASIL-ESTA-SENDO-CHANTAGEADO.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160" length="1297088" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160" fileSize="1297088" type="audio/mpeg" expression="full" duration="162.12" bitrate="64000"/>
+		</item>
+		<item id="1226483">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 23/10/2015 08h</title>
+			<description>Dilma é quase uma cúmplice</description>
+			<titleApp>Dilma é quase uma cúmplice</titleApp>
+			<descriptionApp>Presidente até pode não ter praticado pessoalmente alguma maracutaia, mas ela fez vista grossa sim.</descriptionApp>
+			<itunes:subtitle>Dilma é quase uma cúmplice</itunes:subtitle>
+			<itunes:summary>Dilma é quase uma cúmplice</itunes:summary>
+			<pubDate>Fri, 23 Oct 2015 08:18:24 -0300</pubDate>
+			<itunes:duration>2:24</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/23/DILMA-E-QUASE-UMA-CUMPLICE.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160" length="1155968" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160" fileSize="1155968" type="audio/mpeg" expression="full" duration="144.48" bitrate="64000"/>
+		</item>
+	</channel>
+</rss>

--- a/spec/data_fixtures/unknown-encoding.xml
+++ b/spec/data_fixtures/unknown-encoding.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="nonesense"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+	<channel>
+		<title>CBN - Arnaldo Jabor - O Comentário de Arnaldo Jabor</title>
+		<link>http://cbn.globoradio.globo.com/comentaristas/arnaldo-jabor/ARNALDO-JABOR-O-COMENTARIO-DE-ARNALDO-JABOR.htm</link>
+		<description>Comentários do cineasta e jornalista Arnaldo Jabor sobre política, economia, cultura e comportamento: no Jornal da CBN, às 8h05.</description>
+		<itunes:author>CBN - Arnaldo Jabor - O Comentário de Arnaldo Jabor</itunes:author>
+		<language>pt-br</language>
+		<copyright>Sistema Globo de Radio 2015 </copyright>
+		<lastBuildDate>Sun, 01 Nov 2015 19:35:04 -0300</lastBuildDate>
+		<docs>http://blogs.law.harvard.edu/tech/rss</docs>
+		<webMaster>sitecbn@cbn.com.br</webMaster>
+		<ttl>2</ttl>
+		<itunes:image href="http://cbn.globoradio.globo.com/estaticos/img/CBN_1400x1400.jpg"/>
+		<pubDate>Sun, 01 Nov 2015 19:35:04 -0300</pubDate>
+		<itunes:category text="News"/>
+		<itunes:keywords>arnaldo jabor, sardenberg, carlos alberto sardenberg, miriam leitao, mauro halfeld, halfeld</itunes:keywords>
+		<itunes:explicit>No</itunes:explicit>
+		<item id="1229087">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 29/10/2015 08h</title>
+			<description>Peço cianureto ou taça de champanhe?</description>
+			<titleApp>Peço cianureto ou taça de champanhe?</titleApp>
+			<descriptionApp>Pra que escrever ou falar se nada adianta?</descriptionApp>
+			<itunes:subtitle>Peço cianureto ou taça de champanhe?</itunes:subtitle>
+			<itunes:summary>Peço cianureto ou taça de champanhe?</itunes:summary>
+			<pubDate>Thu, 29 Oct 2015 08:17:52 -0300</pubDate>
+			<itunes:duration>2:50</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/29/PECO-CIANURETO-OU-TACA-DE-CHAMPANHE.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160" length="1361984" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151029.mp3&amp;materiaId=1229087&amp;categoriaId=160" fileSize="1361984" type="audio/mpeg" expression="full" duration="170.232" bitrate="64000"/>
+		</item>
+		<item id="1228555">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 28/10/2015 08h</title>
+			<description>Como essa coisa toda vai acabar?</description>
+			<titleApp>Como essa coisa toda vai acabar?</titleApp>
+			<descriptionApp>Talvez seja preciso criar um novo Ministério Público para dar conta desse latifúndio de roubalheiras.</descriptionApp>
+			<itunes:subtitle>Como essa coisa toda vai acabar?</itunes:subtitle>
+			<itunes:summary>Como essa coisa toda vai acabar?</itunes:summary>
+			<pubDate>Wed, 28 Oct 2015 08:24:57 -0300</pubDate>
+			<itunes:duration>3:12</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/28/COMO-ESSA-COISA-TODA-VAI-ACABAR.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160" length="1538432" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151028.mp3&amp;materiaId=1228555&amp;categoriaId=160" fileSize="1538432" type="audio/mpeg" expression="full" duration="192.288" bitrate="64000"/>
+		</item>
+		<item id="1228011">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 27/10/2015 08h</title>
+			<description>PT está arrasando o país</description>
+			<titleApp>PT está arrasando o país</titleApp>
+			<descriptionApp>Causador disso tudo que nos acontece foi o Lula. Esse homem que nunca viu nada e que não sabia de nada é o grande culpado por nossa transformação.</descriptionApp>
+			<itunes:subtitle>PT está arrasando o país</itunes:subtitle>
+			<itunes:summary>PT está arrasando o país</itunes:summary>
+			<pubDate>Tue, 27 Oct 2015 08:18:08 -0300</pubDate>
+			<itunes:duration>2:29</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/27/PT-ESTA-ARRASANDO-O-PAIS.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160" length="1194752" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151027.mp3&amp;materiaId=1228011&amp;categoriaId=160" fileSize="1194752" type="audio/mpeg" expression="full" duration="149.328" bitrate="64000"/>
+		</item>
+		<item id="1227511">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 26/10/2015 08h</title>
+			<description>Brasil está sendo chantageado</description>
+			<titleApp>Brasil está sendo chantageado</titleApp>
+			<descriptionApp>No Congresso, ninguém liga. E pensam: dane-se o país que eu quero o meu.</descriptionApp>
+			<itunes:subtitle>Brasil está sendo chantageado</itunes:subtitle>
+			<itunes:summary>Brasil está sendo chantageado</itunes:summary>
+			<pubDate>Mon, 26 Oct 2015 08:17:52 -0300</pubDate>
+			<itunes:duration>2:42</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/26/BRASIL-ESTA-SENDO-CHANTAGEADO.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160" length="1297088" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151026.mp3&amp;materiaId=1227511&amp;categoriaId=160" fileSize="1297088" type="audio/mpeg" expression="full" duration="162.12" bitrate="64000"/>
+		</item>
+		<item id="1226483">
+			<title>Arnaldo Jabor - O Comentário de Arnaldo Jabor - 23/10/2015 08h</title>
+			<description>Dilma é quase uma cúmplice</description>
+			<titleApp>Dilma é quase uma cúmplice</titleApp>
+			<descriptionApp>Presidente até pode não ter praticado pessoalmente alguma maracutaia, mas ela fez vista grossa sim.</descriptionApp>
+			<itunes:subtitle>Dilma é quase uma cúmplice</itunes:subtitle>
+			<itunes:summary>Dilma é quase uma cúmplice</itunes:summary>
+			<pubDate>Fri, 23 Oct 2015 08:18:24 -0300</pubDate>
+			<itunes:duration>2:24</itunes:duration>
+			<link>http://cbn.globoradio.globo.com//comentaristas/arnaldo-jabor/2015/10/23/DILMA-E-QUASE-UMA-CUMPLICE.htm</link>
+			<guid isPermaLink="false">http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160</guid>
+			<enclosure url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160" length="1155968" type="audio/mpeg" />
+			<media:content url="http://cbn.globoradio.globo.com/global/podcast.mp3?audio=2015/colunas/jabor_151023.mp3&amp;materiaId=1226483&amp;categoriaId=160" fileSize="1155968" type="audio/mpeg" expression="full" duration="144.48" bitrate="64000"/>
+		</item>
+	</channel>
+</rss>


### PR DESCRIPTION
@knu, I'd like your advice on this if you have time.  #960 contains a feed that cannot be parsed.  Interestingly, your work in #957 errors, but provides a very useful error about the encoding being invalid, while the code currently in master just fails without an error.  This PR allows the feed to be parsed, as does simply setting `"force_encoding": "ISO-8859-1"` in the Agent options.  In both cases, the resulting text looks wrong to me.  Oddly, when I edit it with `vim`, it looks fine.  Perhaps vim can detect or handle something about this file's encoding that Ruby cannot, but I'm confused as to what encoding this file actually has.  It also appears that GitHub's display of these files, when committed, is correct, but when I view Huginn's extracted events in ISO-8859-1, they're messed up.
