### PR TITLE
Prevent PeakDetectorAgent from storing invalid data in it's memory

### DIFF
--- a/app/models/agents/peak_detector_agent.rb
+++ b/app/models/agents/peak_detector_agent.rb
@@ -138,7 +138,7 @@ module Agents
     def remember(group, event)
       memory['data'] ||= {}
       memory['data'][group] ||= []
-      memory['data'][group] << [ Utils.value_at(event.payload, interpolated['value_path']), event.created_at.to_i ]
+      memory['data'][group] << [ Utils.value_at(event.payload, interpolated['value_path']).to_f, event.created_at.to_i ]
       cleanup group
     end
 

--- a/spec/models/agents/peak_detector_agent_spec.rb
+++ b/spec/models/agents/peak_detector_agent_spec.rb
@@ -78,6 +78,13 @@ describe Agents::PeakDetectorAgent do
                                   :pattern => { 'filter' => "something" })
       expect(@agent.memory['peaks']['something'].length).to eq(1)
     end
+
+    it 'raised an exception if the extracted data can not be casted to a float' do
+      event = Event.new(payload: {count: ["not working"]})
+      expect {
+        @agent.receive([event])
+      }.to raise_error(NoMethodError, /undefined method `to_f'/)
+    end
   end
 
   describe "validation" do


### PR DESCRIPTION
The Agent expects the data in its memory groups to be castable to a
float. By attempting the type cast when receiving events we prevent the
memory from being corrupted with invalid data which lead exceptions
while trying to access it.

 #2101