### PR TITLE
Receive events from "shared" agents created by other users

### DIFF
--- a/app/assets/javascripts/components/core.js.coffee
+++ b/app/assets/javascripts/components/core.js.coffee
@@ -19,7 +19,17 @@ $ ->
   $(".select2-linked-tags").select2(
     width: 'resolve',
     formatSelection: (obj) ->
-      "<a href=\"#{this.element.data('urlPrefix')}/#{obj.id}/edit\" onClick=\"Utils.select2TagClickHandler(event, this)\">#{Utils.escape(obj.text)}</a>"
+      origElement = $(obj.element)
+      if origElement.data('shared')
+        "<span class='label label-default'>#{origElement.data('username')}</span> #{Utils.escape(obj.text)}"
+      else
+        "<a href=\"#{this.element.data('urlPrefix')}/#{obj.id}/edit\" onClick=\"Utils.select2TagClickHandler(event, this)\">#{Utils.escape(obj.text)}</a>"
+    formatResult: (obj) ->
+      origElement = $(obj.element)
+      if origElement.data('shared')
+        "<span class='label label-default'>#{origElement.data('username')} (shared)</span> #{Utils.escape(obj.text)}"
+      else
+        "#{obj.text}"
   )
 
   # Helper for selecting text when clicked

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -131,11 +131,13 @@ class @AgentEditPage
 
   hideEventCreation: ->
     $(".event-related-region .select2-container").hide()
+    $(".event-related-region .shared-agent").hide()
     $(".event-related-region .cannot-create-events").show()
     $(".event-related-region").data("can-create-events", false)
 
   showEventCreation: ->
     $(".event-related-region .select2-container").show()
+    $(".event-related-region .shared-agent").show()
     $(".event-related-region .cannot-create-events").hide()
     $(".event-related-region").data("can-create-events", true)
 

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -318,6 +318,9 @@ $service-colors: (
   color: yellow;
   text-decoration: underline;
 }
