### PR TITLE
An /agents/all view for admins

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -18,6 +18,23 @@ class AgentsController < ApplicationController
     end
   end
 
+  def all
+    authenticate_admin!
+
+    set_table_sort sorts: %w[name users.username created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
+
+    @agents = Agent.all.preload(:scenarios, :controllers).includes(:user).reorder(table_sort).page(params[:page])
+
+    if show_only_enabled_agents?
+      @agents = @agents.where(disabled: false)
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @agents }
+    end
+  end
+
   def toggle_visibility
     if show_only_enabled_agents?
       mark_all_agents_viewable

--- a/app/controllers/concerns/sortable_table.rb
+++ b/app/controllers/concerns/sortable_table.rb
@@ -19,7 +19,7 @@ module SortableTable
     default = sort_options[:default] || { valid_sorts.first.to_sym => :desc }
 
     if params[:sort].present?
-      attribute, direction = params[:sort].downcase.split('.')
+      attribute, _, direction = params[:sort].downcase.rpartition('.')
       unless valid_sorts.include?(attribute)
         attribute, direction = default.to_a.first
       end
@@ -29,8 +29,14 @@ module SortableTable
 
     direction = direction.to_s == 'desc' ? 'desc' : 'asc'
 
+    if attribute.to_s.include?(".")
+      ordering = "#{attribute} #{direction.upcase}"
+    else
+      ordering = { attribute.to_sym => direction.to_sym }
+    end
+
     @table_sort_info = {
-      order: { attribute.to_sym => direction.to_sym },
+      order: ordering,
       attribute: attribute,
       direction: direction
     }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,11 @@ class EventsController < ApplicationController
 
   def index
     if params[:agent_id]
-      @agent = current_user.agents.find(params[:agent_id])
+      if current_user.admin?
+        @agent = Agent.find(params[:agent_id])
+      else
+        @agent = current_user.agents.find(params[:agent_id])
+      end
       @events = @agent.events.page(params[:page])
     else
       @events = current_user.events.preload(:agent).page(params[:page])
@@ -41,6 +45,10 @@ class EventsController < ApplicationController
   private
 
   def load_event
-    @event = current_user.events.find(params[:id])
+    if current_user.admin?
+      @event = Event.find(params[:id])
+    else
+      @event = current_user.events.find(params[:id])
+    end
   end
 end

--- a/app/views/agents/_shared_table.html.erb
+++ b/app/views/agents/_shared_table.html.erb
@@ -1,0 +1,103 @@
+<div class='table-responsive'>
+  <table class='table table-striped'>
+    <tr>
+      <th></th>
+      <th><%= sortable_column 'name', 'asc' %></th>
+      <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
+      <th>Schedule</th>
+      <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
+      <th><%= sortable_column 'last_event_at', name: 'Last Event Out' %></th>
+      <th><%= sortable_column 'last_receive_at', name: 'Last Event In' %></th>
+      <th>Events Created</th>
+      <th>Working?</th>
+      <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
+      <th></th>
+    </tr>
+
+    <% agents.each do |agent| %>
+      <tr>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <%= agent_type_icon(agent, agents) %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if current_user == agent.user %>
+          <%= link_to agent.name, agent_path(agent, return: (defined?(return_to) && return_to) || request.path) %>
+          <% else %>
+          <span><%= agent.name %></span>
+          <% end %>
+          <br/>
+          <span class='text-muted'><%= agent.short_type.titleize %></span>
+          <% if current_user == agent.user %>
+          <% if agent.scenarios.present? %>
+            <span>
+              <%= scenario_links(agent) %>
+            </span>
+          <% end %>
+          <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <%= time_ago_in_words agent.created_at %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if agent.can_be_scheduled? %>
+            <%= agent_schedule(agent, ',<br/>') %>
+          <% else %>
+            <span class='not-applicable'></span>
+          <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if agent.can_be_scheduled? %>
+            <%= agent.last_check_at ? time_ago_in_words(agent.last_check_at) + " ago" : "never" %>
+          <% else %>
+            <span class='not-applicable'></span>
+          <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if agent.can_create_events? %>
+            <%= agent.last_event_at ? time_ago_in_words(agent.last_event_at) + " ago" : "never" %>
+          <% else %>
+            <span class='not-applicable'></span>
+          <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if agent.can_receive_events? %>
+            <%= agent.last_receive_at ? time_ago_in_words(agent.last_receive_at) + " ago" : "never" %>
+          <% else %>
+            <span class='not-applicable'></span>
+          <% end %>
+        </td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if agent.can_create_events? %>
+            <%= link_to(agent.events_count || 0, agent_events_path(agent, return: (defined?(return_to) && return_to) || request.path)) %>
+          <% else %>
+            <span class='not-applicable'></span>
+          <% end %>
+        </td>
+        <td><%= working(agent) %></td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if current_user == agent.user %>
+            <span><%= agent.user.username %></span>
+          <% else %>
+            <%= link_to agent.user.username, edit_admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
+          <% end %>
+        </td>
+        <td>
+          <% if current_user == agent.user %>
+            <div class="btn-group">
+              <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
+              </button>
+              <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
+            </div>
+          <% else %>
+            <%#= link_to 'Become User', switch_user_admin_user_path(agent.user), class: "btn btn-sm btn-default btn-info" %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+</div>
+
+<% if defined? agents.preload %>
+<%= paginate agents, :theme => 'twitter-bootstrap-3' %>
+<% end %>

