### PR TITLE
Upgrade omniauth to prevent Hashie warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem 'loofah', '~> 2.0'
 gem 'mini_magick'
 gem 'multi_xml'
 gem 'nokogiri'
-gem 'omniauth', '~> 1.3.1'
+gem 'omniauth', '~> 1.6.1'
 gem 'rails', '~> 5.1.1'
 gem 'rufus-scheduler', '~> 3.3.2', require: false
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.2)
-    hashie (3.5.5)
+    hashie (3.5.6)
     haversine (0.3.0)
     hipchat (1.2.0)
       httparty
@@ -402,9 +402,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
     omniauth-37signals (1.0.5)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.0)
@@ -699,7 +699,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.18, < 0.5)
   net-ftp-list (~> 3.2.8)
   nokogiri
-  omniauth (~> 1.3.1)
+  omniauth (~> 1.6.1)
   omniauth-37signals
   omniauth-dropbox
   omniauth-evernote


### PR DESCRIPTION
Hashie `>= 3.5.0` warns when build in methods are overridden. Omniauth 'fixed' the warning by silencing the logger.