### PR TITLE
Add toggle action to Commander Agent

### DIFF
--- a/app/concerns/agent_controller_concern.rb
+++ b/app/concerns/agent_controller_concern.rb
@@ -27,7 +27,7 @@ module AgentControllerConcern
       if options['configure_options'].nil? || options['configure_options'].keys.length == 0
         errors.add(:base, "The 'configure_options' options hash must be supplied when using the 'configure' action.")
       end
-    when 'enable', 'disable'
+    when 'enable', 'disable', 'toggle'
     when nil
       errors.add(:base, "action must be specified")
     when /\{[%{]/
@@ -67,6 +67,9 @@ module AgentControllerConcern
             target.update!(disabled: true)
             log "Agent '#{target.name}' is disabled"
           end
+        when 'toggle'
+          target.update!(disabled: !target.disabled?)
+          log "Agent '#{target.name}' is #{target.disabled? ? 'disabled' : 'enabled'}"
         when 'configure'
           target.update! options: target.options.deep_merge(interpolated['configure_options'])
           log "Agent '#{target.name}' is configured with #{interpolated['configure_options'].inspect}"

--- a/app/models/agents/commander_agent.rb
+++ b/app/models/agents/commander_agent.rb
@@ -17,6 +17,8 @@ module Agents
 
       * `enable`: Target Agents are enabled (if not) when this agent is triggered.
 
+      * `toggle`: Target Agents are enabled (if currently disabled) or disabled (if currently enabled) when this agent is triggered.
+
       * `configure`: Target Agents have their options updated with the contents of `configure_options`.
 
       Here's a tip: you can use Liquid templating to dynamically determine the action type.  For example:


### PR DESCRIPTION
I have added a toggle option to the Commander Agent that enables or disables agents based on their current state.

I needed this in a scenario where I wanted to switch between two agents being active based on the result  of a Change Detector Agent. It felt a bit too clunky to use four Commander Agents to enable/disable the agents, so I added this instead.
