### PR TITLE
Add `working` and `url` to AgentDrop for diagnostic purposes

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -466,4 +466,12 @@ class AgentDrop
       @object.__send__(attr)
     } unless method_defined?(attr)
   }
+
+  def working
+    @object.working?
+  end
+
+  def url
+    Rails.application.routes.url_helpers.agent_url(@object, Rails.application.config.action_mailer.default_url_options)
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,6 @@ Huginn::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
-  config.action_mailer.default_url_options = { :host => ENV['DOMAIN'] }
+  config.action_mailer.default_url_options = { host: ENV['DOMAIN'] || 'localhost' }
   config.action_mailer.perform_deliveries = true
 end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1041,4 +1041,22 @@ describe AgentDrop do
     expect(interpolate(t, @wsa2)).to eq('1: Formatter')
     expect(interpolate(t, @efa)).to eq('0: ')
   end
+
+  it 'should have .working' do
+    stub(@wsa1).working? { false }
+    stub(@wsa2).working? { true }
+    stub(@efa).working? { false }
+
+    t = '{% if agent.working %}healthy{% else %}unhealthy{% endif %}'
+    expect(interpolate(t, @wsa1)).to eq('unhealthy')
+    expect(interpolate(t, @wsa2)).to eq('healthy')
+    expect(interpolate(t, @efa)).to eq('unhealthy')
+  end
+
+  it 'should have .url' do
+    t = '{{ agent.url }}'
+    expect(interpolate(t, @wsa1)).to eq("http://localhost/agents/#{@wsa1.id}")
+    expect(interpolate(t, @wsa2)).to eq("http://localhost/agents/#{@wsa2.id}")
+    expect(interpolate(t, @efa)).to  eq("http://localhost/agents/#{@efa.id}")
+  end
 end


### PR DESCRIPTION
Huginn does not currently allow access to the `working?` status of each agent, or the URL for use in notifications for quick access to the agent.

This PR is the first step to adding the ability to self-diagnose Huginn.  The next step may be to add a global Liquid variable to access all agents so user can enumerate non-working agents and emit an alert event.