### PR TITLE
Added database creation to installation.md

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -108,6 +108,10 @@ Create a user for Huginn do not type the `mysql>`, this is part of the prompt. C
 
     mysql> CREATE USER 'huginn'@'localhost' IDENTIFIED BY '$password';
 
+Create a database for Huginn to use
+
+    mysql> CREATE DATABASE 'huginn_production';
+    
 Ensure you can use the InnoDB engine which is necessary to support long indexes
 
     mysql> SET default_storage_engine=INNODB;


### PR DESCRIPTION
Testing the MySQL configuration with `sudo -u huginn -H mysql -u huginn -p -D huginn_production` fails if the database hasn't been created.

Ubuntu Xenial / MySQL 5.7.