### PR TITLE
A ?user= param for admin users to see and edit other users' agents

### DIFF
--- a/app/controllers/agents/dry_runs_controller.rb
+++ b/app/controllers/agents/dry_runs_controller.rb
@@ -7,7 +7,7 @@ module Agents
         if current_user.admin?
           @agent_user = User.find_by!(username: params[:user])
         else
-          render(text: 'error', status: 403) and return
+          render(text: 'unauthorized', status: 403) and return
         end
       else
         @agent_user = current_user
@@ -28,7 +28,7 @@ module Agents
         if current_user.admin?
           @agent_user = User.find_by!(username: params[:user])
         else
-          render(text: 'error', status: 403) and return
+          render(text: 'unauthorized', status: 403) and return
         end
       else
         @agent_user = current_user

--- a/app/controllers/agents/dry_runs_controller.rb
+++ b/app/controllers/agents/dry_runs_controller.rb
@@ -2,17 +2,9 @@ module Agents
   class DryRunsController < ApplicationController
     include ActionView::Helpers::TextHelper
 
-    def index
-      if params[:user]
-        if current_user.admin?
-          @agent_user = User.find_by!(username: params[:user])
-        else
-          render(text: 'unauthorized', status: 403) and return
-        end
-      else
-        @agent_user = current_user
-      end
+    before_action :set_agent_user
 
+    def index
       @events = if params[:agent_id]
                   @agent_user.agents.find_by(id: params[:agent_id]).received_events.limit(5)
                 elsif params[:source_ids]
@@ -24,16 +16,6 @@ module Agents
     end
 
     def create
-      if params[:user]
-        if current_user.admin?
-          @agent_user = User.find_by!(username: params[:user])
-        else
-          render(text: 'unauthorized', status: 403) and return
-        end
-      else
-        @agent_user = current_user
-      end
-
       attrs = params[:agent] || {}
       if agent = @agent_user.agents.find_by(id: params[:agent_id])
         # POST /agents/:id/dry_run
@@ -66,6 +48,19 @@ module Agents
       end
 
       render layout: false
+    end
+
+    private
+    def set_agent_user
+      if params[:user]
+        if current_user.admin?
+          @agent_user = User.find_by!(username: params[:user])
+        else
+          render(text: 'unauthorized', status: 403) and return
+        end
+      else
+        @agent_user = current_user
+      end
     end
   end
 end

--- a/app/controllers/agents/dry_runs_controller.rb
+++ b/app/controllers/agents/dry_runs_controller.rb
@@ -3,10 +3,20 @@ module Agents
     include ActionView::Helpers::TextHelper
 
     def index
+      if params[:user]
+        if current_user.admin?
+          @agent_user = User.find_by!(username: params[:user])
+        else
+          render(text: 'error', status: 403) and return
+        end
+      else
+        @agent_user = current_user
+      end
+
       @events = if params[:agent_id]
-                  current_user.agents.find_by(id: params[:agent_id]).received_events.limit(5)
+                  @agent_user.agents.find_by(id: params[:agent_id]).received_events.limit(5)
                 elsif params[:source_ids]
-                  Event.where(agent_id: current_user.agents.where(id: params[:source_ids]).pluck(:id))
+                  Event.where(agent_id: @agent_user.agents.where(id: params[:source_ids]).pluck(:id))
                        .order("id DESC").limit(5)
                 end
 
@@ -14,26 +24,36 @@ module Agents
     end
 
     def create
+      if params[:user]
+        if current_user.admin?
+          @agent_user = User.find_by!(username: params[:user])
+        else
+          render(text: 'error', status: 403) and return
+        end
+      else
+        @agent_user = current_user
+      end
+
       attrs = params[:agent] || {}
-      if agent = current_user.agents.find_by(id: params[:agent_id])
+      if agent = @agent_user.agents.find_by(id: params[:agent_id])
         # POST /agents/:id/dry_run
         if attrs.present?
           attrs.merge!(memory: agent.memory)
           type = agent.type
-          agent = Agent.build_for_type(type, current_user, attrs)
+          agent = Agent.build_for_type(type, @agent_user, attrs)
         end
       else
         # POST /agents/dry_run
         type = attrs.delete(:type)
