### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -128,7 +128,7 @@ describe "Creating a new agent", js: true do
     end
 
     it "does not show the target select2 field when the agent can not create events" do
-      select_agent_type("Growl Agent")
+      select_agent_type("Email Agent")
       expect(page).to have_content('This type of Agent cannot create events.')
     end
   end


### PR DESCRIPTION
The `select_agent_type` helper is waiting for the options editor to be
initialized, which will never happen for Agents that are
FormConfigurable. The GrowlAgent was recently changed to
FormConfigurable which mean the spec should always have failed.
I have no idea how it passes on CI in some cases but this should fix the
'random' failures.