### PR TITLE
Upgrade letter_opener_web version to 1.3.1 to support Rails 5.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ group :development do
   gem 'guard-livereload', '~> 2.5.1'
   gem 'guard-rspec', '~> 4.6.4'
   gem 'rack-livereload', '~> 0.3.16'
-  gem 'letter_opener_web', '~> 1.3.0'
+  gem 'letter_opener_web', '~> 1.3.1'
   gem 'web-console', '>= 3.3.0'
 
   gem 'capistrano', '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
-    letter_opener_web (1.3.0)
+    letter_opener_web (1.3.1)
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
@@ -662,7 +662,7 @@ DEPENDENCIES
   jsonpath (~> 0.7.2)
   kaminari!
   kramdown (~> 1.3.3)
-  letter_opener_web (~> 1.3.0)
+  letter_opener_web (~> 1.3.1)
   liquid (~> 4.0)
   listen (~> 3.0.5)
   loofah (~> 2.0)


### PR DESCRIPTION
I noticed that letter_opener_web 1.3.0 doesn't work with rails 5. It still uses before_filter instead of the new before_action syntax causing an exception to be thrown when accessing http://localhost:3000/letter_opener. Upgrading to 1.3.1 fixes the issue.