### PR TITLE
Instructions to use SendLocation with the User Location Agent

### DIFF
--- a/app/models/agents/user_location_agent.rb
+++ b/app/models/agents/user_location_agent.rb
@@ -8,6 +8,8 @@ module Agents
 
     description do <<-MD
       The User Location Agent creates events based on WebHook POSTS that contain a `latitude` and `longitude`.  You can use the [POSTLocation](https://github.com/cantino/post_location) or [PostGPS](https://github.com/chriseidhof/PostGPS) iOS app to post your location to `https://#{ENV['DOMAIN']}/users/#{user.id}/update_location/:secret` where `:secret` is specified in your options.
+      
+      You can also use [SendLocation](https://itunes.apple.com/us/app/sendlocation/id377724446), available on the iOS App Store.  With SendLocation, though, you will need to use a Webhook Agent to receive the GPS pings, and then an Event Formatting Agent to convert "lat" to "latitude" and "lon" to "longitude". These messages can then be handled by your User Location Agent.
 
       #{'## Include `haversine` in your Gemfile to use this Agent!' if dependencies_missing?}
 


### PR DESCRIPTION
I added instructions on how an iOS app called "SendLocation" can be used to send GPS coordinates to Huginn.  There are already two applications listed as options, but this one is available on the App Store as a $0.99 download.  I've been experimenting with it for a few weeks, and it works just fine.

![screenshot_092016_063052_am](https://cloud.githubusercontent.com/assets/148768/18668559/c78a3d22-7efb-11e6-9259-4e01aa90f815.jpg)

![screenshot_092016_063122_am](https://cloud.githubusercontent.com/assets/148768/18668582/d996e254-7efb-11e6-99b4-f1d417017149.jpg)
