### PR TITLE
Issue 2054

### DIFF
--- a/app/models/agents/rss_agent.rb
+++ b/app/models/agents/rss_agent.rb
@@ -230,7 +230,7 @@ module Agents
         url: feed.url,
         links: feed.links,
         title: feed.title,
-        description: feed.description,
+        description: feed.try(:description),
         copyright: feed.copyright,
         generator: feed.generator,
         icon: feed.icon,


### PR DESCRIPTION
PR to attempt addressing Issue #2054 
The more I looked into this, I more I think this is an issue with FeedJira, there are other fields that are missing, `copyright` for example.  However, those values return null correctly.  Regardless, in the interim, here is a fix that at least resolved my exact issue. 

### Before 
```
[00:00:00] INFO -- : Dry Run started
[00:00:00] ERROR -- : Failed to fetch https://www.youtube.com/feeds/videos.xml?channel_id=UCoTLdfNePDQzvdEgIToLIUg with message 'undefined method `description' for #<Feedjira::Parser::AtomYoutube:0x00564b82bd9880>': ["/home/huginn/huginn/app/models/agents/rss_agent.rb:233:in `feed_data'", "/home/huginn/huginn/app/models/agents/rss_agent.rb:319:in `feed_to_events'",[SNIP]
```
### After  
```
 [
  {
    "feed": {
      "id": "yt:channel:UCoTLdfNePDQzvdEgIToLIUg",
      "type": "atom",
      "url": "https://www.youtube.com/channel/UCoTLdfNePDQzvdEgIToLIUg",
      "links": [
        {
          "href": "http://www.youtube.com/feeds/videos.xml?channel_id=UCoTLdfNePDQzvdEgIToLIUg",
          "rel": "self"
        },
        {
          "href": "https://www.youtube.com/channel/UCoTLdfNePDQzvdEgIToLIUg",
          "rel": "alternate"
        }
      ],
      "title": "SecDSM",
      "description": null,
      "copyright": null,
      "generator": null,
      "icon": null,
      "authors": [
        "SecDSM (https://www.youtube.com/channel/UCoTLdfNePDQzvdEgIToLIUg)"
      ],
      "date_published": "2016-07-28T18:46:21+00:00",
      "last_updated": "2016-07-28T18:46:21+00:00"
    },

```


