### PR TITLE
Switch back to the upstream heroku-buildpack-graphviz

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/cantino/heroku-selectable-procfile.git
 https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/dsander/heroku-buildpack-graphviz.git
+https://github.com/weibeld/heroku-buildpack-graphviz.git


### PR DESCRIPTION
The upstream added an additional change for Graphviz to work on heroku-16 after 00dffe32 (#1998).