### PR TITLE
Support Ruby >=2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,26 +29,26 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
-    - rvm: 2.3.3
+    - rvm: 2.3.4
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.3.3
+    - rvm: 2.3.4
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
 rvm:
 - 2.2
-- 2.3.3
-- 2.4.0
+- 2.3.4
+- 2.4.1
 cache: bundler
 bundler_args: --without development production
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,21 +29,21 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
 rvm:
 - 2.2
-- 2.3.1
+- 2.3.3
 cache: bundler
 bundler_args: --without development production
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,18 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
-    - rvm: 2.3.3
+    - rvm: 2.4.0
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.3.3
+    - rvm: 2.4.0
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.3.3
+    - rvm: 2.4.0
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.3.3
+    - rvm: 2.4.0
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
+    - rvm: 2.4.0
+      env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
+    - rvm: 2.4.0
+      env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
     - rvm: 2.3.3
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
     - rvm: 2.3.3
@@ -44,6 +48,7 @@ matrix:
 rvm:
 - 2.2
 - 2.3.3
+- 2.4.0
 cache: bundler
 bundler_args: --without development production
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'weibo_2', github: 'dsander/weibo_2', branch: 'master'
 gem 'google-api-client', '~> 0.7.1', require: 'google/api_client'
 
 # Twitter Agents
-gem 'twitter', '~> 5.14.0' # Must to be loaded before cantino-twitter-stream.
+gem 'twitter', github: 'sferik/twitter' # Must to be loaded before cantino-twitter-stream.
 gem 'twitter-stream', github: 'cantino/twitter-stream', branch: 'huginn'
 gem 'omniauth-twitter', '~> 1.3.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'google-api-client', '~> 0.7.1', require: 'google/api_client'
 # Twitter Agents
 gem 'twitter', '~> 5.14.0' # Must to be loaded before cantino-twitter-stream.
 gem 'twitter-stream', github: 'cantino/twitter-stream', branch: 'huginn'
-gem 'omniauth-twitter', '~> 1.2.1'
+gem 'omniauth-twitter', '~> 1.3.0'
 
 # Tumblr Agents
 gem 'tumblr_client', github: 'tumblr/tumblr_client', branch: 'master', ref: '0c59b04e49f2a8c89860613b18cf4e8f978d8dc7'  # '>= 0.8.5'

--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ group :development do
     gem 'rails-controller-testing'
     gem 'shoulda-matchers'
     gem 'vcr'
-    gem 'webmock', '~> 1.17.4', require: false
+    gem 'webmock', '~> 2.3'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ gem 'rufus-scheduler', '~> 3.3.2', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
-gem 'therubyracer', '~> 0.12.2'
+gem 'therubyracer', '~> 0.12.3'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '~> 2.7.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     jsonpath (0.7.2)
       multi_json
     jwt (1.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       simplecov (~> 0.9.1)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.1.9)
     debug_inspector (0.0.2)
@@ -292,6 +292,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (0.3.2)
     hashie (3.4.6)
     haversine (0.3.0)
     hipchat (1.2.0)
@@ -595,9 +596,10 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
-    webmock (1.17.4)
-      addressable (>= 2.2.7)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -713,7 +715,7 @@ DEPENDENCIES
   unicorn (~> 5.1.0)
   vcr
   web-console (>= 3.3.0)