+.select2-search-choice span.label {
+  display: inline-block;
+}
 
 .glyphicon-flipped {
   -ms-transform: translateZ(0);

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -7,6 +7,22 @@ class AgentsController < ApplicationController
     set_table_sort sorts: %w[name created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
 
     @agents = current_user.agents.preload(:scenarios, :controllers).reorder(table_sort).page(params[:page])
+    @shared_agents = Agent.shared - @agents
+
+    if show_only_enabled_agents?
+      @agents = @agents.where(disabled: false)
+    end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @agents }
+    end
+  end
+
+  def shared
+    set_table_sort sorts: %w[name users.username created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
+
+    @agents = Agent.shared.preload(:scenarios, :controllers).reorder(table_sort).page(params[:page])
 
     if show_only_enabled_agents?
       @agents = @agents.where(disabled: false)

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -7,7 +7,6 @@ class AgentsController < ApplicationController
     set_table_sort sorts: %w[name created_at last_check_at last_event_at last_receive_at], default: { created_at: :desc }
 
     @agents = current_user.agents.preload(:scenarios, :controllers).reorder(table_sort).page(params[:page])
-    @shared_agents = Agent.shared - @agents
 
     if show_only_enabled_agents?
       @agents = @agents.where(disabled: false)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -24,17 +24,17 @@ class Agent < ActiveRecord::Base
 
   EVENT_RETENTION_SCHEDULES = [["Forever", 0], ['1 hour', 1.hour], ['6 hours', 6.hours], ["1 day", 1.day], *([2, 3, 4, 5, 7, 14, 21, 30, 45, 90, 180, 365].map {|n| ["#{n} days", n.days] })]
 
-  attr_accessible :options, :memory, :name, :type, :schedule, :controller_ids, :control_target_ids, :disabled, :source_ids, :receiver_ids, :scenario_ids, :keep_events_for, :propagate_immediately, :drop_pending_events
+  attr_accessible :options, :memory, :name, :type, :schedule, :controller_ids, :control_target_ids, :disabled, :shared, :source_ids, :receiver_ids, :scenario_ids, :keep_events_for, :propagate_immediately, :drop_pending_events
 
   json_serialize :options, :memory
 
   validates_presence_of :name, :user
   validates_inclusion_of :keep_events_for, :in => EVENT_RETENTION_SCHEDULES.map(&:last)
-  validates :sources, owned_by: :user_id
-  validates :receivers, owned_by: :user_id
   validates :controllers, owned_by: :user_id
   validates :control_targets, owned_by: :user_id
   validates :scenarios, owned_by: :user_id
+  validate :validate_sources
+  validate :validate_receivers
   validate :validate_schedule
   validate :validate_options
 
@@ -64,6 +64,7 @@ class Agent < ActiveRecord::Base
 
   scope :active,   -> { where(disabled: false, deactivated: false) }
   scope :inactive, -> { where(['disabled = ? OR deactivated = ?', true, true]) }
+  scope :shared, -> { where(shared: true) }
 
   scope :of_type, lambda { |type|
     type = case type
@@ -268,6 +269,21 @@ class Agent < ActiveRecord::Base
   
   private
   
+  def validate_sources
+    return if sources.all? do |s|
+      s.shared || (s.user_id == user_id)
+    end
+    errors.add(:sources,"must be owned by you or shared")
+  end
+
+  def validate_receivers
+    return if shared
+    return if receivers.all? do |r|
+      user_id == r.user_id
+    end
+    errors.add(:receivers,"must be owned by you or receive from a shared agent")
+  end
+
   def validate_schedule
     unless cannot_be_scheduled?
       errors.add(:schedule, "is not a valid schedule") unless SCHEDULES.include?(schedule.to_s)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -65,6 +65,7 @@ class Agent < ActiveRecord::Base
   scope :active,   -> { where(disabled: false, deactivated: false) }
   scope :inactive, -> { where(['disabled = ? OR deactivated = ?', true, true]) }
   scope :shared, -> { where(shared: true) }
+  scope :available_to_user, lambda { |user| where("agents.user_id = ? or agents.shared = true", user.id) }
 
   scope :of_type, lambda { |type|
     type = case type

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -87,7 +87,7 @@
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
                 <% eventSources = (current_user.agents + Agent.shared - [@agent]).find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
-                             options_for_select(eventSources.map {|s| [s.name, s.id] },
+                             options_for_select(eventSources.map {|s| [s.name, s.id, {'data-username': s.user.username, 'data-shared': s.user != @agent.user}] },
                                                 @agent.source_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
                 <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>
@@ -108,14 +108,12 @@
                              options_for_select(eventTargets.map {|s| [s.name, s.id] },
                                                 @agent.receiver_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
-
+                <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
                 <%= f.label :shared, :class => 'shared-agent' do %>Shared Agent
                   <%= f.check_box :shared %>
                   &nbsp;
                   <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, an Agent's events are only accessible to agents owned by the same user. Marking it shared allows this agent's events to be received by an Agent created by any user."></span>
                 <% end %>
-
-                <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
               </div>
             </div>
 

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -85,7 +85,7 @@
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (current_user.agents - [@agent]).find_all { |a| a.can_create_events? } %>
+                <% eventSources = (current_user.agents + Agent.shared - [@agent]).find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
                              options_for_select(eventSources.map {|s| [s.name, s.id] },
                                                 @agent.source_ids),
@@ -108,6 +108,13 @@
                              options_for_select(eventTargets.map {|s| [s.name, s.id] },
                                                 @agent.receiver_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+
+                <%= f.label :shared, :class => 'shared-agent' do %>Shared Agent
+                  <%= f.check_box :shared %>
+                  &nbsp;
+                  <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, an Agent's events are only accessible to agents owned by the same user. Marking it shared allows this agent's events to be received by an Agent created by any user."></span>
+                <% end %>
+
                 <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
               </div>
             </div>

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -85,9 +85,9 @@
               <%= f.label :sources %>
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
               <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (current_user.agents + Agent.shared - [@agent]).find_all { |a| a.can_create_events? } %>
+                <% eventSources = Agent.available_to_user(@agent.user).find_all { |a| a.can_create_events? } %>
                 <%= f.select(:source_ids,
-                             options_for_select(eventSources.map {|s| [s.name, s.id, {'data-username': s.user.username, 'data-shared': s.user != @agent.user}] },
+                             options_for_select(eventSources.map {|s| [s.name, s.id, {"data-username" => s.user.username, "data-shared" => s.user != @agent.user}] },
                                                 @agent.source_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
                 <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>

--- a/app/views/agents/_shared_table.html.erb
+++ b/app/views/agents/_shared_table.html.erb
@@ -10,6 +10,7 @@
       <th><%= sortable_column 'last_receive_at', name: 'Last Event In' %></th>
       <th>Events Created</th>
       <th>Working?</th>
+      <th><%= sortable_column 'users.username', 'asc', name: 'User' %></th>
       <th></th>
     </tr>
 
@@ -19,13 +20,19 @@
           <%= agent_type_icon(agent, agents) %>
         </td>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if current_user == agent.user %>
           <%= link_to agent.name, agent_path(agent, return: (defined?(return_to) && return_to) || request.path) %>
+          <% else %>
+          <span><%= agent.name %></span>
+          <% end %>
           <br/>
           <span class='text-muted'><%= agent.short_type.titleize %></span>
+          <% if current_user == agent.user %>
           <% if agent.scenarios.present? %>
             <span>
               <%= scenario_links(agent) %>
             </span>
+          <% end %>
           <% end %>
         </td>
         <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
@@ -67,13 +74,24 @@
           <% end %>
         </td>
         <td><%= working(agent) %></td>
+        <td class='<%= "agent-unavailable" if agent.unavailable? %>'>
+          <% if current_user == agent.user %>
+            <span><%= agent.user.username %></span>
+          <% else %>
+            <%= link_to agent.user.username, edit_admin_user_path(agent.user, return: (defined?(return_to) && return_to) || request.path) %>
+          <% end %>
+        </td>
         <td>
-          <div class="btn-group">
-            <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-              <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
-            </button>
-            <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
-          </div>
+          <% if current_user == agent.user %>
+            <div class="btn-group">
+              <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
+              </button>
+              <%= render 'agents/action_menu', agent: agent, return_to: (defined?(return_to) && return_to) || request.path %>
+            </div>
+          <% else %>
+            <%#= link_to 'Become User', switch_user_admin_user_path(agent.user), class: "btn btn-sm btn-default btn-info" %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/agents/index.html.erb
+++ b/app/views/agents/index.html.erb
@@ -5,7 +5,7 @@
         <h2><%= session[:original_admin_user_id].present? ? "#{current_user.username}’s Agents" : 'Your Agents' %></h2>
       </div>
 
-      <%= render 'agents/table' %>
+      <%= render partial: 'agents/table', locals: {agents: @agents} %>
 
       <br/>
 
@@ -14,6 +14,10 @@
         <%= link_to icon_tag('glyphicon-refresh') + ' Run event propagation', propagate_agents_path, method: 'post', class: "btn btn-default" %>
         <%= link_to icon_tag('glyphicon-random') + ' View diagram', diagram_path, class: "btn btn-default" %>
         <%= link_to icon_tag('glyphicon-adjust') + toggle_disabled_text, toggle_visibility_agents_path, method: :put, class: "btn btn-default visibility-enabler" %>
+      </div>
+
+      <div class="btn-group">
+        <%= link_to 'Shared Agents', shared_agents_path, class: "btn btn-default" %>
       </div>
     </div>
   </div>

--- a/app/views/agents/shared.html.erb
+++ b/app/views/agents/shared.html.erb
@@ -1,0 +1,17 @@
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class="page-header">
+        <h2>Shared Agents</h2>
+      </div>
+
+      <%= render partial: 'agents/shared_table', locals: {agents: @agents} %>
+
+      <br/>
+
+      <div class="btn-group">
+        <%= link_to 'My Agents', agents_path, class: "btn btn-default" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -118,7 +118,7 @@
               <p>
                 <b>Event sources:</b>
                 <% if (agents = @agent.sources).length > 0 %>
-                  <%= agents.map { |agent| link_to(agent.name, agent_path(agent)) }.to_sentence.html_safe %>
+                  <%= agents.map { |agent| current_user == agent.user ? link_to(agent.name, agent_path(agent)) : agent.name }.to_sentence.html_safe %>
                 <% else %>
                   None
                 <% end %>

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -130,6 +130,11 @@
               </p>
             <% end %>
 
+            <p>
+              <b>Shared:</b>
+              <%= yes_no @agent.shared %>
+            <p>
+
             <% if @agent.can_create_events? %>
               <p>
                 <b>Event receivers:</b>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -10,7 +10,7 @@
         <blockquote><%= markdown(@scenario.description) %></blockquote>
       <% end %>
 
-      <%= render 'agents/table', :return_to => scenario_path(@scenario) %>
+      <%= render partial: 'agents/table', locals: {agents: @agents}, :return_to => scenario_path(@scenario) %>
 
       <br/>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Huginn::Application.routes.draw do
     end
 
     collection do
+      get :shared
       put :toggle_visibility
       post :propagate
       get :type_details

--- a/db/migrate/20160825172604_add_shared_to_agents.rb
+++ b/db/migrate/20160825172604_add_shared_to_agents.rb
@@ -1,7 +1,4 @@
 class AddSharedToAgents < ActiveRecord::Migration
-  class Agents < ActiveRecord::Base
-  end
-
   def change
     add_column :agents, :shared, :boolean, :default => false
     add_index :agents, [:shared]

--- a/db/migrate/20160825172604_add_shared_to_agents.rb
+++ b/db/migrate/20160825172604_add_shared_to_agents.rb
@@ -1,0 +1,9 @@
+class AddSharedToAgents < ActiveRecord::Migration
+  class Agents < ActiveRecord::Base
+  end
+
+  def change
+    add_column :agents, :shared, :boolean, :default => false
+    add_index :agents, [:shared]
+  end
+end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -26,6 +26,10 @@ describe AgentsController do
     end
   end
 
+  describe "GET all" do
+    pending("it returns all Agents if the current user is an admin")
+  end
+
   describe "POST handle_details_post" do
     it "passes control to handle_details_post on the agent" do
       sign_in users(:bob)


### PR DESCRIPTION
Part of https://github.com/cantino/huginn/pull/1593

Still WIP, probably to be merged after https://github.com/cantino/huginn/issues/1659 and along with https://github.com/cantino/huginn/issues/1660 after writing some tests.

This adds
- A database migration that adds a `shared` boolean field to Agent
- Updates to the agent form to allow shared agents as sources
- A `/agents/shared` route to show the publicly shared agents
