### PR TITLE
[WIP] Enhance the Agent picker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,7 @@ group :development do
 
   group :test do
     gem 'coveralls', '~> 0.7.4', require: false
-    gem 'capybara-select2', require: false
+    gem 'capybara-select2', github: 'goodwill/capybara-select2', require: false
     gem 'delorean'
     gem 'poltergeist'
     gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem 'omniauth', '~> 1.3.1'
 gem 'rails', '~> 5.0.0.1'
 gem 'rufus-scheduler', '~> 3.0.8', require: false
 gem 'sass-rails',   '~> 5.0.6'
-gem 'select2-rails', '~> 3.5.4'
+gem 'select2-rails'
 gem 'spectrum-rails'
 gem 'therubyracer', '~> 0.12.2'
 gem 'typhoeus', '~> 0.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,14 @@ GIT
       rest-client (~> 1.8)
 
 GIT
+  remote: git://github.com/goodwill/capybara-select2.git
+  revision: 585192e4bb0db8d52e761ab68f08c17294806447
+  specs:
+    capybara-select2 (1.0.1)
+      capybara
+      rspec
+
+GIT
   remote: git://github.com/lostisland/faraday_middleware.git
   revision: c5836ae55857272732b33eb0e0a98d60e995a376
   branch: master
@@ -136,16 +144,13 @@ GEM
     capistrano-rails (1.1.3)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (2.6.2)
+    capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-select2 (1.0.1)
-      capybara
-      rspec
     chronic (0.10.2)
     cliver (0.3.2)
     coderay (1.1.0)
@@ -603,7 +608,7 @@ DEPENDENCIES
   capistrano (~> 3.4.0)
   capistrano-bundler (~> 1.1.4)
   capistrano-rails (~> 1.1)
-  capybara-select2
+  capybara-select2!
   coffee-rails (~> 4.2)
   coveralls (~> 0.7.4)
   daemons (~> 1.1.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     sax-machine (1.3.2)
-    select2-rails (3.5.9.3)
+    select2-rails (4.0.3)
       thor (~> 0.14)
     shellany (0.0.1)
     shoulda-matchers (3.0.0)
@@ -675,7 +675,7 @@ DEPENDENCIES
   ruby-growl (~> 4.1.0)
   rufus-scheduler (~> 3.0.8)
   sass-rails (~> 5.0.6)
-  select2-rails (~> 3.5.4)
+  select2-rails
   shoulda-matchers
   slack-notifier (~> 1.0.0)
   spectrum-rails

--- a/app/assets/javascripts/components/core.js.coffee
+++ b/app/assets/javascripts/components/core.js.coffee
@@ -15,6 +15,8 @@ $ ->
 
   # Select2 Selects
   $(".select2").select2(width: 'resolve')
+  $('select').on 'select2:close', ->
+    this.focus()
 
   $(".select2-linked-tags").select2(
     width: 'resolve',

--- a/app/assets/javascripts/components/core.js.coffee
+++ b/app/assets/javascripts/components/core.js.coffee
@@ -18,8 +18,9 @@ $ ->
 
   $(".select2-linked-tags").select2(
     width: 'resolve',
-    formatSelection: (obj) ->
-      "<a href=\"#{this.element.data('urlPrefix')}/#{obj.id}/edit\" onClick=\"Utils.select2TagClickHandler(event, this)\">#{Utils.escape(obj.text)}</a>"
+    escapeMarkup: (m) -> m
+    templateSelection: (obj) ->
+      "<a href=\"#{obj.element.parentNode.dataset.urlPrefix}/#{obj.id}/edit\" onclick=\"Utils.select2TagClickHandler(event, this)\">#{Utils.escape(obj.text)}</a>"
   )
 
   # Helper for selecting text when clicked

--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -63,6 +63,7 @@ class @AgentEditPage
               if aVal < bVal
                 return -1
             0
+      .select2('open')
 
     else
       @enableDryRunButton()

--- a/app/assets/javascripts/pages/scenario-form-page.js.coffee
+++ b/app/assets/javascripts/pages/scenario-form-page.js.coffee
@@ -9,7 +9,8 @@ class @ScenarioFormPage
   enabledSelect2: () ->
     $('.select2-fountawesome-icon').select2
       width: '100%'
-      formatResult: @format
-      
+      escapeMarkup: (m) -> m
+      templateResult: @format
+
 $ ->
   Utils.registerPage(ScenarioFormPage, forPathsMatching: /^scenarios/)

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -11,6 +11,16 @@ end
 
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
+module Capybara::Select2
+  module CloseBeforeSelecting
+    def select2(value, options = {})
+      page.execute_script('$(".select2.select2-container--open").prev("select").select2("close")')
+      super
+    end
+  end
+
+  prepend CloseBeforeSelecting
+end
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers


### PR DESCRIPTION
Although searching also by the Agent's description (#830) was a great addition, it has made it difficult to identify an Agent by typing just a few letters, because the descriptions of Agents contains a lot of random words that may often accidentally match your query, and the matched Agents are listed in the original order.

To solve the problem, this commit introduces the scoring and sorting of matched items making use of select2 4.0's enhanced matcher.  With this improvement, Agents with a specified keyword in their names will be listed first followed by ones with the keyword in their descriptions.  Among each group, Agents are sorted by the position where the keyword has matched in the title or description so that one can easily pick an Agent by the name that one already knows, while it is still possible to find an Agent one doesn't remember exactly nor even know of.
