### PR TITLE
Proposal: Allow to access event payload created by previous Agents

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -334,9 +334,25 @@ module LiquidInterpolatable
         "\n"
       end
     end
+
+    class PreviousEvent < Liquid::Tag
+      def initialize(_, args, tokens)
+        (@agent_name, @template) = args.scan(Liquid::QuotedString).map { |e| Liquid::Expression.parse(e) }
+        super
+      end
+
+      def render(context)
+        return if context['event_uuid'].blank?
+        user = context.registers[:agent].user
+        payload = user.events.joins(:agent).where(uuid: context['event_uuid'], agents: {name: @agent_name}).first.try(:payload) || {}
+        throw :as_object, payload unless @template
+        Liquid::Template.parse(@template).render!(payload)
+      end
+    end
   end
   Liquid::Template.register_tag('credential', LiquidInterpolatable::Tags::Credential)
   Liquid::Template.register_tag('line_break', LiquidInterpolatable::Tags::LineBreak)
+  Liquid::Template.register_tag('previous_event', LiquidInterpolatable::Tags::PreviousEvent)
 
   module Blocks
     # Replace every occurrence of a given regex pattern in the first

--- a/app/concerns/wrap_receive.rb
+++ b/app/concerns/wrap_receive.rb
@@ -1,0 +1,36 @@
+module WrapReceive
+  extend ActiveSupport::Concern
+
+  class EventsWrapper < Array
+    attr_reader :events, :agent
+
+    def initialize(events, agent)
+      @agent = agent
+      super(events)
+    end
+
+    def each
+      super do |event|
+        agent.receiving_event(event)
+        yield event
+      end
+    end
+  end
+
+  module ReceiveWrapper
+    def receive(incoming_events)
+      super EventsWrapper.new(incoming_events, self)
+    end
+  end
+
+  def receiving_event(event)
+    @receiving_event = event
+  end
+
+  module ClassMethods
+    def inherited(subclass)
+      super
+      subclass.prepend ReceiveWrapper
+    end
+  end
+end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -14,6 +14,7 @@ class Agent < ActiveRecord::Base
   include LiquidDroppable
   include DryRunnable
   include SortableEvents
+  include WrapReceive
 
   markdown_class_attributes :description, :event_description
 
@@ -119,6 +120,7 @@ class Agent < ActiveRecord::Base
   def create_event(event)
     if can_create_events?
       event = build_event(event)
+      event.uuid = @receiving_event.try(:uuid) || SecureRandom.uuid
       event.save!
       event
     else

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -120,6 +120,10 @@ class EventDrop
     @object.location
   end
 
+  def event_uuid
+    @object.uuid
+  end
+
   def as_json
     {location: _location_.as_json, agent: @object.agent.to_liquid.as_json, payload: @payload.as_json, created_at: created_at.as_json}
   end

--- a/db/migrate/20161020103625_add_uuid_to_events.rb
+++ b/db/migrate/20161020103625_add_uuid_to_events.rb
@@ -1,0 +1,6 @@
+class AddUuidToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :uuid, :string
+    add_index :events, :uuid
+  end
+end

--- a/spec/models/agents/data_output_agent_spec.rb
+++ b/spec/models/agents/data_output_agent_spec.rb
@@ -87,7 +87,7 @@ describe Agents::DataOutputAgent do
         { status: 200, body: 'ok' }
       }
 
