### PR TITLE
Load .env.test instead of .env.development when running rspec

### DIFF
--- a/lib/gemfile_helper.rb
+++ b/lib/gemfile_helper.rb
@@ -1,5 +1,15 @@
 class GemfileHelper
   class << self
+    def rails_env
+      ENV['RAILS_ENV'] ||
+        case File.basename($0)
+        when 'rspec'
+          'test'
+        when 'rake'
+          'test' if ARGV.any? { |arg| /\Aspec(?:\z|:)/ === arg }
+        end || 'development'
+    end
+
     def load_dotenv
       dotenv_dir = Dir[File.join(File.dirname(__FILE__), '../vendor/gems/dotenv-[0-9]*')].sort.last
 
@@ -14,7 +24,7 @@ class GemfileHelper
       root = Pathname.new(File.join(File.dirname(__FILE__), '..'))
       sanity_check Dotenv.load(
                                 root.join(".env.local"),
-                                root.join(".env.#{ENV['RAILS_ENV'] || 'development'}"),
+                                root.join(".env.#{rails_env}"),
                                 root.join(".env")
                               )
     end


### PR DESCRIPTION
Currently GemfileHelper loads .env.development when running rspec without RAILS_ENV set to `test`, and it could lead to unexpected database access and stuff.