### PR TITLE
Change docker image namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,25 @@ env:
     - DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
     - DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
     - DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
+    - DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
+    - DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - RSPEC_TASK=spec:features
 matrix:
   exclude:
     - env: DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
     - env: DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
+    - env: DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
+    - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
     - rvm: 2.3.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
     - rvm: 2.3.1
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
+    - rvm: 2.3.1
+      env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
+    - rvm: 2.3.1
+      env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - rvm: 2.3.1
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
     - rvm: 2.3.1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::Base
     return unless current_user
     twitter_oauth_check
     basecamp_auth_check
+    outdated_docker_image_namespace_check
   end
 
   def filtered_agent_return_link(options = {})
@@ -63,6 +64,10 @@ class ApplicationController < ActionController::Base
     unless Devise.omniauth_providers.include?(:'37signals')
       @basecamp_agent = current_user.agents.where(type: 'Agents::BasecampAgent').first
     end
+  end
+
+  def outdated_docker_image_namespace_check
+    @outdated_docker_image_namespace = ENV['OUTDATED_DOCKER_IMAGE_NAMESPACE'] == 'true'
   end
 
   def agent_params

--- a/app/views/application/_upgrade_warning.html.erb
+++ b/app/views/application/_upgrade_warning.html.erb
@@ -24,3 +24,20 @@ TWITTER_OAUTH_SECRET=<%= @twitter_oauth_secret %>
     <% end %>
   </div>
 <% end -%>
+<% if @outdated_docker_image_namespace %>
+  <dir class="container">
+    <div class="alert alert-danger" role="alert">
+      <p>
+        <b>Warning!</b> You need to change the namespace of the Huginn Docker image you are using.
+      </p>
+      <br/>
+      <p>
+        Since Huginn moved to a GitHub organization we also changed the namespace of the Docker images. Please change your configuration to the new namespace:
+        <ul>
+          <li><code>cantino/huginn</code> is now <code>huginn/huginn</code></li>
+          <li><code>cantino/huginn-single-process</code> is now <code>huginn/huginn-single-process</code></li>
+        </ul>
+      </p>
+    </div>
+  </dir>
+<% end -%>

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -2,7 +2,12 @@
 set -ev
 
 docker pull $DOCKER_IMAGE
-docker build -t $DOCKER_IMAGE -f $DOCKERFILE .
+
+if [[ $DOCKER_IMAGE =~ "cantino" ]]; then
+  docker build --build-arg OUTDATED_DOCKER_IMAGE_NAMESPACE='true' -t $DOCKER_IMAGE -f $DOCKERFILE .
+else
+  docker build -t $DOCKER_IMAGE -f $DOCKERFILE .
+fi
 
 if [[ -n "${DOCKER_USER}" && "${TRAVIS_PULL_REQUEST}" = 'false' && "${TRAVIS_BRANCH}" = "master" ]]; then
   docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,10 +3,10 @@ Huginn Docker images
 
 Huginn is packaged in two docker images.
 
-#### [cantino/huginn](multi-process/README.md) multiple process image
+#### [huginn/huginn](multi-process/README.md) multiple process image
 
 This image runs all processes needed by Huginn in one container, when the database is not linked it will also start MySQL internally. This is great to try huginn without having to set up anything, however maintenance and backups can be difficult.
 
-#### [cantino/huginn-single-process](single-process/README.md) multiple container image
+#### [huginn/huginn-single-process](single-process/README.md) multiple container image
 
 This image runs just one process per container and thus needs at least two container to be started, one for the Huginn application server and one for the threaded background worker. It is also possible to every background worker in a separate container to improve the performance. See [the PostgreSQL docker-compose configuration](single-process/postgresql.yml) for an example.

--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER Andrew Cantino
 
 ADD docker/scripts/prepare /scripts/prepare
 RUN /scripts/prepare
@@ -17,6 +16,9 @@ RUN chown -R huginn:huginn /app && \
     sudo -u huginn -H echo "gem 'sqlite3', '~> 1.3.11'" >> /app/Gemfile && \
     sudo -u huginn -H LC_ALL=en_US.UTF-8 RAILS_ENV=production ON_HEROKU=true bundle install --without test development --path vendor/bundle -j 4
 COPY . /app
+
+ARG OUTDATED_DOCKER_IMAGE_NAMESPACE=false
+ENV OUTDATED_DOCKER_IMAGE_NAMESPACE ${OUTDATED_DOCKER_IMAGE_NAMESPACE}
 
 ADD ["docker/scripts/setup", "docker/multi-process/scripts/init", "/scripts/"]
 RUN /scripts/setup