--- a/app/views/agents/_table.html.erb
+++ b/app/views/agents/_table.html.erb
@@ -3,6 +3,11 @@
     <tr>
       <th></th>
       <th><%= sortable_column 'name', 'asc' %></th>
+
+      <% if defined?(locals) != nil && locals[:show_user] == true %>
+      <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
+      <% end %>
+
       <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
       <th>Schedule</th>
       <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
@@ -28,6 +33,15 @@
             </span>
           <% end %>
         </td>
+
+        <% if defined?(locals) != nil && locals[:show_user] == true %>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <%= link_to agent.user.username, edit_admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
+          <br/>
+        </td>
+        <% end %>
+
+
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
           <%= time_ago_in_words agent.created_at %>
         </td>

--- a/app/views/agents/all.html.erb
+++ b/app/views/agents/all.html.erb
@@ -90,14 +90,14 @@
               </td>
               <td>
                 <% if current_user == agent.user %>
-                <div class="btn-group">
-                  <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                    <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
-                  </button>
-                  <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
-                </div>
+                  <div class="btn-group">
+                    <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                      <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
+                    </button>
+                    <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
+                  </div>
                 <% else %>
-                <% # stub: put a link to "Become User" here %>
+                  <%#= link_to 'Become User', switch_user_admin_user_path(agent.user), class: "btn btn-sm btn-default btn-info" %>
                 <% end %>
               </td>
             </tr>

--- a/app/views/agents/all.html.erb
+++ b/app/views/agents/all.html.erb
@@ -5,110 +5,13 @@
         <h2>All Agents</h2>
       </div>
 