-  webmock (~> 1.17.4)
+  webmock (~> 2.3)
   weibo_2!
   wunderground (~> 1.2.0)
   xmpp4r (~> 0.5.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,8 +289,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    httparty (0.13.7)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
     huginn_agent (0.4.0)
       thor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
-    libv8 (3.16.14.15)
+    libv8 (3.16.14.19)
     liquid (4.0.0)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
@@ -538,8 +538,8 @@ GEM
     systemu (2.6.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.4)
     thread_safe (0.3.6)
@@ -692,7 +692,7 @@ DEPENDENCIES
   spring (~> 1.7.2)
   spring-commands-rspec (~> 1.0.4)
   spring-watcher-listen (~> 2.0.0)
-  therubyracer (~> 0.12.2)
+  therubyracer (~> 0.12.3)
   tumblr_client!
   twilio-ruby (~> 3.11.5)
   twitter (~> 5.14.0)
@@ -710,7 +710,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.5p303
 
 BUNDLED WITH
    1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,7 +588,7 @@ GEM
     uuid (2.3.7)
       macaddr (~> 1.0)
     uuidtools (2.1.5)
-    vcr (2.9.2)
+    vcr (3.0.3)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,9 +382,9 @@ GEM
     omniauth-tumblr (1.2)
       multi_json
       omniauth-oauth (~> 1.0)
-    omniauth-twitter (1.2.1)
-      json (~> 1.3)
+    omniauth-twitter (1.3.0)
       omniauth-oauth (~> 1.1)
+      rack
     omniauth-wunderlist (0.0.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
@@ -666,7 +666,7 @@ DEPENDENCIES
   omniauth-dropbox
   omniauth-evernote
   omniauth-tumblr (~> 1.2)
-  omniauth-twitter (~> 1.2.1)
+  omniauth-twitter (~> 1.3.0)
   omniauth-wunderlist
   pg (~> 0.18.3)
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,22 @@ GIT
       faraday (>= 0.7.4, < 1.0)
 
 GIT
+  remote: https://github.com/sferik/twitter.git
+  revision: d11707edf4abd13f7ada0eef57fc1eaa1062d75b
+  specs:
+    twitter (5.15.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.11)
+      http (~> 2.0)
+      http-form_data (~> 1.0)
+      http_parser.rb (~> 0.6.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
+
+GIT
   remote: https://github.com/tumblr/tumblr_client.git
   revision: 0c59b04e49f2a8c89860613b18cf4e8f978d8dc7
   ref: 0c59b04e49f2a8c89860613b18cf4e8f978d8dc7
@@ -284,10 +300,14 @@ GEM
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
-    http (0.6.4)
+    http (2.1.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
       http_parser.rb (~> 0.6.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
+    http-form_data (1.0.1)
     http_parser.rb (0.6.0)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
@@ -341,7 +361,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     mysql2 (0.3.20)
-    naught (1.0.0)
+    naught (1.1.0)
     nenv (0.2.0)
     net-ftp-list (3.2.8)
     net-scp (1.2.1)
@@ -551,17 +571,6 @@ GEM
       builder (>= 2.1.2)
       jwt (>= 0.1.2)
       multi_json (>= 1.3.0)
-    twitter (5.14.0)
-      addressable (~> 2.3)
-      buftok (~> 0.2.0)
-      equalizer (~> 0.0.9)
-      faraday (~> 0.9.0)
-      http (~> 0.6.0)
-      http_parser.rb (~> 0.6.0)
-      json (~> 1.8)
-      memoizable (~> 0.4.0)
-      naught (~> 1.0)
-      simple_oauth (~> 0.3.0)
     typhoeus (0.6.9)
       ethon (>= 0.7.1)
     tzinfo (1.2.3)
@@ -695,7 +704,7 @@ DEPENDENCIES
   therubyracer (~> 0.12.3)
   tumblr_client!
   twilio-ruby (~> 3.11.5)
-  twitter (~> 5.14.0)
+  twitter!
   twitter-stream!
   typhoeus (~> 0.6.3)
   tzinfo (>= 1.2.0)

--- a/app/models/agents/csv_agent.rb
+++ b/app/models/agents/csv_agent.rb
@@ -161,8 +161,17 @@ module Agents
       end
     end
 
+    def parse_csv_options(mo)
+      options = {
+        col_sep: separator(mo),
+        headers: boolify(mo['with_header']),
+      }
+      options[:liberal_parsing] = true if CSV::DEFAULT_OPTIONS.key?(:liberal_parsing)
+      options
+    end
+
     def parse_csv(io, mo, array = nil)
-      CSV.new(io, col_sep: separator(mo), headers: boolify(mo['with_header'])).each do |row|
+      CSV.new(io, **parse_csv_options(mo)).each do |row|
         if block_given?
           yield get_payload(row, mo)
         else

--- a/doc/deployment/capistrano/deploy.rb
+++ b/doc/deployment/capistrano/deploy.rb
@@ -68,7 +68,7 @@ namespace :foreman do
 end
 
 # If you want to use rvm on your server and have it maintained by Capistrano, uncomment these lines:
-#   set :rvm_ruby_string, '2.3.1@huginn'
+#   set :rvm_ruby_string, '2.3.3@huginn'
 #   set :rvm_type, :user
 #   before 'deploy', 'rvm:install_rvm'
 #   before 'deploy', 'rvm:install_ruby'

--- a/doc/deployment/capistrano/deploy.rb
+++ b/doc/deployment/capistrano/deploy.rb
@@ -68,7 +68,7 @@ namespace :foreman do
 end
 
 # If you want to use rvm on your server and have it maintained by Capistrano, uncomment these lines:
-#   set :rvm_ruby_string, '2.3.3@huginn'
+#   set :rvm_ruby_string, '2.3.4@huginn'
 #   set :rvm_type, :user
 #   before 'deploy', 'rvm:install_rvm'
 #   before 'deploy', 'rvm:install_ruby'

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -65,8 +65,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2 | tar xj
-    cd ruby-2.3.3
+    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2 | tar xj
+    cd ruby-2.3.4
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -65,8 +65,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2 | tar xj
-    cd ruby-2.3.1
+    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2 | tar xj
+    cd ruby-2.3.3
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install

--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -27,7 +27,7 @@ $minimal_apt_get_install build-essential checkinstall git-core \
   libncurses5-dev libffi-dev libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev \
   graphviz libgraphviz-dev \
   libmysqlclient-dev libpq-dev libsqlite3-dev \
-  ruby2.3 ruby2.3-dev
+  ruby2.4 ruby2.4-dev
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 gem install --no-ri --no-rdoc bundler

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -563,7 +563,7 @@ describe Agent do
         agent.options = 5
         expect(agent.options["hi"]).to eq(2)
         expect(agent).to have(1).errors_on(:options)
-        expect(agent.errors_on(:options)).to include("cannot be set to an instance of Fixnum")
+        expect(agent.errors_on(:options)).to include("cannot be set to an instance of #{2.class}")  # Integer (ruby >=2.4) or Fixnum (ruby <2.4)
       end
 
       it "should not allow source agents owned by other people" do

--- a/spec/models/agents/csv_agent_spec.rb
+++ b/spec/models/agents/csv_agent_spec.rb
@@ -132,7 +132,7 @@ describe Agents::CsvAgent do
       end
 
       it "handles quotes correctly" do
-        event = event_with_contents("\"one\",\"two\"\n1,2\n\"\"2, two\",3")
+        event = event_with_contents("\"one\",\"two\"\n1,2\n\"\"\"2, two\",3")
         expect { @checker.receive([event]) }.to change(Event, :count).by(2)
         expect(Event.last.payload).to eq(@checker.options['data_key'] => {'one' => '"2, two', 'two' => '3'})
       end

--- a/spec/models/agents/pushbullet_agent_spec.rb
+++ b/spec/models/agents/pushbullet_agent_spec.rb
@@ -99,17 +99,19 @@ describe Agents::PushbulletAgent do
 
   describe "#receive" do
     it "send a note" do
-      stub_request(:post, "https://token:@api.pushbullet.com/v2/pushes").
-        with(:body => "device_iden=124&type=note&title=hello%20from%20huginn&body=One%20two%20test").
-        to_return(:status => 200, :body => "{}", :headers => {})
+      stub_request(:post, "https://api.pushbullet.com/v2/pushes").
+        with(basic_auth: [@checker.options[:api_key], ''],
+             body: "device_iden=124&type=note&title=hello%20from%20huginn&body=One%20two%20test").
+        to_return(status: 200, body: "{}", headers: {})
       dont_allow(@checker).error
       @checker.receive([@event])
     end
 
     it "should log resquests which return an error" do
-      stub_request(:post, "https://token:@api.pushbullet.com/v2/pushes").
-        with(:body => "device_iden=124&type=note&title=hello%20from%20huginn&body=One%20two%20test").
-        to_return(:status => 200, :body => '{"error": {"message": "error"}}', :headers => {})
+      stub_request(:post, "https://api.pushbullet.com/v2/pushes").
+        with(basic_auth: [@checker.options[:api_key], ''],
+             body: "device_iden=124&type=note&title=hello%20from%20huginn&body=One%20two%20test").
+        to_return(status: 200, body: '{"error": {"message": "error"}}', headers: {})
       mock(@checker).error("error")
       @checker.receive([@event])
     end
@@ -125,8 +127,11 @@ describe Agents::PushbulletAgent do
 
   describe '#devices' do
     it "should return an array of devices" do
-      stub_request(:get, "https://token:@api.pushbullet.com/v2/devices").
-         to_return(:status => 200, :body => '{"devices": [{"pushable": false}, {"nickname": "test", "iden": "iden", "pushable": true}]}', :headers => {})
+      stub_request(:get, "https://api.pushbullet.com/v2/devices").
+        with(basic_auth: [@checker.options[:api_key], '']).
+        to_return(status: 200,
+                  body: '{"devices": [{"pushable": false}, {"nickname": "test", "iden": "iden", "pushable": true}]}',
+                  headers: {})
       expect(@checker.send(:devices)).to eq([{"nickname"=>"test", "iden"=>"iden", "pushable"=>true}])
     end
 
@@ -138,9 +143,12 @@ describe Agents::PushbulletAgent do
 
   describe '#create_device' do
     it "should create a new device and assign it to the options" do
-      stub_request(:post, "https://token:@api.pushbullet.com/v2/devices").
-         with(:body => "nickname=Huginn&type=stream").
-         to_return(:status => 200, :body => '{"iden": "udm0Tdjz5A7bL4NM"}', :headers => {})
+      stub_request(:post, "https://api.pushbullet.com/v2/devices").
+        with(basic_auth: [@checker.options[:api_key], ''],
+             body: "nickname=Huginn&type=stream").
+        to_return(status: 200,
+                  body: '{"iden": "udm0Tdjz5A7bL4NM"}',
+                  headers: {})
       @checker.options['device_id'] = nil
       @checker.send(:create_device)
       expect(@checker.options[:device_id]).to eq('udm0Tdjz5A7bL4NM')

--- a/spec/models/agents/twitter_favorites_spec.rb
+++ b/spec/models/agents/twitter_favorites_spec.rb
@@ -4,6 +4,7 @@ describe Agents::TwitterFavorites do
   before do
     stub_request(:any, /tectonic.*[?&]tweet_mode=extended/).
       to_return(body: File.read(Rails.root.join("spec/data_fixtures/user_fav_tweets.json")),
+                headers: { 'Content-Type': 'application/json;charset=utf-8' },
                 status: 200)
   end
 

--- a/spec/models/agents/twitter_search_agent_spec.rb
+++ b/spec/models/agents/twitter_search_agent_spec.rb
@@ -5,7 +5,9 @@ describe Agents::TwitterSearchAgent do
     # intercept the twitter API request
     stub_request(:any, /freebandnames.*[?&]tweet_mode=extended/).
       to_return(body: File.read(Rails.root.join("spec/data_fixtures/search_tweets.json")),
+                headers: { 'Content-Type': 'application/json;charset=utf-8' },
                 status: 200)
+
     @opts = {
       search: "freebandnames",
       expected_update_period_in_days: "2",

--- a/spec/models/agents/twitter_user_agent_spec.rb
+++ b/spec/models/agents/twitter_user_agent_spec.rb
@@ -5,6 +5,7 @@ describe Agents::TwitterUserAgent do
     # intercept the twitter API request for @tectonic's user profile
     stub_request(:any, "https://api.twitter.com/1.1/statuses/user_timeline.json?contributor_details=true&count=200&exclude_replies=false&include_entities=true&include_rts=true&screen_name=tectonic&tweet_mode=extended").
       to_return(body: File.read(Rails.root.join("spec/data_fixtures/user_tweets.json")),
+                headers: { 'Content-Type': 'application/json;charset=utf-8' },
                 status: 200)
 
     @opts = {

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -1312,15 +1312,9 @@ fire: hot
       @checker.user = users(:bob)
       @checker.save!
 
-      case @checker.faraday_backend
-      when :typhoeus
-        # Webmock's typhoeus adapter does not read the Authorization
-        # header: https://github.com/bblimke/webmock/pull/592
-        stub_request(:any, "www.example.com").
-          with(headers: { 'Authorization' => "Basic #{['user:pass'].pack('m0')}" })
-      else
-        stub_request(:any, "user:pass@www.example.com")
-      end.to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+      stub_request(:any, "www.example.com").
+        with(basic_auth: ['user', 'pass']).
+        to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
     end
 
     describe "#check" do


### PR DESCRIPTION
I know that the json gem version 1.8.6 was released the other day which supports ruby >=2.4, but there are other gems that need to be updated for ruby >=2.4, and I think this is a good opportunity for us to check on existing dependencies and move forward.