### PR TITLE
Add runit-information for Debian Stretch

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -55,9 +55,9 @@ Install the required packages (needed to compile Ruby and native extensions to R
 
 ### Debian Stretch
 
-Since Debian Stretch, `runit` isn't started anymore automatically, but this gets handled by the init system. For a default installation use this package:
+Since Debian Stretch, `runit` isn't started anymore automatically, but this gets handled by the init system. Additionally, Ruby requires the OpenSSL 1.0 development packages instead of 1.1. For a default installation use these packages:
 
-     sudo apt-get install -y runit-systemd
+     sudo apt-get install -y runit-systemd libssl1.0-dev
 
 
 ## 2. Ruby

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -53,8 +53,14 @@ Install the required packages (needed to compile Ruby and native extensions to R
     sudo apt-get install -y runit build-essential git zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils pkg-config cmake nodejs graphviz
 
 
-## 2. Ruby
+### Debian Stretch
 
+Since Debian Stretch, `runit` isn't started anymore automatically, but this gets handled by the init system. For a default installation use this package:
+
+     sudo apt-get install -y runit-systemd
+
+
+## 2. Ruby
 
 The use of Ruby version managers such as [RVM](http://rvm.io/), [rbenv](https://github.com/sstephenson/rbenv) or [chruby](https://github.com/postmodern/chruby) with Huginn in production frequently leads to hard-to-diagnose problems. Version managers are not supported and we strongly advise everyone to follow the instructions below to use a system Ruby.
 
@@ -90,7 +96,7 @@ Install the database packages
     # Pick a MySQL root password (can be anything), type it and press enter,
     # retype the MySQL root password and press enter
 
-Check the installed MySQL version (remeber if its >= 5.5.3 for the `.env` configuration done later):
+Check the installed MySQL version (remember if its >= 5.5.3 for the `.env` configuration done later):
 
     mysql --version
 

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -96,6 +96,8 @@ Install the database packages
     # Pick a MySQL root password (can be anything), type it and press enter,
     # retype the MySQL root password and press enter
 
+For Debian Stretch, replace `libmysqlclient-dev` with `default-libmysqlclient-dev`. See the [additional notes section](#additional-notes) for more information.
+
 Check the installed MySQL version (remember if its >= 5.5.3 for the `.env` configuration done later):
 
     mysql --version
@@ -413,3 +415,8 @@ When you want to monitor the background processes you can easily watch all the f
 ### Still having problems? :crying_cat_face:
 
 You probably found an error message or exception backtrace you could not resolve. Please create a new [issue](https://github.com/cantino/huginn/issues) and include as much information as you could gather about the problem your are experiencing.
+
+
+### Additional notes
+
+Debian Stretch switched from MySQL to [MariaDB](https://mariadb.org/). All packages with `mysql` in the name are just wrappers around the MariaDB ones, with some containing some compatibility symlinks. Huginn should also work fine with the MariaDB packages directly, although to keep the installation instructions more compact, they still use the MySQL packages.


### PR DESCRIPTION
I just updated from Debian Jessie to Stretch and ran into some problems.

Since version [2.1.2-4](http://metadata.ftp-master.debian.org/changelogs/main/r/runit/runit_2.1.2-9.2_changelog), which is first offered to Stretch (Jessie is at 2.1.2-3), runit isn't started automatically anymore: `Remove scripting in runit's maintainer scripts to adjust /etc/inittab.`

The starting is now handled by the init system with the package [runit-systemd](https://packages.debian.org/stretch/runit-systemd) or [runit-sysv](https://packages.debian.org/stretch/runit-sysv). As the default init system is _systemd_, I just mentioned the first one. Advanced users that switched it should be able to find the corresponding package.

Also, Stretch now provides ruby 2.3. It might be a good idea to test it with that.