### PR TITLE
Add shared memory to Scenarios & allow JSAgents to manipulate it

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,13 @@ GIT
       oauth
       simple_oauth
 
+GIT
+  remote: https://github.com/yubuylov/huginn_mysql2_agent.git
+  revision: 5db95d73cd3016a6ac9860ce9cdb4e8d19cd9f0f
+  specs:
+    huginn_mysql2_agent (0.1)
+      huginn_agent (~> 0.2)
+
 PATH
   remote: vendor/gems/dotenv-2.0.1
   specs:
@@ -640,6 +647,7 @@ DEPENDENCIES
   httmultiparty (~> 0.3.16)
   httparty (~> 0.13)
   huginn_agent (~> 0.4.0)
+  huginn_mysql2_agent!
   hypdf (~> 1.0.10)
   jquery-rails (~> 4.2.1)
   json (~> 1.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,7 +705,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,13 +68,6 @@ GIT
       oauth
       simple_oauth
 
-GIT
-  remote: https://github.com/yubuylov/huginn_mysql2_agent.git
-  revision: 5db95d73cd3016a6ac9860ce9cdb4e8d19cd9f0f
-  specs:
-    huginn_mysql2_agent (0.1)
-      huginn_agent (~> 0.2)
-
 PATH
   remote: vendor/gems/dotenv-2.0.1
   specs:
@@ -647,7 +640,6 @@ DEPENDENCIES
   httmultiparty (~> 0.3.16)
   httparty (~> 0.13)
   huginn_agent (~> 0.4.0)
-  huginn_mysql2_agent!
   hypdf (~> 1.0.10)
   jquery-rails (~> 4.2.1)
   json (~> 1.8.1)
@@ -713,7 +705,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.13.6

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -1,5 +1,8 @@
 class Scenario < ActiveRecord::Base
   include HasGuid
+  include JSONSerializedField
+
+  json_serialize :shared_memory
 
   belongs_to :user, :counter_cache => :scenario_count, :inverse_of => :scenarios
   has_many :scenario_memberships, :dependent => :destroy, :inverse_of => :scenario

--- a/db/migrate/20161211040238_add_sharedmem_to_scenarios.rb
+++ b/db/migrate/20161211040238_add_sharedmem_to_scenarios.rb
@@ -1,0 +1,5 @@
+class AddSharedmemToScenarios < ActiveRecord::Migration[5.0]
+  def change
+    add_column :scenarios, :shared_memory, :string
+  end
+end


### PR DESCRIPTION
Simplest possible approach I could implement, given my complete lack of familiarity with Ruby/Rails.
Comes with a dash of documentation for how to use it from JS side of JS Agents.

I'm sure there's plenty of room for improvement on performance, but here's a thing that works, at least.