### PR TITLE
SimpleMetaAgent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem 'haversine'
 gem 'omniauth-evernote'
 gem 'evernote_oauth'
 
+# SimpleMetaAgent
+gem 'metainspector'
+
 # Optional Services.
 gem 'omniauth-37signals'          # BasecampAgent
 gem 'omniauth-wunderlist', github: 'wunderlist/omniauth-wunderlist', ref: 'd0910d0396107b9302aa1bc50e74bb140990ccb8'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'xmpp4r',  '~> 0.5.6'         # JabberAgent
 gem 'mqtt'                        # MQTTAgent
 gem 'slack-notifier', '~> 1.0.0'  # SlackAgent
 gem 'hypdf', '~> 1.0.7'           # PDFInfoAgent
+gem 'metainspector'               # SimpleMetaAgent
 
 # Weibo Agents
 gem 'weibo_2', github: 'cantino/weibo_2', branch: 'master'
@@ -42,9 +43,6 @@ gem 'haversine'
 # EvernoteAgent
 gem 'omniauth-evernote'
 gem 'evernote_oauth'
-
-# SimpleMetaAgent
-gem 'metainspector'
 
 # Optional Services.
 gem 'omniauth-37signals'          # BasecampAgent

--- a/app/models/agents/simple_meta_agent.rb
+++ b/app/models/agents/simple_meta_agent.rb
@@ -58,8 +58,12 @@ module Agents
     def receive(incoming_events)
       incoming_events.each do |event|
         if url = Utils.value_at(event.payload, interpolated['url_path'])
-          page = MetaInspector.new(url)
-          create_event payload: event.payload.merge(meta: page.to_hash, untracked_url: page.untracked_url)
+          begin
+            page = MetaInspector.new(url, connection_timeout: 10)
+          rescue Faraday::TimeoutError
+          else
+            create_event payload: event.payload.merge(meta: page.to_hash, untracked_url: page.untracked_url)
+          end
         end
       end
     end