--- a/docker/multi-process/Makefile
+++ b/docker/multi-process/Makefile
@@ -1,2 +1,2 @@
 build:
-	docker build -t cantino/huginn .
+	docker build -t huginn/huginn .

--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -1,9 +1,9 @@
 Huginn for docker with multiple container linkage
 =================================================
 
-This image runs a linkable [Huginn](https://github.com/cantino/huginn) instance.
+This image runs a linkable [Huginn](https://github.com/huginn/huginn) instance.
 
-There is an automated build repository on docker hub for [cantino/huginn](https://hub.docker.com/r/cantino/huginn/builds/).
+There is an automated build repository on docker hub for [huginn/huginn](https://hub.docker.com/r/huginn/huginn/builds/).
 
 This was patterned after [sameersbn/gitlab](https://registry.hub.docker.com/u/sameersbn/gitlab) by [ianblenke/huginn](http://github.com/ianblenke/huginn), and imported here for official generation of a docker hub auto-build image.
 
@@ -51,11 +51,11 @@ The CMD launches Huginn via the scripts/init script. This may become the ENTRYPO
 
 Simple stand-alone usage (use only for testing/evaluation as it can not be updated without losing data):
 
-    docker run -it -p 3000:3000 cantino/huginn
+    docker run -it -p 3000:3000 huginn/huginn
 
 Use a volume to export the data of the internal mysql server:
 
-    docker run -it -p 3000:3000 -v /home/huginn/mysql-data:/var/lib/mysql cantino/huginn
+    docker run -it -p 3000:3000 -v /home/huginn/mysql-data:/var/lib/mysql huginn/huginn
 
 To link to another mysql container, for example:
 
@@ -71,7 +71,7 @@ To link to another mysql container, for example:
         -e HUGINN_DATABASE_NAME=huginn \
         -e HUGINN_DATABASE_USERNAME=huginn \
         -e HUGINN_DATABASE_PASSWORD=somethingsecret \
-        cantino/huginn
+        huginn/huginn
 
 To link to another container named 'postgres':
 
@@ -84,7 +84,7 @@ To link to another container named 'postgres':
         -e HUGINN_DATABASE_USERNAME=huginn \
         -e HUGINN_DATABASE_PASSWORD=mysecretpassword \
         -e HUGINN_DATABASE_ADAPTER=postgresql \
-        cantino/huginn
+        huginn/huginn
 
 The `docker/multi-process` folder also has a `docker-compose.yml` that allows for a sample database formation with a data volume container:
 
@@ -92,19 +92,19 @@ The `docker/multi-process` folder also has a `docker-compose.yml` that allows fo
 
 ## Environment Variables
 
-Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/cantino/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
+Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/huginn/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
 
 For variables in the .env.example that are commented out, the default is to not include that variable in the generated .env file.
 
 ## Building on your own
 
-You don't need to do this on your own, because there is an [automated build](https://registry.hub.docker.com/u/cantino/huginn/) for this repository, but if you really want run this command in the Huginn root directory:
+You don't need to do this on your own, because there is an [automated build](https://registry.hub.docker.com/u/huginn/huginn/) for this repository, but if you really want run this command in the Huginn root directory:
 
     docker build --rm=true --tag={yourname}/huginn -f docker/multi-process/Dockerfile .
 
 ## Source
 
-The source is [available on GitHub](https://github.com/cantino/huginn/docker/multi-process/).
+The source is [available on GitHub](https://github.com/huginn/huginn/docker/multi-process/).
 
 Please feel free to submit pull requests and/or fork at your leisure.
 

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:14.04
-MAINTAINER Dominik Sander
 
 ADD docker/scripts/prepare /scripts/prepare
 RUN /scripts/prepare
@@ -14,6 +13,9 @@ RUN chown -R huginn:huginn /app && \
     sudo -u huginn -H echo "gem 'sqlite3', '~> 1.3.11'" >> /app/Gemfile && \
     sudo -u huginn -H LC_ALL=en_US.UTF-8 RAILS_ENV=production ON_HEROKU=true bundle install --without test development --path vendor/bundle -j 4
 COPY . /app
+
+ARG OUTDATED_DOCKER_IMAGE_NAMESPACE=false
+ENV OUTDATED_DOCKER_IMAGE_NAMESPACE ${OUTDATED_DOCKER_IMAGE_NAMESPACE}
 
 ADD ["docker/scripts/setup", "docker/single-process/scripts/init", "/scripts/"]
 

--- a/docker/single-process/README.md
+++ b/docker/single-process/README.md
@@ -1,9 +1,9 @@
 Docker image for Huginn using the production environment and separate container for every process
 =================================================
 
-This image runs a linkable [Huginn](https://github.com/cantino/huginn) instance.
+This image runs a linkable [Huginn](https://github.com/huginn/huginn) instance.
 
-It was inspired by the [official docker container for huginn](https://registry.hub.docker.com/u/cantino/huginn)
+It was inspired by the [official docker container for huginn](https://registry.hub.docker.com/u/huginn/huginn)
 
 The scripts/init script generates a .env file containing the variables as passed as per normal Huginn documentation.
 The same environment variables that would be used for Heroku PaaS deployment are used by this script.
@@ -66,18 +66,18 @@ Manual startup and linking to a MySQL container:
         -e DATABASE_NAME=huginn \
         -e DATABASE_USERNAME=huginn \
         -e DATABASE_PASSWORD=somethingsecret \
-        cantino/huginn-single-process
+        huginn/huginn-single-process
 
     docker run --name huginn_threaded \
         --link huginn_mysql:mysql \
         -e DATABASE_NAME=huginn \
         -e DATABASE_USERNAME=huginn \
         -e DATABASE_PASSWORD=somethingsecret \
-        cantino/huginn-single-process /scripts/init bin/threaded.rb
+        huginn/huginn-single-process /scripts/init bin/threaded.rb
 
 ## Environment Variables
 
-Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/cantino/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
+Other Huginn 12factored environment variables of note, as generated and put into the .env file as per Huginn documentation. All variables of the [.env.example](https://github.com/huginn/huginn/blob/master/.env.example) can be used to override the defaults which a read from the current `.env.example`.
 
 For variables in the .env.example that are commented out, the default is to not include that variable in the generated .env file.
 
@@ -89,7 +89,7 @@ You don't need to do this on your own, but if you really want run this command i
 
 ## Source
 
-The source is [available on GitHub](https://github.com/cantino/huginn/docker/single-process/).
+The source is [available on GitHub](https://github.com/huginn/huginn/docker/single-process/).
 
 Please feel free to submit pull requests and/or fork at your leisure.
 

--- a/docker/single-process/docker-compose.yml
+++ b/docker/single-process/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       MYSQL_PASSWORD: myhuginnpassword
 
   huginn_web:
-    image: cantino/huginn-single-process
+    image: huginn/huginn-single-process
     restart: always
     extends:
       file: environment.yml
@@ -31,7 +31,7 @@ services:
       MYSQL_PORT_3306_TCP_PORT: 3306
 
   huginn_threaded:
-    image: cantino/huginn-single-process
+    image: huginn/huginn-single-process
     restart: always
     extends:
       file: environment.yml

--- a/docker/single-process/postgresql.yml
+++ b/docker/single-process/postgresql.yml
@@ -15,7 +15,7 @@ services:
       POSTGRES_USER: huginn
 
   huginn_web:
-    image: cantino/huginn-single-process
+    image: huginn/huginn-single-process
     restart: always
     extends:
       file: environment.yml
@@ -30,7 +30,7 @@ services:
       - postgres
 
   huginn_threaded:
-    image: cantino/huginn-single-process
+    image: huginn/huginn-single-process
     restart: always
     extends:
       file: environment.yml
@@ -44,7 +44,7 @@ services:
     command: /scripts/init bin/threaded.rb
 
   # huginn_schedule:
-  #   image: cantino/huginn-single-process
+  #   image: huginn/huginn-single-process
   #   extends:
   #     file: environment.yml
   #     service: huginn_base
@@ -58,7 +58,7 @@ services:
 
 
   # huginn_twitter_stream:
-  #   image: cantino/huginn-single-process
+  #   image: huginn/huginn-single-process
   #   extends:
   #     file: environment.yml
   #     service: huginn_base
@@ -72,7 +72,7 @@ services:
 
 
   # huginn_dj1:
-  #   image: cantino/huginn-single-process
+  #   image: huginn/huginn-single-process
   #   extends:
   #     file: environment.yml
   #     service: huginn_base


### PR DESCRIPTION
For now we keep pushing to the old namespace but add a warning to users a chance to change their images to the new namespace.

After a few weeks/months we could change the `cantino/huginn*` to a dummy webserver which serves a static page pointing the user to the new image or simply remove them.