### PR TITLE
Fix DataOutputAgent so that it can output items with multiple categories

### DIFF
--- a/spec/models/agents/data_output_agent_spec.rb
+++ b/spec/models/agents/data_output_agent_spec.rb
@@ -7,6 +7,7 @@ describe Agents::DataOutputAgent do
     _agent = Agents::DataOutputAgent.new(:name => 'My Data Output Agent')
     _agent.options = _agent.default_options.merge('secrets' => ['secret1', 'secret2'], 'events_to_show' => 3)
     _agent.options['template']['item']['pubDate'] = "{{date}}"
+    _agent.options['template']['item']['category'] = "{{ category | as_object }}"
     _agent.user = users(:bob)
     _agent.sources << agents(:bob_website_agent)
     _agent.save!
@@ -122,7 +123,8 @@ describe Agents::DataOutputAgent do
           "site_title" => "XKCD",
           "url" => "http://imgs.xkcd.com/comics/evolving.png",
           "title" => "Evolving",
-          "hovertext" => "Biologists play reverse Pokemon, trying to avoid putting any one team member on the front lines long enough for the experience to cause evolution."
+          "hovertext" => "Biologists play reverse Pokemon, trying to avoid putting any one team member on the front lines long enough for the experience to cause evolution.",
+          "category" => []
         }
       end
 
@@ -132,7 +134,8 @@ describe Agents::DataOutputAgent do
           "url" => "http://imgs.xkcd.com/comics/evolving2.png",
           "title" => "Evolving again",
           "date" => '',
-          "hovertext" => "Something else"
+          "hovertext" => "Something else",
+          "category" => ["Category 1", "Category 2"]
         }
       end
 
@@ -142,7 +145,8 @@ describe Agents::DataOutputAgent do
           "url" => "http://imgs.xkcd.com/comics/evolving0.png",
           "title" => "Evolving yet again with a past date",
           "date" => '2014/05/05',
-          "hovertext" => "A small text"
+          "hovertext" => "A small text",
+          "category" => ["Some category"]
         }
       end
 
@@ -169,6 +173,7 @@ describe Agents::DataOutputAgent do
             <description>Secret hovertext: A small text</description>
             <link>http://imgs.xkcd.com/comics/evolving0.png</link>
             <pubDate>#{Time.zone.parse(event3.payload['date']).rfc2822}</pubDate>
+            <category>Some category</category>
             <guid isPermaLink="false">#{event3.id}</guid>
            </item>
 
@@ -177,6 +182,8 @@ describe Agents::DataOutputAgent do
             <description>Secret hovertext: Something else</description>
             <link>http://imgs.xkcd.com/comics/evolving2.png</link>
             <pubDate>#{event2.created_at.rfc2822}</pubDate>
+            <category>Category 1</category>
+            <category>Category 2</category>
             <guid isPermaLink="false">#{event2.id}</guid>
            </item>
 
@@ -233,6 +240,7 @@ describe Agents::DataOutputAgent do
               'link' => 'http://imgs.xkcd.com/comics/evolving0.png',
               'guid' => {"contents" => event3.id, "isPermaLink" => "false"},
               'pubDate' => Time.zone.parse(event3.payload['date']).rfc2822,
+              'category' => ['Some category'],
               'foo' => 'hi'
             },
             {
@@ -241,6 +249,7 @@ describe Agents::DataOutputAgent do
               'link' => 'http://imgs.xkcd.com/comics/evolving2.png',
               'guid' => {"contents" => event2.id, "isPermaLink" => "false"},
               'pubDate' => event2.created_at.rfc2822,
+              'category' => ['Category 1', 'Category 2'],
               'foo' => 'hi'
             },
             {
@@ -249,6 +258,7 @@ describe Agents::DataOutputAgent do
               'link' => 'http://imgs.xkcd.com/comics/evolving.png',
               'guid' => {"contents" => event1.id, "isPermaLink" => "false"},
               'pubDate' => event1.created_at.rfc2822,
+              'category' => [],
               'foo' => 'hi'
             }
           ]
@@ -551,6 +561,7 @@ describe Agents::DataOutputAgent do
           "title" => "Evolving",
           "hovertext" => "Biologists play reverse Pokemon, trying to avoid putting any one team member on the front lines long enough for the experience to cause evolution.",
           "media_url" => "http://google.com/audio.mpeg",
+          "category" => ["Category 1", "Category 2"],
           "foo" => 1
         }
       end
@@ -565,6 +576,7 @@ describe Agents::DataOutputAgent do
             'link' => 'http://imgs.xkcd.com/comics/evolving.png',
             'guid' => {"contents" => event.id, "isPermaLink" => "false"},
             'pubDate' => event.created_at.rfc2822,
+            'category' => ['Category 1', 'Category 2'],
             'enclosure' => {
               "type" => "audio/mpeg",
               "url" => "http://google.com/audio.mpeg"
@@ -614,6 +626,8 @@ describe Agents::DataOutputAgent do
              <description>Secret hovertext: Biologists play reverse Pokemon, trying to avoid putting any one team member on the front lines long enough for the experience to cause evolution.</description>
              <link>http://imgs.xkcd.com/comics/evolving.png</link>
              <pubDate>#{event.created_at.rfc2822}</pubDate>
+             <category>Category 1</category>
+             <category>Category 2</category>
              <enclosure type="audio/mpeg" url="http://google.com/audio.mpeg" />
              <foo attr="attr-value-1">Foo: 1</foo>
              <nested key="value"><title>some title</title></nested>


### PR DESCRIPTION
The to_xml method encodes `{ "category": ["a", "b"] }` as follows:
```xml
<item>
 <category>
  <category>a</category>
  <category>b</category>
 </category>
</item>
```
Instead of this:
```xml
<item>
 <category>a</category>
 <category>b</category>
</item>
```
Even if `category` is a singular noun.  This feature prevents DataOutputAgent from emitting multiple `<category>` elements (or `<enclosure>`, etc.) properly, so I've added a tweak to fix the resulted XML document.

I know the code in the current form is far from optimal, so I think we'll have to revisit here soon or later...