-      agent.receive(events(:bob_website_agent_event))
+      agent.receive([])
 
       expect(alist).to eq [
         ["hub.mode", "publish"],


### PR DESCRIPTION
**Reasoning**: We have a some Agents that allow to merge the received event into the created payload, but most of them don't. A client had the need to chain multiple extraction and annotation Agents and store all of extracted data in files. The Agent pipeline looks something like this: `WebsiteAgent -> WebsiteMetadataAgent -> ReadabilityAgent -> (multiple)NlpAgents -> LocalFileAgent`

To make this work we had to add a `merge` option to all [DKT](https://github.com/kreuzwerker/DKT.huginn_dkt_curation_agents) and [FREME](https://github.com/kreuzwerker/DKT.huginn_freme_enrichment_agents) Agents, which wasn't a lot of work but made the pipeline inefficient. Instead of just combining all the Event data before writing it to a file it is stored multiple times.

The idea of this PR is to add a liquid tag to allow to access the event data of previous Agents which are in the current pipeline.

`{% previous_event 'Stock Fetcher', '{{headers | as_object}}' %}` will return the object inside the `headers` key of event emitted by the Agent named `Stock Fetcher`.

This is the scenario I am using: http://pastie.org/private/getcpcvilwfupvqv3hyvw

The last Agent in the pipeline is able to access the event of the first Agent by using the liquid tag I mentioned before. The resulting Event looks like this:

```
{
  "message": "10,710.73",
  "headers": {
    "Content-Type": "text/html; charset=utf-8",
    "P3p": "CP=\"This is not a P3P policy! See https://support.google.com/accounts/answer/151657?hl=en for more info.\"",
    "Date": "Fri, 21 Oct 2016 20:57:49 GMT",
    "Expires": "Fri, 21 Oct 2016 20:57:49 GMT",
    "Cache-Control": "private, max-age=0",
    "X-Content-Type-Options": "nosniff",
    "X-Frame-Options": "SAMEORIGIN",
    "X-Xss-Protection": "1; mode=block",
    "Server": "GSE",
    "Set-Cookie": "NID=89=rXCBcKV5dgZQ2xoQmK4i0nnfqIWHjWO-1zIbpn2JwCUWmk5jyl88KMXBEwrkOtymPpyQn3lw6b6Po0dtvok5uGgHh5LtEac498dSq6k_XXI1xf_gB_3XOpbHkzqbpIaT;Domain=.google.com;Path=/;Expires=Sat, 22-Apr-2017 20:57:49 GMT;HttpOnly",
    "Alt-Svc": "quic=\":443\"; ma=2592000; v=\"36,35,34\"",
    "Transfer-Encoding": "chunked",
    "Content-Length": 79727
  },
  "payload": {
    "body": "<!DOCTYPE html><html><head> a lot of html ...",
    "headers": {
      "Content-Type": "text/html; charset=utf-8",
      "P3p": "CP=\"This is not a P3P policy! See https://support.google.com/accounts/answer/151657?hl=en for more info.\"",
      "Date": "Fri, 21 Oct 2016 20:57:49 GMT",
      "Expires": "Fri, 21 Oct 2016 20:57:49 GMT",
      "Cache-Control": "private, max-age=0",
      "X-Content-Type-Options": "nosniff",
      "X-Frame-Options": "SAMEORIGIN",
      "X-Xss-Protection": "1; mode=block",
      "Server": "GSE",
      "Set-Cookie": "NID=89=rXCBcKV5dgZQ2xoQmK4i0nnfqIWHjWO-1zIbpn2JwCUWmk5jyl88KMXBEwrkOtymPpyQn3lw6b6Po0dtvok5uGgHh5LtEac498dSq6k_XXI1xf_gB_3XOpbHkzqbpIaT;Domain=.google.com;Path=/;Expires=Sat, 22-Apr-2017 20:57:49 GMT;HttpOnly",
      "Alt-Svc": "quic=\":443\"; ma=2592000; v=\"36,35,34\"",
      "Transfer-Encoding": "chunked",
      "Content-Length": 79727
    },
    "status": 200
  }
}
```

This approach should work for all Agents as long as they are not aggregating Events like the `DeDuplicationAgent` or the digest Agents. I am open for suggestion on how to solve this with a simpler approach or one that works for all Agents.

The specs currently fail with multiple `stack level too deep` exceptions which seems to happen randomly. I don't understand why they are happening, any pointers would be greatly appreciated 😄 