--- a/app/models/agents/simple_meta_agent.rb
+++ b/app/models/agents/simple_meta_agent.rb
@@ -1,0 +1,67 @@
+module Agents
+  class SimpleMetaAgent < Agent
+    cannot_be_scheduled!
+
+    description <<-MD
+      The SimpleMetaAgent scrapes meta from url_path, merges a meta object with the event.payload and re-emits the updated event.
+
+      `url_path` is a [JSONPaths](http://goessner.net/articles/JsonPath/) to the URL to extract meta from.
+
+      `expected_receive_period_in_days` is used to determine if the Agent is working. Set it to the maximum number of days
+      that you anticipate passing without this Agent receiving an incoming Event.
+    MD
+
+    event_description <<-MD
+      Incomining events are merged with a `meta` object provided by the [metainspector gem](https://github.com/jaimeiniesta/metainspector)(meta object is the same as `page.to_hash` response) and should look like:
+
+          {
+            incoming_url: 'http://angularjobs.com',
+            ... all fields from the incoming event merged with (below)...
+            title: "AngularJS Jobs + JavaScript Developer Community Resources",
+            best_title: "AngularJS Jobs + JavaScript Developer Community Resources",
+            description: "Top JavaScript Engineers seeking Contract & Full-time work...",
+            meta_tags: {
+              name: {
+                description: [
+                  "Businesses, startups & organizations find Senior, Full-Stack, Lead & Architect candidates with AngularJS, React, jQuery & NodeJS experience."
+                ],
+                keywords: [
+                  "AngularJS, JavaScript, React, Ember, Rails, Talent, Hiring, Interviewing"
+                ]
+              }
+            }
+          }
+
+        ... see [metainspector](https://github.com/jaimeiniesta/metainspector) to learn more about the merged fields.
+    MD
+
+    def default_options
+      {
+        url_path: 'path.to.url',
+        expected_receive_period_in_days: "10"
+      }
+    end
+
+    def validate_options
+      unless options['expected_receive_period_in_days'].present? && options['expected_receive_period_in_days'].to_i > 0
+        errors.add(:base, "Please provide 'expected_receive_period_in_days' to indicate how many days can pass before this Agent is considered to be not working")
+      end
+      unless options['url_path'].present?
+        errors.add(:base, "Please provide 'url_path' to indicate which value to analyze for collecting top events.")
+      end
+    end
+
+    def working?
+      last_receive_at && last_receive_at > options['expected_receive_period_in_days'].to_i.days.ago && !recent_error_logs?
+    end
+
+    def receive(incoming_events)
+      incoming_events.each do |event|
+        if url = Utils.value_at(event.payload, interpolated['url_path'])
+          page = MetaInspector.new(url)
+          create_event payload: event.payload.merge(meta: page.to_hash, untracked_url: page.untracked_url)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -7,3 +7,13 @@ jane_website_agent_event:
   user: jane
   agent: jane_website_agent
   payload: <%= { :title => "foo", :url => "http://foo.com" }.to_json.inspect %>
+
+url_event:
+  user: bob
+  agent: bob_website_agent
+  payload: <%= { title: "foo", url: "http://xkcd.com" }.to_json.inspect %>
+
+url_less_event:
+  user: bob
+  agent: bob_website_agent
+  payload: <%= { title: "foo" }.to_json.inspect %>

--- a/spec/models/agents/simple_meta_agent_spec.rb
+++ b/spec/models/agents/simple_meta_agent_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe Agents::SimpleMetaAgent do
+  before do
+    stub_request(:any, /xkcd/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")),
+                                         status: 200,
+                                         headers: {
+                                           'X-Status-Message' => 'OK'
+                                         })
+  end
+  let(:agent) do
+    _agent = Agents::SimpleMetaAgent.new(name: 'My SimpleMetaAgent')
+    _agent.options = _agent.default_options.merge(url_path: 'url')
+    _agent.user = users(:bob)
+    _agent.sources << agents(:bob_website_agent)
+    _agent.save!
+    _agent
+  end
+
+  describe "#working?" do
+    it "checks if events have been received within expected receive period" do
+      expect(agent).not_to be_working
+      Agents::SimpleMetaAgent.async_receive agent.id, [events(:url_event).id]
+      expect(agent.reload).to be_working
+      the_future = (agent.options[:expected_receive_period_in_days].to_i + 1).days.from_now
+      stub(Time).now { the_future }
+      expect(agent.reload).not_to be_working
+    end
+  end
+
+  describe "validation" do
+    before do
+      expect(agent).to be_valid
+    end
+    it "should validate presence of expected_receive_period_in_days" do
+      agent.options['expected_receive_period_in_days'] = ""
+      expect(agent).not_to be_valid
+      agent.options['expected_receive_period_in_days'] = 0
+      expect(agent).not_to be_valid
+      agent.options['expected_receive_period_in_days'] = -1
+      expect(agent).not_to be_valid
+    end
+    it "should validate presence of url_path" do
+      agent.options[:url_path] = nil
+      expect(agent).not_to be_valid
+    end
+  end
+
+  describe "#receive" do
+    it 'should re-emit event with merged "meta" object' do
+      expect {
+        agent.receive([events(:url_event)])
+      }.to change {Event.count}.by 1
+      expect(Event.last.payload['meta']).not_to be nil
+    end
+    it 'should not emit event if value at url_path is nil' do
+      expect {
+        agent.receive([events(:url_less_event)])
+      }.to change {Event.count}.by 0
+    end
+  end
+
+end

--- a/spec/models/agents/simple_meta_agent_spec.rb
+++ b/spec/models/agents/simple_meta_agent_spec.rb
@@ -10,7 +10,7 @@ describe Agents::SimpleMetaAgent do
   end
   let(:agent) do
     _agent = Agents::SimpleMetaAgent.new(name: 'My SimpleMetaAgent')
-    _agent.options = _agent.default_options.merge(url_path: 'url')
+    _agent.options = _agent.default_options.merge(url: '{{url}}')
     _agent.user = users(:bob)
     _agent.sources << agents(:bob_website_agent)
     _agent.save!
@@ -40,8 +40,8 @@ describe Agents::SimpleMetaAgent do
       agent.options['expected_receive_period_in_days'] = -1
       expect(agent).not_to be_valid
     end
-    it "should validate presence of url_path" do
-      agent.options[:url_path] = nil
+    it "should validate presence of url" do
+      agent.options[:url] = nil
       expect(agent).not_to be_valid
     end
   end
@@ -53,7 +53,7 @@ describe Agents::SimpleMetaAgent do
       }.to change {Event.count}.by 1
       expect(Event.last.payload['meta']).not_to be nil
     end
-    it 'should not emit event if value at url_path is nil' do
+    it 'should not emit event if value at url is nil' do
       expect {
         agent.receive([events(:url_less_event)])
       }.to change {Event.count}.by 0


### PR DESCRIPTION
The SimpleMetaAgent:
1. scrapes meta from a URL(specified by `url_path` option) 
2. merges the results into `event.payload.meta` 
3. emits the updated event.payload 

This is in response to https://github.com/cantino/huginn/issues/1126
