### PR TITLE
Build and publish huginn/huginn-test

### DIFF
--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -17,3 +17,7 @@ if [[ -n "${DOCKER_USER}" && "${TRAVIS_PULL_REQUEST}" = 'false' && "${TRAVIS_BRA
 else
   echo "Docker image are only pushed for builds of the master branch when Docker Hub credentials are present."
 fi
+
+if [[ $DOCKER_IMAGE == "huginn/huginn" ]]; then
+  DOCKER_IMAGE=huginn/huginn-test DOCKERFILE=docker/test/Dockerfile ./build_docker_image.sh
+fi

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -18,6 +18,6 @@ else
   echo "Docker image are only pushed for builds of the master branch when Docker Hub credentials are present."
 fi
 
-if [[ $DOCKER_IMAGE == "huginn/huginn" ]]; then
+if [[ $DOCKER_IMAGE == "huginn/huginn-single-process" ]]; then
   DOCKER_IMAGE=huginn/huginn-test DOCKERFILE=docker/test/Dockerfile ./build_docker_image.sh
 fi


### PR DESCRIPTION
If we publish this docker image, then it will be possible to execute commands from within a huginn development/test environment. For example, it should be possible to test and build an external `huginn_agent` using this docker image:
```
# docker-compose.yml
version: '2'

services:
  ...
  huginn_gem_build:
    image: huginn/huginn_test
    environment:
      DATABASE_ADAPTER: postgresql
      TEST_DATABASE_NAME: huginn
       ...
    links:
      - postgres
    command: rake prepare spec build
    working_dir: /build
    volumes:
      - .:/build
```

I don't think the Travis job will work until `docker.io/huginn/huginn-test` is created:
```
DOCKER_IMAGE=huginn/huginn-test DOCKERFILE=docker/test/Dockerfile ./build_docker_image.sh

docker pull $DOCKER_IMAGE
Using default tag: latest
Pulling repository docker.io/huginn/huginn-test
Error: image huginn/huginn-test:latest not found
```