### PR TITLE
Switch graphviz heroku buildpack to a fork to support new heroku stack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/cantino/heroku-selectable-procfile.git
 https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/weibeld/heroku-buildpack-graphviz.git
+https://github.com/dsander/heroku-buildpack-graphviz.git


### PR DESCRIPTION
The new default Heroku-16 stack is based on Ubuntu 16 which is not yet
supported by the upstream version of the graphviz buildpack.

Switching to a fork until upstream is updated.

Fixes https://gitter.im/huginn/huginn?at=5912a8ac2b926f8a673d1070