### PR TITLE
show hover tooltips on the peak graph & set graph minimum to automatic

### DIFF
--- a/app/assets/javascripts/graphing.js.coffee
+++ b/app/assets/javascripts/graphing.js.coffee
@@ -9,6 +9,7 @@ window.renderGraph = ($chart, data, peaks, name) ->
     element: $chart.find(".chart").get(0)
     width: 700
     height: 240
+    min: 'auto'
     series: [
       data: data
       name: name
@@ -28,6 +29,9 @@ window.renderGraph = ($chart, data, peaks, name) ->
     orientation: 'left'
     tickFormat: Rickshaw.Fixtures.Number.formatKMBT
     element: $chart.find(".y-axis").get(0)
+
+  hover_detail = new Rickshaw.Graph.HoverDetail
+    graph: graph
 
   graph.onUpdate ->
     mean = d3.mean data, (i) -> i.y

--- a/app/assets/stylesheets/agent_views/peak_detector_agent/show.css.scss
+++ b/app/assets/stylesheets/agent_views/peak_detector_agent/show.css.scss
@@ -29,7 +29,6 @@
       .chart {
         position: relative;
         left: 40px;
-        overflow: hidden;
         width: 700px;
       }
 


### PR DESCRIPTION
The rickshaw graphing library has a default minimum value of 0, anything that might have very small fluctuations but at larger numbers couldn't be seen. Rickshaw now shows an automatic minimum value of whatever the lowest was in the set. Also turned on tooltips to show the values.
