### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 | DateOfChange   | Changes                                                                                                      |
 |----------------|--------------------------------------------------------------------------------------------------------------|
+| Apr 18, 2019   | Replace rubyracer with mini_racer, dropped support for Debian 7 aka Wheezy [1961](https://github.com/huginn/huginn/pull/1961) |
 | Oct 03, 2018   | Added support for MySQL 8 and MariaDB 10.3. Dropped support for MySQL < 5.5 and PostgreSQL < 9.2 [2384](https://github.com/huginn/huginn/pull/2384) |
 | Sep 15, 2017   | Tweets view of `TwitterStreamAgent` has been enhanced. [2122](https://github.com/huginn/huginn/pull/2122) |
 | Sep 09, 2017   | Agent objects in Liquid templating now have new properties `working` and `url`. [2118](https://github.com/huginn/huginn/pull/2118) |

--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,8 @@ gem 'rufus-scheduler', '~> 3.4.2', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
-gem 'therubyracer', '~> 0.12.3'
+gem 'mini_racer', '~> 0.2.3'
+gem 'execjs', '~> 2.7.0'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '~> 2.7.2'
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ gem 'rufus-scheduler', '~> 3.4.2', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
-gem 'mini_racer', '~> 0.2.3'
+gem 'mini_racer', '~> 0.2.4'
 gem 'execjs', '~> 2.7.0'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '~> 2.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
     mini_magick (4.2.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    mini_racer (0.2.3)
+    mini_racer (0.2.4)
       libv8 (>= 6.3)
     minitest (5.11.3)
     mqtt (0.3.1)
@@ -721,7 +721,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   loofah (~> 2.0)
   mini_magick
-  mini_racer (~> 0.2.3)
+  mini_racer (~> 0.2.4)
   mqtt
   multi_xml
   mysql2 (~> 0.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
     evernote_oauth (0.2.3)
       evernote-thrift
       oauth (>= 0.4.1)
-    execjs (2.6.0)
+    execjs (2.7.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -374,7 +374,7 @@ GEM
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
-    libv8 (3.16.14.19)
+    libv8 (6.7.288.46.1)
     liquid (4.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -404,6 +404,8 @@ GEM
     mini_magick (4.2.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.3)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     mqtt (0.3.1)
     msgpack (1.2.4)
@@ -514,7 +516,6 @@ GEM
       ffi (>= 0.5.0, < 2)
     rb-kqueue (0.2.4)
       ffi (>= 0.5.0)
-    ref (2.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -610,9 +611,6 @@ GEM
     systemu (2.6.4)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -692,6 +690,7 @@ DEPENDENCIES
   em-http-request (~> 1.1.2)
   erector!
   evernote_oauth
+  execjs (~> 2.7.0)
   faraday (~> 0.9)
   faraday_middleware (~> 0.12.2)
   feedjira (~> 2.1)
@@ -722,6 +721,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   loofah (~> 2.0)
   mini_magick
+  mini_racer (~> 0.2.3)
   mqtt
   multi_xml
   mysql2 (~> 0.5.2)
@@ -760,7 +760,6 @@ DEPENDENCIES
   spring-commands-rspec (~> 1.0.4)
   spring-watcher-listen (~> 2.0.1)
   sprockets (~> 3.7.2)
-  therubyracer (~> 0.12.3)
   tumblr_client!
   twilio-ruby (~> 3.11.5)
   twitter!

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -221,7 +221,7 @@ module Agents
     def log_errors
       begin
         yield
-      rescue MiniRacer::EvalError, MiniRacer::SnapshotError, MiniRacer::PlatformAlreadyInitialized => e
+      rescue MiniRacer::Error => e
         error "JavaScript error: #{e.message}"
       end
     end

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -107,26 +107,22 @@ module Agents
 
     def execute_js(js_function, incoming_events = [])
       js_function = js_function == "check" ? "check" : "receive"
-      context = V8::Context.new
+      context = MiniRacer::Context.new
       context.eval(setup_javascript)
 
-      context["doCreateEvent"] = lambda { |a, y| create_event(payload: clean_nans(JSON.parse(y))).payload.to_json }
-      context["getIncomingEvents"] = lambda { |a| incoming_events.to_json }
-      context["getOptions"] = lambda { |a, x| interpolated.to_json }
-      context["doLog"] = lambda { |a, x| log x }
-      context["doError"] = lambda { |a, x| error x }
-      context["getMemory"] = lambda { |a| memory.to_json }
-      context["setMemoryKey"] = lambda do |a, x, y|
-        memory[x] = clean_nans(y)
-      end
-      context["setMemory"] = lambda do |a, x|
-        memory.replace(clean_nans(x))
-      end
-      context["deleteKey"] = lambda { |a, x| memory.delete(x).to_json }
-      context["escapeHtml"] = lambda { |a, x| CGI.escapeHTML(x) }
-      context["unescapeHtml"] = lambda { |a, x| CGI.unescapeHTML(x) }
-      context['getCredential'] = lambda { |a, k| credential(k); }
-      context['setCredential'] = lambda { |a, k, v| set_credential(k, v) }
+      context.attach("doCreateEvent", -> (y) { create_event(payload: clean_nans(JSON.parse(y))).payload.to_json })
+      context.attach("getIncomingEvents", -> { incoming_events.to_json })
+      context.attach("getOptions", -> { interpolated.to_json })
+      context.attach("doLog", -> (x) { log x })
+      context.attach("doError", -> (x) { error x })
+      context.attach("getMemory", -> { memory.to_json })
+      context.attach("setMemoryKey", -> (x, y) { memory[x] = clean_nans(y) })
+      context.attach("setMemory", -> (x) { memory.replace(clean_nans(x)) })
+      context.attach("deleteKey", -> (x) { memory.delete(x).to_json })
+      context.attach("escapeHtml", -> (x) { CGI.escapeHTML(x) })
+      context.attach("unescapeHtml", -> (x) { CGI.unescapeHTML(x) })
+      context.attach('getCredential', -> (k) { credential(k); })
+      context.attach('setCredential', -> (k, v) { set_credential(k, v) })
 
       if (options['language'] || '').downcase == 'coffeescript'
         context.eval(CoffeeScript.compile code)
@@ -225,15 +221,15 @@ module Agents
     def log_errors
       begin
         yield
-      rescue V8::Error => e
+      rescue MiniRacer::EvalError, MiniRacer::SnapshotError, MiniRacer::PlatformAlreadyInitialized => e
         error "JavaScript error: #{e.message}"
       end
     end
 
     def clean_nans(input)
-      if input.is_a?(V8::Array)
+      if input.is_a?(Array)
         input.map {|v| clean_nans(v) }
-      elsif input.is_a?(V8::Object)
+      elsif input.is_a?(Hash)
         input.inject({}) { |m, (k, v)| m[k] = clean_nans(v); m }
       elsif input.is_a?(Float) && input.nan?
         'NaN'

--- a/doc/manual/requirements.md
+++ b/doc/manual/requirements.md
@@ -5,7 +5,7 @@
 ### Supported Unix distributions by this guide
 
 - Ubuntu (18.04, 16.04 and 14.04)
-- Debian (Jessie and Wheezy)
+- Debian (Stretch and Jessie)
 
 ### Unsupported Unix distributions
 


### PR DESCRIPTION
Initially this PR was created to improve compatibility on ARM(64) devices. Sadly this did not work out, the newer libv8 version still has issues compiling on arm devices.

For all other users the change is a improvement, `mini_racer` is a lot faster because the libv8 version is newer. 

It also fixes a massive memory leak reported in #2512.

 #1959

Might help with #1919