### PR TITLE
Increase accessibility of Trigger agent options

### DIFF
--- a/spec/fixtures/agents.yml
+++ b/spec/fixtures/agents.yml
@@ -132,3 +132,22 @@ bob_data_output_agent:
         }
       }
     }.to_json.inspect %>
+
+bob_trigger_agent:
+  type: Agents::TriggerAgent
+  user: bob
+  name: Filter RSS Feed 
+  guid: <%= SecureRandom.hex %>
+  options: <%= {
+    expected_receive_period_in_days: 3,
+    keep_event: "true",
+    message: "unchanged",
+    rules: {
+      rule1:
+        {
+          type: "!regex",
+          value: "unchanged",
+          path: "text"
+        }
+    }
+  }.to_json.inspect %>

--- a/spec/models/scenario_import_spec.rb
+++ b/spec/models/scenario_import_spec.rb
@@ -17,11 +17,13 @@ describe ScenarioImport do
   let(:trigger_agent_options) {
     {
       'expected_receive_period_in_days' => 2,
-      'rules' => [{
+      'rules' => {
+        'rule1' => {
                     'type' => "regex",
                     'value' => "rain|storm",
                     'path' => "conditions",
-                  }],
+                  }
+      },
       'message' => "Looks like rain!"
     }
   }

--- a/spec/support/shared_examples/agent_controller_concern.rb
+++ b/spec/support/shared_examples/agent_controller_concern.rb
@@ -50,6 +50,18 @@ shared_examples_for AgentControllerConcern do
         agent.options['configure_options'] = { 'key' => 'value' }
         expect(agent).to be_valid
       end
+
+      it "should allow 'configure_options_nested_array_update_mode' to exist in options when the action is 'configure'" do
+        agent.options['action'] = 'configure'
+        agent.options['configure_options'] = { 'key' => 'value' }
+        expect(agent).to be_valid
+        agent.options['configure_options_nested_array_update_mode'] = 'replace'
+        expect(agent).to be_valid
+        agent.options['configure_options_nested_array_update_mode'] = 'merge'
+        expect(agent).to be_valid
+        agent.options['configure_options_nested_array_update_mode'] = 'fail'
+        expect(agent).not_to be_valid
+      end
     end
   end
 
@@ -146,6 +158,49 @@ shared_examples_for AgentControllerConcern do
 
       expect(agent.control_targets.reload).to all(satisfy { |a| a.options['template'] && a.options['template']['item'] && (a.options['template']['item']['title'] == 'changed') })
       expect(agents(:bob_data_output_agent).reload.options).to eq(old_options.deep_merge(agent.options['configure_options']))
+    end
+    it "should merge nested arrays in configured targets" do
+      agent.control_targets << agents(:bob_trigger_agent)
+      agent.options['action'] = 'configure'
+      agent.options['configure_options'] = { 
+          rules: {
+            rule1:
+              {
+                  type: "!regex",
+                  value: "changed",
+                  path: "text"
+                }
+            }
+        }
+      agent.save!
+      old_options = agents(:bob_trigger_agent).options
+      agent.check
+      old_options['rules'].merge! agent.options['configure_options']['rules']
+      new_options = old_options
+      expect(agent.control_targets.reload).to all(satisfy { |a| a.options['rules'] && a.options['rules']['rule1']['value'] && (a.options['rules']['rule1']['value'] == 'changed') })
+      expect(agents(:bob_trigger_agent).reload.options).to eq(new_options)
+    end
+    it "should replace configured target's nested array when 'configure_options_nested_array_update_mode' is set to 'replace'" do
+      agent.control_targets << agents(:bob_trigger_agent)
+      agent.options['action'] = 'configure'
+      agent.options['configure_options_nested_array_update_mode'] = 'replace'
+      agent.options['configure_options'] = { 
+          rules: {
+            rule1:
+              {
+                  type: "!regex",
+                  value: "changed",
+                  path: "text"
+                }
+            }
+        }
+      agent.save!
+      old_options = agents(:bob_trigger_agent).options
+      agent.check
+      old_options['rules'] = agent.options['configure_options']['rules']
+      new_options = old_options
+      expect(agent.control_targets.reload).to all(satisfy { |a| a.options['rules'] && a.options['rules']['rule1']['value'] && (a.options['rules']['rule1']['value'] == 'changed') })
+      expect(agents(:bob_trigger_agent).reload.options).to eq(new_options)
     end
   end
 end


### PR DESCRIPTION
Increase accessibility of Trigger agent options by using a Hash instead of an Array. Includes a patch to facilitate migration to the new rules format. The deprecated array format is still works. When the agent is next updated(i.e. saving from edit page) rules in the array format will be converted into the hash format. Tests/fixtures were updated that specified rules using array specific logic.

Inspired by this conversation https://github.com/cantino/huginn/pull/1139#discussion_r44586348

Basically, it was really inconvenient to update options inside an object(rule) that was also inside an array(rules). So I replaced that array(rules) with a hash(rules) and gave each object(rule) a name(hash['recipe_name']). 