-      <div class='table-responsive'>
-        <table class='table table-striped'>
-          <tr>
-            <th></th>
-            <th><%= sortable_column 'name', 'asc' %></th>
-            <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
-            <th>Schedule</th>
-            <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
-            <th><%= sortable_column 'last_event_at', name: 'Last Event Out' %></th>
-            <th><%= sortable_column 'last_receive_at', name: 'Last Event In' %></th>
-            <th>Events Created</th>
-            <th>Working?</th>
-            <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
-            <th></th>
-          </tr>
-
-          <% @agents.each do |agent| %>
-            <tr>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <%= agent_type_icon(agent, @agents) %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if current_user == agent.user %>
-                <%= link_to agent.name, agent_path(agent, return: (defined?(return_to) && return_to) || request.path) %>
-                <% else %>
-                <span><%= agent.name %></span>
-                <% end %>
-                <br/>
-                <span class='text-muted'><%= agent.short_type.titleize %></span>
-                <% if current_user == agent.user %>
-                <% if agent.scenarios.present? %>
-                  <span>
-                    <%= scenario_links(agent) %>
-                  </span>
-                <% end %>
-                <% end %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <%= time_ago_in_words agent.created_at %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if agent.can_be_scheduled? %>
-                  <%= agent_schedule(agent, ',<br/>') %>
-                <% else %>
-                  <span class='not-applicable'></span>
-                <% end %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if agent.can_be_scheduled? %>
-                  <%= agent.last_check_at ? time_ago_in_words(agent.last_check_at) + " ago" : "never" %>
-                <% else %>
-                  <span class='not-applicable'></span>
-                <% end %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if agent.can_create_events? %>
-                  <%= agent.last_event_at ? time_ago_in_words(agent.last_event_at) + " ago" : "never" %>
-                <% else %>
-                  <span class='not-applicable'></span>
-                <% end %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if agent.can_receive_events? %>
-                  <%= agent.last_receive_at ? time_ago_in_words(agent.last_receive_at) + " ago" : "never" %>
-                <% else %>
-                  <span class='not-applicable'></span>
-                <% end %>
-              </td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if agent.can_create_events? %>
-                  <%= link_to(agent.events_count || 0, agent_events_path(agent, return: (defined?(return_to) && return_to) || request.path)) %>
-                <% else %>
-                  <span class='not-applicable'></span>
-                <% end %>
-              </td>
-              <td><%= working(agent) %></td>
-              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
-                <% if current_user == agent.user %>
-                  <span><%= agent.user.username %></span>
-                <% else %>
-                  <%= link_to agent.user.username, edit_admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
-                <% end %>
-              </td>
-              <td>
-                <% if current_user == agent.user %>
-                  <div class="btn-group">
-                    <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                      <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
-                    </button>
-                    <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
-                  </div>
-                <% else %>
-                  <%#= link_to 'Become User', switch_user_admin_user_path(agent.user), class: "btn btn-sm btn-default btn-info" %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </table>
-      </div>
-
-      <%= paginate @agents, :theme => 'twitter-bootstrap-3' %>
-
+      <%= render partial: 'agents/shared_table', locals: {agents: @agents} %>
 
       <br/>
+
+      <div class="btn-group">
+        <%= link_to 'My Agents', agents_path, class: "btn btn-default" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/agents/all.html.erb
+++ b/app/views/agents/all.html.erb
@@ -1,0 +1,114 @@
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class="page-header">
+        <h2>All Agents</h2>
+      </div>
+
+      <div class='table-responsive'>
+        <table class='table table-striped'>
+          <tr>
+            <th></th>
+            <th><%= sortable_column 'name', 'asc' %></th>
+            <th><%= sortable_column 'created_at', 'desc', name: 'Age' %></th>
+            <th>Schedule</th>
+            <th><%= sortable_column 'last_check_at', name: 'Last Check' %></th>
+            <th><%= sortable_column 'last_event_at', name: 'Last Event Out' %></th>
+            <th><%= sortable_column 'last_receive_at', name: 'Last Event In' %></th>
+            <th>Events Created</th>
+            <th>Working?</th>
+            <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
+            <th></th>
+          </tr>
+
+          <% @agents.each do |agent| %>
+            <tr>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <%= agent_type_icon(agent, @agents) %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if current_user == agent.user %>
+                <%= link_to agent.name, agent_path(agent, return: (defined?(return_to) && return_to) || request.path) %>
+                <% else %>
+                <span><%= agent.name %></span>
+                <% end %>
+                <br/>
+                <span class='text-muted'><%= agent.short_type.titleize %></span>
+                <% if current_user == agent.user %>
+                <% if agent.scenarios.present? %>
+                  <span>
+                    <%= scenario_links(agent) %>
+                  </span>
+                <% end %>
+                <% end %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <%= time_ago_in_words agent.created_at %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if agent.can_be_scheduled? %>
+                  <%= agent_schedule(agent, ',<br/>') %>
+                <% else %>
+                  <span class='not-applicable'></span>
+                <% end %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if agent.can_be_scheduled? %>
+                  <%= agent.last_check_at ? time_ago_in_words(agent.last_check_at) + " ago" : "never" %>
+                <% else %>
+                  <span class='not-applicable'></span>
+                <% end %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if agent.can_create_events? %>
+                  <%= agent.last_event_at ? time_ago_in_words(agent.last_event_at) + " ago" : "never" %>
+                <% else %>
+                  <span class='not-applicable'></span>
+                <% end %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if agent.can_receive_events? %>
+                  <%= agent.last_receive_at ? time_ago_in_words(agent.last_receive_at) + " ago" : "never" %>
+                <% else %>
+                  <span class='not-applicable'></span>
+                <% end %>
+              </td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if agent.can_create_events? %>
+                  <%= link_to(agent.events_count || 0, agent_events_path(agent, return: (defined?(return_to) && return_to) || request.path)) %>
+                <% else %>
+                  <span class='not-applicable'></span>
+                <% end %>
+              </td>
+              <td><%= working(agent) %></td>
+              <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+                <% if current_user == agent.user %>
+                  <span><%= agent.user.username %></span>
+                <% else %>
+                  <%= link_to agent.user.username, edit_admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
+                <% end %>
+              </td>
+              <td>
+                <% if current_user == agent.user %>
+                <div class="btn-group">
+                  <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                    <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
+                  </button>
+                  <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
+                </div>
+                <% else %>
+                <% # stub: put a link to "Become User" here %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+
+      <%= paginate @agents, :theme => 'twitter-bootstrap-3' %>
+
+
+      <br/>
+    </div>
+  </div>
+</div>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -15,6 +15,11 @@
         <%= link_to icon_tag('glyphicon-random') + ' View diagram', diagram_path, class: "btn btn-default" %>
         <%= link_to icon_tag('glyphicon-adjust') + toggle_disabled_text, toggle_visibility_agents_path, method: :put, class: "btn btn-default visibility-enabler" %>
       </div>