-        agent = Agent.build_for_type(type, current_user, attrs)
+        agent = Agent.build_for_type(type, @agent_user, attrs)
       end
       agent.name ||= '(Untitled)'
 
       if agent.valid?
         if event_payload = params[:event]
-          dummy_agent = Agent.build_for_type('ManualEventAgent', current_user, name: 'Dry-Runner')
+          dummy_agent = Agent.build_for_type('ManualEventAgent', @agent_user, name: 'Dry-Runner')
           dummy_agent.readonly!
-          event = dummy_agent.events.build(user: current_user, payload: event_payload)
+          event = dummy_agent.events.build(user: @agent_user, payload: event_payload)
         end
 
         @results = agent.dry_run!(event)

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -260,7 +260,7 @@ class AgentsController < ApplicationController
       if current_user.admin?
         @agent_user = User.find_by!(username: params[:user])
       else
-        render(text: 'error', status: 403) and return
+        render(text: 'unauthorized', status: 403) and return
       end
     else
       @agent_user = current_user

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -9,9 +9,11 @@ class AgentsController < ApplicationController
     set_table_sort sorts: %w[name created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
 
     @agents = @current_agents.preload(:scenarios, :controllers).reorder(table_sort).page(params[:page])
+    @shared_agents = Agent.shared - @agents
 
     if show_only_enabled_agents?
       @agents = @agents.where(disabled: false)
+      @shared_agents = @shared_agents.where(disabled: false)
     end
 
     respond_to do |format|

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -20,6 +20,24 @@ class AgentsController < ApplicationController
     end
   end
 
+  def all
+    authenticate_admin!
+
+    set_table_sort sorts: %w[name users.username created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
+
+    # @agent_user = current_user
+    @agents = Agent.all.preload(:scenarios, :controllers).includes(:user).reorder(table_sort).page(params[:page])
+
+    if show_only_enabled_agents?
+      @agents = @agents.where(disabled: false)
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @agents }
+    end
+  end
+
   def toggle_visibility
     if show_only_enabled_agents?
       mark_all_agents_viewable

--- a/app/controllers/concerns/sortable_table.rb
+++ b/app/controllers/concerns/sortable_table.rb
@@ -19,7 +19,7 @@ module SortableTable
     default = sort_options[:default] || { valid_sorts.first.to_sym => :desc }
 
     if params[:sort].present?
-      attribute, direction = params[:sort].downcase.split('.')
+      attribute, _, direction = params[:sort].downcase.rpartition('.')
       unless valid_sorts.include?(attribute)
         attribute, direction = default.to_a.first
       end
@@ -29,8 +29,14 @@ module SortableTable
 
     direction = direction.to_s == 'desc' ? 'desc' : 'asc'
 
+    if attribute.to_s.include?(".")
+      ordering = "#{attribute} #{direction.upcase}"
+    else
+      ordering = { attribute.to_sym => direction.to_sym }
+    end
+
     @table_sort_info = {
-      order: { attribute.to_sym => direction.to_sym },
+      order: ordering,
       attribute: attribute,
       direction: direction
     }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
       if current_user.admin?
         @agent_user = User.find_by!(username: params[:user])
       else
-        render(text: 'error', status: 403) and return
+        render(text: 'unauthorized', status: 403) and return
       end
     else
       @agent_user = current_user

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -14,6 +14,10 @@ class LogsController < ApplicationController
   protected
 
   def load_agent
-    @agent = current_user.agents.find(params[:agent_id])
+    if current_user.admin?
+      @agent = Agent.find(params[:agent_id])
+    else
+      @agent = current_user.agents.find(params[:agent_id])
+    end
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -24,17 +24,17 @@ class Agent < ActiveRecord::Base
 
   EVENT_RETENTION_SCHEDULES = [["Forever", 0], ['1 hour', 1.hour], ['6 hours', 6.hours], ["1 day", 1.day], *([2, 3, 4, 5, 7, 14, 21, 30, 45, 90, 180, 365].map {|n| ["#{n} days", n.days] })]
 
-  attr_accessible :options, :memory, :name, :type, :schedule, :controller_ids, :control_target_ids, :disabled, :source_ids, :receiver_ids, :scenario_ids, :keep_events_for, :propagate_immediately, :drop_pending_events
+  attr_accessible :options, :memory, :name, :type, :schedule, :controller_ids, :control_target_ids, :disabled, :shared, :source_ids, :receiver_ids, :scenario_ids, :keep_events_for, :propagate_immediately, :drop_pending_events
 
   json_serialize :options, :memory
 
   validates_presence_of :name, :user
   validates_inclusion_of :keep_events_for, :in => EVENT_RETENTION_SCHEDULES.map(&:last)
-  validates :sources, owned_by: :user_id
-  validates :receivers, owned_by: :user_id
   validates :controllers, owned_by: :user_id
   validates :control_targets, owned_by: :user_id
   validates :scenarios, owned_by: :user_id
+  validate :validate_sources
+  validate :validate_receivers
   validate :validate_schedule
   validate :validate_options
 
@@ -64,6 +64,7 @@ class Agent < ActiveRecord::Base
 
   scope :active,   -> { where(disabled: false, deactivated: false) }
   scope :inactive, -> { where(['disabled = ? OR deactivated = ?', true, true]) }
+  scope :shared, -> { where(shared: true) }
 
   scope :of_type, lambda { |type|
     type = case type
@@ -268,6 +269,21 @@ class Agent < ActiveRecord::Base
   
   private
   
+  def validate_sources
+    return if sources.all? do |s|
+      s.shared || (s.user_id == user_id)
+    end
+    errors.add(:sources,"must be owned by you or shared")
+  end
+
+  def validate_receivers
+    return if shared
+    return if receivers.all? do |r|
+      user_id == r.user_id
+    end
+    errors.add(:receivers,"must be owned by you or receive from a shared agent")
+  end
+
   def validate_schedule
     unless cannot_be_scheduled?
       errors.add(:schedule, "is not a valid schedule") unless SCHEDULES.include?(schedule.to_s)

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -24,7 +24,7 @@
               <td><%= link_to user.username, edit_admin_user_path(user) %></td>
               <td><%= user.email %></td>
               <td><%= user_account_state(user) %></td>
-              <td><%= user.agents.active.count %></td>
+              <td><%= link_to user.agents.active.count, agents_path(user: user.username) %></td>
               <td><%= user.agents.inactive.count %></td>
               <td title='<%= user.created_at %>'><%= time_ago_in_words user.created_at %> ago</td>
               <td>

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -25,7 +25,7 @@
           <% if @agent.new_record? %>
             <div class="form-group type-select">
               <%= f.label :type %>
-              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [type.name.gsub(/^.*::/, '').underscore.humanize.titleize, type, {title: h(Agent.build_for_type(type.name,current_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, :class => 'form-control' %>
+              <%= f.select :type, options_for_select([['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [type.name.gsub(/^.*::/, '').underscore.humanize.titleize, type, {title: h(Agent.build_for_type(type.name,@agent_user,{}).html_description.lines.first.strip)}] }, @agent.type), {}, :class => 'form-control' %>
             </div>
           <% end %>
         </div>
@@ -66,7 +66,7 @@
                 <div class="form-group">
                   <%= f.label :control_targets %>
                   <%= f.select(:control_target_ids,
-                               options_for_select(current_user.agents.map {|s| [s.name, s.id] },
+                               options_for_select(@current_agents.map {|s| [s.name, s.id] },
                                                   @agent.control_target_ids),
                                {}, { multiple: true, size: 5, class: 'select2-linked-tags form-control', data: {url_prefix: '/agents'}}) %>
                 </div>
@@ -85,7 +85,7 @@
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (current_user.agents - [@agent]).find_all { |a| a.can_create_events? } %>
+                <% eventSources = (@current_agents - [@agent]).find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
                              options_for_select(eventSources.map {|s| [s.name, s.id] },
                                                 @agent.source_ids),
@@ -103,7 +103,7 @@
               <%= f.label :receivers %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="Events created by this Agent will be sent to the selected Agents."></span>
               <div class="event-related-region">
-                <% eventTargets = (current_user.agents - [@agent]).find_all { |a| a.can_receive_events? } %>
+                <% eventTargets = (@current_agents - [@agent]).find_all { |a| a.can_receive_events? } %>
                 <%= f.select(:receiver_ids,
                              options_for_select(eventTargets.map {|s| [s.name, s.id] },
                                                 @agent.receiver_ids),
@@ -112,12 +112,12 @@
               </div>
             </div>
 
-            <% if current_user.scenario_count > 0 %>
+            <% if @agent_user.scenario_count > 0 %>
               <div class="form-group">
                 <%= f.label :scenarios %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="Use Scenarios to group sets of Agents, both for organization, and to make them easy to export and share."></span>
                 <%= f.select(:scenario_ids,
-                             options_for_select(current_user.scenarios.pluck(:name, :id), @agent.scenario_ids),
+                             options_for_select(@agent_user.scenarios.pluck(:name, :id), @agent.scenario_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/scenarios'} }) %>
               </div>
             <% end %>

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -85,7 +85,7 @@
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (@current_agents + Agent.shared - [@agent]).find_all { |a| a.can_create_events? } %>
+                <% eventSources = (@current_agents + Agent.shared - [@agent]).uniq.find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
                              options_for_select(eventSources.map {|s| [s.name, s.id] },
                                                 @agent.source_ids),

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -85,7 +85,7 @@
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (@current_agents - [@agent]).find_all { |a| a.can_create_events? } %>
+                <% eventSources = (@current_agents + Agent.shared - [@agent]).find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
                              options_for_select(eventSources.map {|s| [s.name, s.id] },
                                                 @agent.source_ids),
@@ -108,6 +108,13 @@
                              options_for_select(eventTargets.map {|s| [s.name, s.id] },
                                                 @agent.receiver_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+
+                <%= f.label :shared, :class => 'shared-agent' do %>Shared Agent
+                  <%= f.check_box :shared %>
+                  &nbsp;
+                  <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, an Agent's events are only accessible to agents owned by the same user. Marking it shared allows this agent's events to be received by an Agent created by any user."></span>
+                <% end %>
+
                 <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
               </div>
             </div>

--- a/app/views/agents/_oauth_dropdown.html.erb
+++ b/app/views/agents/_oauth_dropdown.html.erb
@@ -1,6 +1,6 @@
 <% if agent.try(:oauthable?) %>
   <div class="form-group type-select">
     <%= label_tag :service %>
-    <%= select_tag 'agent[service_id]', options_for_select(agent.valid_services_for(current_user).collect { |s| [service_label_text(s), s.id] }, agent.service_id), class: 'form-control' %>
+    <%= select_tag 'agent[service_id]', options_for_select(agent.valid_services_for(@agent_user).collect { |s| [service_label_text(s), s.id] }, agent.service_id), class: 'form-control' %>
   </div>
 <% end %>

--- a/app/views/agents/_table.html.erb
+++ b/app/views/agents/_table.html.erb
@@ -3,6 +3,11 @@
     <tr>
       <th></th>
       <th><%= sortable_column 'name', 'asc' %></th>
+
+      <% if defined?(locals) != nil && locals[:show_user] == true %>
+      <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
+      <% end %>
+
       <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
       <th>Schedule</th>
       <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
@@ -28,6 +33,15 @@
             </span>
           <% end %>
         </td>
+
+        <% if defined?(locals) != nil && locals[:show_user] == true %>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <%= link_to agent.user.username, admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
+          <br/>
+        </td>
+        <% end %>
+
+
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
           <%= time_ago_in_words agent.created_at %>
         </td>

--- a/app/views/agents/_table.html.erb
+++ b/app/views/agents/_table.html.erb
@@ -4,7 +4,7 @@
       <th></th>
       <th><%= sortable_column 'name', 'asc' %></th>
 
-      <% if defined?(locals) != nil && locals[:show_user] == true %>
+      <% if defined?(show_user) != nil && show_user == true %>
       <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
       <% end %>
 
@@ -18,10 +18,10 @@
       <th></th>
     </tr>
 
-    <% @agents.each do |agent| %>
+    <% agents.each do |agent| %>
       <tr>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-          <%= agent_type_icon(agent, @agents) %>
+          <%= agent_type_icon(agent, agents) %>
         </td>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
           <%= link_to agent.name, agent_path(agent, return: (defined?(return_to) && return_to) || request.path) %>
@@ -34,7 +34,7 @@
           <% end %>
         </td>
 
-        <% if defined?(locals) != nil && locals[:show_user] == true %>
+        <% if defined?(show_user) != nil && show_user == true %>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
           <%= link_to agent.user.username, admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
           <br/>
@@ -94,4 +94,6 @@
   </table>
 </div>
 
-<%= paginate @agents, :theme => 'twitter-bootstrap-3' %>
+<% if defined? agents.preload %>
+<%= paginate agents, :theme => 'twitter-bootstrap-3' %>
+<% end %>

--- a/app/views/agents/agent_views/data_output_agent/_show.html.erb
+++ b/app/views/agents/agent_views/data_output_agent/_show.html.erb
@@ -5,7 +5,7 @@
 
 <ul>
   <% @agent.options['secrets'].each do |secret| %>
-    <% url = lambda { |format| web_requests_url(:agent_id => @agent.id, :user_id => current_user.id, :secret => secret, :format => format) } %>
+    <% url = lambda { |format| web_requests_url(:agent_id => @agent.id, :user_id => @agent_user.id, :secret => secret, :format => format) } %>
     <li><%= link_to url.call(:json), url.call(:json), :target => :blank %></li>
     <li><%= link_to url.call(:xml), url.call(:xml), :target => :blank %></li>
   <% end %>

--- a/app/views/agents/agent_views/webhook_agent/_show.html.erb
+++ b/app/views/agents/agent_views/webhook_agent/_show.html.erb
@@ -1,3 +1,3 @@
 <p>
-  Send WebHooks (POST requests) to this Agent at <%= link_to web_requests_url(:agent_id => @agent.id, :user_id => current_user.id, :secret => @agent.options['secret']), web_requests_url(:agent_id => @agent.id, :user_id => current_user.id, :secret => @agent.options['secret']), :target => :blank %>
+  Send WebHooks (POST requests) to this Agent at <%= link_to web_requests_url(:agent_id => @agent.id, :user_id => @agent_user.id, :secret => @agent.options['secret']), web_requests_url(:agent_id => @agent.id, :user_id => @agent_user.id, :secret => @agent.options['secret']), :target => :blank %>
 </p>

--- a/app/views/agents/all.html.erb
+++ b/app/views/agents/all.html.erb
@@ -1,0 +1,13 @@
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class="page-header">
+        <h2>All Agents</h2>
+      </div>
+
+      <%= render 'agents/table', locals: {show_user: true} %>
+
+      <br/>
+    </div>
+  </div>
+</div>

--- a/app/views/agents/all.html.erb
+++ b/app/views/agents/all.html.erb
@@ -5,7 +5,7 @@
         <h2>All Agents</h2>
       </div>
 
-      <%= render 'agents/table', locals: {show_user: true} %>
+      <%= render partial: 'agents/table', locals: {agents: @agents, show_user: true} %>
 
       <br/>
     </div>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -5,7 +5,7 @@
         <h2><%= current_user == @agent_user ? 'Your Agents' : "#{@agent_user.username}’s Agents" %></h2>
       </div>
 
-      <%= render 'agents/table' %>
+      <%= render partial: 'agents/table', locals: {agents: @agents} %>
 
       <br/>
 
@@ -15,6 +15,11 @@
         <%= link_to icon_tag('glyphicon-random') + ' View diagram', diagram_path, class: "btn btn-default" %>
         <%= link_to icon_tag('glyphicon-adjust') + toggle_disabled_text, toggle_visibility_agents_path, method: :put, class: "btn btn-default visibility-enabler" %>
       </div>
+
+      <h3>Shared Agents</h3>
+
+      <%= render partial: 'agents/table', locals: {agents: @shared_agents} %>
+
     </div>
   </div>
 </div>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -2,7 +2,7 @@
   <div class='row'>
     <div class='col-md-12'>
       <div class="page-header">
-        <h2>Your Agents</h2>
+        <h2><%= current_user == @agent_user ? 'Your Agents' : "#{@agent_user.username}’s Agents" %></h2>
       </div>
 
       <%= render 'agents/table' %>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -64,6 +64,13 @@
           <div class="tab-pane <%= agent_show_view(@agent).present? ? "" : "active" %>" id="details">
             <h2><%= @agent.name %> Details</h2>
 
+            <% if current_user != @agent_user %>
+            <p>
+              <b>User:</b>
+              <%= @agent.user.username.titleize %>
+            </p>
+            <% end %>
+
             <p>
               <b>Type:</b>
               <%= @agent.short_type.titleize %>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -137,6 +137,11 @@
               </p>
             <% end %>
 
+            <p>
+              <b>Shared:</b>
+              <%= yes_no @agent.shared %>
+            <p>
+
             <% if @agent.can_create_events? %>
               <p>
                 <b>Event receivers:</b>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -12,17 +12,17 @@
   
   <% if user_signed_in? %>
     <ul class='nav navbar-nav'>
-      <%= nav_link "Agents", agents_path do %>
+      <%= nav_link "Agents", agents_path(user: nil) do %>
         <ul class='dropdown-menu' role='menu'>
-          <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path %>
-          <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path, method: 'post' %>
-          <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path %>
+          <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path(user: nil) %>
+          <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path(user: nil), method: 'post' %>
+          <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path(user: nil) %>
         </ul>
       <% end %>
-      <%= nav_link "Scenarios", scenarios_path %>
-      <%= nav_link "Events", events_path %>
-      <%= nav_link "Credentials", user_credentials_path %>
-      <%= nav_link "Services", services_path %>
+      <%= nav_link "Scenarios", scenarios_path(user: nil) %>
+      <%= nav_link "Events", events_path(user: nil) %>
+      <%= nav_link "Credentials", user_credentials_path(user: nil) %>
+      <%= nav_link "Services", services_path(user: nil) %>
     </ul>
   <% end %>
   

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -17,6 +17,9 @@
           <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path(user: nil) %>
           <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path(user: nil), method: 'post' %>
           <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path(user: nil) %>
+          <% if current_user.admin? %>
+            <%= nav_link "Admin: " + " All Agents", all_agents_path %>
+          <% end %>
         </ul>
       <% end %>
       <%= nav_link "Scenarios", scenarios_path(user: nil) %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -10,7 +10,7 @@
         <blockquote><%= markdown(@scenario.description) %></blockquote>
       <% end %>
 
-      <%= render 'agents/table', :return_to => scenario_path(@scenario) %>
+      <%= render partial: 'agents/table', locals: {agents: @agents}, :return_to => scenario_path(@scenario) %>
 
       <br/>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Huginn::Application.routes.draw do
     end
 
     collection do
+      get :all
       put :toggle_visibility
       post :propagate
       get :type_details

--- a/db/migrate/20160825172604_add_shared_to_agents.rb
+++ b/db/migrate/20160825172604_add_shared_to_agents.rb
@@ -1,0 +1,9 @@
+class AddSharedToAgents < ActiveRecord::Migration
+  class Agents < ActiveRecord::Base
+  end
+
+  def change
+    add_column :agents, :shared, :boolean, :default => false
+    add_index :agents, [:shared]
+  end
+end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -24,6 +24,21 @@ describe AgentsController do
       get :index
       expect(assigns(:agents).map(&:disabled).uniq).to eq([false])
     end
+
+    it "should allow admin user to see another user's Agents" do
+      sign_in users(:jane)
+      get :index, :user => "bob"
+      expect(assigns(:agents).all? {|i| expect(i.user).to eq(users(:bob)) }).to be_truthy
+      expect(assigns(:agents).count).to eq(8)
+    end
+
+    it "should not allow non-admin user to see another user's Agents" do
+      sign_in users(:bob)
+      get :index, :user => "jane"
+      expect(response).to be_forbidden
+      expect(response.response_code).to eq(403)
+      expect(response.body).to eq("unauthorized")
+    end
   end
 
   describe "POST handle_details_post" do

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -41,6 +41,10 @@ describe AgentsController do
     end
   end
 
+  describe "GET all" do
+    pending("it returns all Agents if the current user is an admin")
+  end
+
   describe "POST handle_details_post" do
     it "passes control to handle_details_post on the agent" do
       sign_in users(:bob)


### PR DESCRIPTION
This is a first pass at implementing the feature described in #1387 

From the user management index, a link to the agents view with `?user=bob` to display bob's agents. The admin can then see/edit/create agents on that user's behalf.

Most updates are in agents_controller.rb to replace references to `current_user` with `@agent_user` which gets set in a `before_action`

Test coverage is not complete yet, but wanted to solicit feedback on this approach.
