### PR TITLE
Add validations for `mode` values in EventFormattingAgent

### DIFF
--- a/app/models/agents/event_formatting_agent.rb
+++ b/app/models/agents/event_formatting_agent.rb
@@ -84,7 +84,7 @@ module Agents
     event_description do
       "Events will have the following fields%s:\n\n    %s" % [
         case options['mode'].to_s
-        when 'merged'
+        when 'merge'
           ', merged with the original contents'
         when /\{/
           ', conditionally merged with the original contents'
@@ -97,6 +97,10 @@ module Agents
 
     def validate_options
       errors.add(:base, "instructions and mode need to be present.") unless options['instructions'].present? && options['mode'].present?
+
+      if options['mode'].present? && !options['mode'].to_s.include?('{{') && !%[clean merge].include?(options['mode'].to_s)
+        errors.add(:base, "mode must be 'clean' or 'merge'")
+      end
 
       validate_matchers
     end

--- a/spec/models/agents/event_formatting_agent_spec.rb
+++ b/spec/models/agents/event_formatting_agent_spec.rb
@@ -188,5 +188,25 @@ describe Agents::EventFormattingAgent do
       @checker.options[:mode] = ""
       expect(@checker).not_to be_valid
     end
+
+    it "requires mode to be 'clean' or 'merge'" do
+      @checker.options['mode'] = 'what?'
+      expect(@checker).not_to be_valid
+
+      @checker.options['mode'] = 'clean'
+      expect(@checker).to be_valid
+
+      @checker.options['mode'] = 'merge'
+      expect(@checker).to be_valid
+
+      @checker.options['mode'] = :clean
+      expect(@checker).to be_valid
+
+      @checker.options['mode'] = :merge
+      expect(@checker).to be_valid
+
+      @checker.options['mode'] = '{{somekey}}'
+      expect(@checker).to be_valid
+    end
   end
 end

--- a/spec/models/agents/event_formatting_agent_spec.rb
+++ b/spec/models/agents/event_formatting_agent_spec.rb
@@ -74,6 +74,12 @@ describe Agents::EventFormattingAgent do
       expect(Event.last.payload[:content]).not_to eq(nil)
     end
 
+    it "should handle Liquid templating in mode" do
+      @checker.options[:mode] = "{{'merge'}}"
+      @checker.receive([@event])
+      expect(Event.last.payload[:content]).not_to eq(nil)
+    end
+
     it "should handle Liquid templating in instructions" do
       @checker.receive([@event])
       expect(Event.last.payload[:message]).to eq("Received Some Lorem Ipsum from somevalue .")


### PR DESCRIPTION
Fix conditional event_description. Should check for `merge` instead of `merged`.