### PR TITLE
Enhance agent association editing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,7 @@ group :development do
   group :test do
     gem 'coveralls', '~> 0.7.4', require: false
     gem 'capybara', '~> 2.13.0'
+    gem 'capybara-screenshot'
     gem 'capybara-select2', require: false
     gem 'delorean'
     gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.17)
+      capybara (>= 1.0, < 3)
+      launchy
     capybara-select2 (1.0.1)
       capybara
       rspec
@@ -625,6 +628,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1.4)
   capistrano-rails (~> 1.1)
   capybara (~> 2.13.0)
+  capybara-screenshot
   capybara-select2
   coffee-rails (~> 4.2)
   coveralls (~> 0.7.4)

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -66,10 +66,6 @@ img.odin {
   display: none;
 }
 
-.controller-region[data-has-controllers=false] {
-  display: none;
-}
-
 .spinner {
   display: none;
   vertical-align: bottom;

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -294,7 +294,7 @@ class Agent < ActiveRecord::Base
   class << self
     def build_clone(original)
       new(original.slice(:type, :options, :service_id, :schedule, :controller_ids, :control_target_ids,
-                         :source_ids, :keep_events_for, :propagate_immediately, :scenario_ids)) { |clone|
+                         :source_ids, :receiver_ids, :keep_events_for, :propagate_immediately, :scenario_ids)) { |clone|
         # Give it a unique name
         2.step do |i|
           name = '%s (%d)' % [original.name, i]

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -51,13 +51,14 @@
               </div>
             </div>
 
-            <div class="controller-region" data-has-controllers="<%= !@agent.controllers.empty? %>">
+            <div class="controller-region">
               <div class="form-group">
                 <%= f.label :controllers %>
                 <span class="glyphicon glyphicon-question-sign hover-help" data-content="Other than the system-defined schedule above, this agent may be run or controlled by these user-defined Agents."></span>
-                <div class="controller-list">
-                  <%= agent_controllers(@agent) || 'None' %>
-                </div>
+                <%= f.select(:controller_ids,
+                             options_for_select(current_user.agents.select(&:can_control_other_agents?).pluck(:name, :id),
+                                                @agent.controller_ids),
+                             {}, { multiple: true, size: 5, class: 'select2-linked-tags form-control', data: {url_prefix: '/agents'}}) %>
               </div>
             </div>
 

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -106,7 +106,7 @@
               <div class="event-related-region">
                 <% eventTargets = (current_user.agents - [@agent]).find_all { |a| a.can_receive_events? } %>
                 <%= f.select(:receiver_ids,
-                             options_for_select(eventTargets.map {|s| [s.name, s.id] },
+                             options_for_select(eventTargets.pluck(:name, :id),
                                                 @agent.receiver_ids),
                              {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
                 <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require 'capybara/rails'
 require 'capybara/poltergeist'
+require 'capybara-screenshot/rspec'
 require 'capybara-select2'
 
 CAPYBARA_TIMEOUT = ENV['CI'] == 'true' ? 60 : 5
@@ -11,6 +12,8 @@ end
 
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
+
+Capybara::Screenshot.prune_strategy = { keep: 3 }
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -17,6 +17,71 @@ describe "Creating a new agent", js: true do
     expect(page).to have_text("Test Trigger Agent")
   end
 
+  context "with associated agents" do
+    let!(:bob_scheduler_agent) {
+      Agents::SchedulerAgent.create!(
+        user: users(:bob),
+        name: 'Example Scheduler',
+        options: {
+          'action' => 'run',
+          'schedule' => '0 * * * *'
+        },
+      )
+    }
+
+    let!(:bob_weather_agent) {
+      agents(:bob_weather_agent)
+    }
+
+    let!(:bob_formatting_agent) {
+      agents(:bob_formatting_agent).tap { |agent|
+        # Make this valid
+        agent.options['instructions']['foo'] = 'bar'
+        agent.save!
+      }
+    }
+
+    it "creates an agent with a source and a receiver" do
+      visit "/"
+      page.find("a", text: "Agents").trigger(:mouseover)
+      click_on("New Agent")
+
+      select_agent_type("Trigger Agent")
+      fill_in(:agent_name, with: "Test Trigger Agent")
+
+      select2("SF Weather", from: 'Sources')
+      select2("Formatting Agent", from: 'Receivers')
+
+      click_on "Save"
+
+      expect(page).to have_text("Test Trigger Agent")
+
+      agent = Agent.find_by(name: "Test Trigger Agent")
+
+      expect(agent.sources).to eq([bob_weather_agent])
+      expect(agent.receivers).to eq([bob_formatting_agent])
+    end
+
+    it "creates an agent with a control target" do
+      visit "/"
+      page.find("a", text: "Agents").trigger(:mouseover)
+      click_on("New Agent")
+
+      select_agent_type("Scheduler Agent")
+      fill_in(:agent_name, with: "Test Scheduler Agent")
+
+      select2("SF Weather", from: 'Control targets')
+
+      click_on "Save"
+
+      expect(page).to have_text("Test Scheduler Agent")
+
+      agent = Agent.find_by(name: "Test Scheduler Agent")
+
+      expect(agent.control_targets).to eq([bob_weather_agent])
+    end
+  end
+
   it "creates an alert if a new agent with invalid json is submitted" do
     visit "/"
     page.find("a", text: "Agents").trigger(:mouseover)

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -80,6 +80,25 @@ describe "Creating a new agent", js: true do
 
       expect(agent.control_targets).to eq([bob_weather_agent])
     end
+
+    it "creates an agent with a controller" do
+      visit "/"
+      page.find("a", text: "Agents").trigger(:mouseover)
+      click_on("New Agent")
+
+      select_agent_type("Weather Agent")
+      fill_in(:agent_name, with: "Test Weather Agent")
+
+      select2("Example Scheduler", from: 'Controllers')
+
+      click_on "Save"
+
+      expect(page).to have_text("Test Weather Agent")
+
+      agent = Agent.find_by(name: "Test Weather Agent")
+
+      expect(agent.controllers).to eq([bob_scheduler_agent])
+    end
   end
 
   it "creates an alert if a new agent with invalid json is submitted" do


### PR DESCRIPTION
Here's what this PR is about:

- Receivers are inherited when cloning an agent.
- Controllers are selectable from the agent edit form.