### PR TITLE
Add multi stream support to gap detector

### DIFF
--- a/app/models/agents/gap_detector_agent.rb
+++ b/app/models/agents/gap_detector_agent.rb
@@ -8,6 +8,11 @@ module Agents
       The `value_path` value is a [JSONPath](http://goessner.net/articles/JsonPath/) to a value of interest. If either
       this value is empty, or no Events are received, during `window_duration_in_days`, an Event will be created with
       a payload of `message`.
+
+      The `stream_path` value is a [JSONPath](http://goessner.net/articles/JsonPath/) to a value in the event that will
+      be used to as a stream differentiator.  If `stream_path` is present and set to "my_stream". Then for each event that
+      has a "my_stream" in the payload, this agent will watch for a gap in the stream for each value of my_stream
+      that has been seen.
     MD
 
     event_description <<-MD
@@ -42,12 +47,16 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.sort_by(&:created_at).each do |event|
-        memory['newest_event_created_at'] ||= 0
-
         if !interpolated['value_path'].present? || Utils.value_at(event.payload, interpolated['value_path']).present?
-          if event.created_at.to_i > memory['newest_event_created_at']
-            memory['newest_event_created_at'] = event.created_at.to_i
-            memory.delete('alerted_at')
+          stream = nil
+          if stream_path
+            stream = Utils.value_at(event.payload, stream_path)
+            next unless stream
+          end
+          storage = event_storage(stream)
+          if event.created_at.to_i > storage.newest_event_created_at
+            storage.newest_event_created_at = event.created_at.to_i
+            storage.clear_alerted_at
           end
         end
       end
@@ -55,13 +64,72 @@ module Agents
 
     def check
       window = interpolated['window_duration_in_days'].to_f.days.ago
-      if memory['newest_event_created_at'].present? && Time.at(memory['newest_event_created_at']) < window
-        unless memory['alerted_at']
-          memory['alerted_at'] = Time.now.to_i
-          create_event payload: { message: interpolated['message'],
-                                  gap_started_at: memory['newest_event_created_at'] }
+      if stream_path
+        memory.each_key do |stream|
+          next unless memory[stream].is_a? Hash
+          next unless memory[stream].has_key? 'newest_event_created_at'
+          check_stream(window, stream)
+        end
+      else
+        check_stream(window)
+      end
+    end
+
+    private
+
+    def check_stream(window, stream=nil)
+      storage = event_storage(stream)
+      if storage.newest_event_created_at? && Time.at(storage.newest_event_created_at) < window
+        unless storage.alerted_at
+          storage.alerted_at = Time.now.to_i
+          event_payload = { message: interpolated['message'],
+                            gap_started_at: storage.newest_event_created_at }
+          event_payload.merge!({ stream: stream }) if stream_path
+          create_event payload: event_payload
         end
       end
     end
+
+    def event_storage(stream)
+      return EventStorage.new(memory) unless stream_path
+      memory[stream] = {} unless memory.has_key?(stream)
+      EventStorage.new(memory[stream])
+    end
+
+    def stream_path
+      return @stream_path unless @stream_path.nil?
+      @stream_path = interpolated['stream_path'] || false
+    end
+
+    class EventStorage
+      def initialize(hash)
+        @memory = hash
+      end
+
+      def newest_event_created_at?
+        @memory['newest_event_created_at'].present?
+      end
+
+      def newest_event_created_at
+        @memory['newest_event_created_at'] || 0
+      end
+
+      def newest_event_created_at=(value)
+        @memory['newest_event_created_at'] = value
+      end
+
+      def alerted_at
+        @memory['alerted_at']
+      end
+
+      def alerted_at=(value)
+        @memory['alerted_at'] = value
+      end
+
+      def clear_alerted_at
+        @memory.delete('alerted_at')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Add the ability of the gap detector to monitor multiple streams based on a parameter in the event payload.
