### PR TITLE
Upgrade mysql2 gem to 0.4.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -198,7 +198,7 @@ if_true(ENV['DATABASE_ADAPTER'].strip == 'postgresql') do
 end
 
 if_true(ENV['DATABASE_ADAPTER'].strip == 'mysql2') do
-  gem 'mysql2', '~> 0.3.20'
+  gem 'mysql2', ">= 0.3.18", "< 0.5"
 end
 
 GemfileHelper.parse_each_agent_gem(ENV['ADDITIONAL_GEMS']) do |args|

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.20)
+    mysql2 (0.4.8)
     naught (1.1.0)
     nenv (0.2.0)
     net-ftp-list (3.2.8)
@@ -673,7 +673,7 @@ DEPENDENCIES
   mini_magick
   mqtt
   multi_xml
-  mysql2 (~> 0.3.20)
+  mysql2 (>= 0.3.18, < 0.5)
   net-ftp-list (~> 3.2.8)
   nokogiri
   omniauth (~> 1.3.1)


### PR DESCRIPTION
Rails 5.1 supports the `mysql2` gem [up until (but not including) 0.5][1]

Version `0.4.7` [added support for MariaDB 10.2 ][2]

Fixes #2064

[1]: https://github.com/rails/rails/blob/5-1-stable/railties/lib/rails/generators/app_base.rb#L275
[2]: https://github.com/brianmario/mysql2/releases/tag/0.4.7