+      <% if current_user.admin? %>
+      <div class="btn-group">
+        <%= link_to 'All Agents', all_agents_path, class: "btn btn-default" %>
+      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,7 +6,9 @@
           Your Events
           <% if @agent %>
             from <%= @agent.name %>
+            <% if @agent.user == current_user %>
             <%= render 'agents/mini_action_menu', agent: @agent, return_to: request.path %>
+            <% end %>
           <% end %>
         </h2>
       </div>
@@ -33,8 +35,10 @@
             <td>
               <div class="btn-group btn-group-xs">
                 <%= link_to 'Show', event_path(event, return: request.fullpath), class: "btn btn-default" %>
+                <% if current_user.admin? or current_user == event.user %>
                 <%= link_to 'Re-emit', reemit_event_path(event), method: :post, data: { confirm: 'Are you sure you want to duplicate this event and emit the new one now?' }, class: "btn btn-default" %>
                 <%= link_to 'Delete', event_path(event), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-default" %>
+                <% end %>
               </div>
             </td>
           <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,9 @@
       <div class="page-header">
         <h2>
           Event from <%= @event.agent.name %>
+          <% if @event.agent.user == current_user %>
           <%= render 'agents/mini_action_menu', agent: @event.agent, return_to: event_path(@event) %>
+          <% end %>
         </h2>
       </div>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -14,9 +14,12 @@
     <ul class='nav navbar-nav'>
       <%= nav_link "Agents", agents_path do %>
         <ul class='dropdown-menu' role='menu'>
-          <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path %>
-          <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path, method: 'post' %>
-          <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path %>
+          <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path(user: nil) %>
+          <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path(user: nil), method: 'post' %>
+          <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path(user: nil) %>
+          <% if current_user.admin? %>
+            <%= nav_link "Admin: " + " All Agents", all_agents_path %>
+          <% end %>
         </ul>
       <% end %>
       <%= nav_link "Scenarios", scenarios_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Huginn::Application.routes.draw do
     end
 
     collection do
+      get :all
       put :toggle_visibility
       post :propagate
       get :type_details


### PR DESCRIPTION
A page where admins can view all agents. Part of https://github.com/cantino/huginn/pull/1593

The route is `/agents/all`, this creates `views/agents/_shared_table.html.erb` as a version of `_table.html.erb` with conditionals to not link to pages that only the owner of the agent can see.

Still WIP - sending this for discussion first.

This would work best in conjunction with https://github.com/cantino/huginn/issues/1659 - the table showing agents could then include a "Become User" button to allow the admin to quickly become a user to edit one of that user's agents.
