### PR TITLE
Enhance the tweets view of TwitterStreamAgent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 | DateOfChange   | Changes                                                                                                      |
 |----------------|--------------------------------------------------------------------------------------------------------------|
+| Sep 15, 2017   | Tweets view of `TwitterStreamAgent` has been enhanced. [2122](https://github.com/huginn/huginn/pull/2122) |
 | Sep 09, 2017   | Agent objects in Liquid templating now have new properties `working` and `url`. [2118](https://github.com/huginn/huginn/pull/2118) |
 | Sep 06, 2017   | `DataOutputAgent` includes an icon in a podcast feed. [2114](https://github.com/huginn/huginn/pull/2114) |
 | Sep 05, 2017   | `DataOutputAgent` can properly output an RSS feed with items containing  multiple categories, enclosures, etc. [2110](https://github.com/huginn/huginn/pull/2110) |

--- a/app/assets/javascripts/tweets.js.coffee
+++ b/app/assets/javascripts/tweets.js.coffee
@@ -1,0 +1,10 @@
+$ ->
+  $('.tweet-body').each ->
+    $(this).click ->
+      twttr.widgets.createTweet(
+        this.dataset.tweetId
+        this
+        # conversation: 'none'
+        # cards: 'hidden'
+      ).then (el) ->
+        el.previousSibling.style.display = 'none'

--- a/app/assets/javascripts/tweets.js.coffee
+++ b/app/assets/javascripts/tweets.js.coffee
@@ -1,6 +1,7 @@
 $ ->
   $('.tweet-body').each ->
     $(this).click ->
+      $(this).off('click')
       twttr.widgets.createTweet(
         this.dataset.tweetId
         this

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -326,3 +326,15 @@ $service-colors: (
   -webkit-transform: scaleX(-1);
   transform: scaleX(-1);
 }
+
+.tweet-body {
+  .tweet-plain {
+    cursor: help;
+  }
+
+  .twitter-tweet-rendered {
+    display: inline !important;
+    margin: 0 !important;
+    vertical-align: bottom !important;
+  }
+}

--- a/app/views/agents/agent_views/twitter_stream_agent/_show.html.erb
+++ b/app/views/agents/agent_views/twitter_stream_agent/_show.html.erb
@@ -1,20 +1,22 @@
 <% content_for :head do %>
   <%= javascript_include_tag "graphing" %>
+  <%= javascript_include_tag "tweets" %>
+  <%= javascript_include_tag "//platform.twitter.com/widgets.js", charset: "utf-8", async: "async" %>
 <% end %>
 
 <% grouped_events = @agent.events.order("id desc").limit(2000).group_by {|e| e.payload[:filter] || e.payload[:match] }%>
 <% if grouped_events.length > 0 %>
   <% if @agent.options[:generate] == "events" %>
-
     <h3>Recent Tweets</h3>
-      <% grouped_events.each do |filter, group|  %>
+    <% grouped_events.each do |filter, group| %>
       <div class="filter-group tweets">
         <div class='filter'><%= filter %></div>
         <% group.each do |event| %>
-          <% next unless event.payload[:text].present? %>
-          <div class='tweet'>
-            <%= event.payload[:text] %> - <%= link_to event.payload[:user][:screen_name], "http://twitter.com/#{event.payload[:user][:screen_name]}" %>
-          </div>
+          <% tweet = event.payload %>
+          <% text = tweet.dig(:extended_tweet, :full_text) %>
+          <% next unless text.present? %>
+          <% screen_name = tweet.dig(:user, :screen_name) %>
+          <div class='tweet'><span class="tweet-body" data-tweet-id='<%= tweet[:id_str] %>'><span class="tweet-plain" title="Click to expand"><%= link_to "@#{screen_name}", "https://twitter.com/#{screen_name}" %>: <%= text %> - <%= link_to l(Time.zone.parse(tweet[:created_at]), format: :long), "https://twitter.com/#{screen_name}/status/#{tweet[:id_str]}" %></span></span> (<%= link_to 'event', event_path(id: event.id) %>)</div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/agents/agent_views/twitter_stream_agent/_show.html.erb
+++ b/app/views/agents/agent_views/twitter_stream_agent/_show.html.erb
@@ -16,7 +16,7 @@
           <% text = tweet.dig(:extended_tweet, :full_text) %>
           <% next unless text.present? %>
           <% screen_name = tweet.dig(:user, :screen_name) %>
-          <div class='tweet'><span class="tweet-body" data-tweet-id='<%= tweet[:id_str] %>'><span class="tweet-plain" title="Click to expand"><%= link_to "@#{screen_name}", "https://twitter.com/#{screen_name}" %>: <%= text %> - <%= link_to l(Time.zone.parse(tweet[:created_at]), format: :long), "https://twitter.com/#{screen_name}/status/#{tweet[:id_str]}" %></span></span> (<%= link_to 'event', event_path(id: event.id) %>)</div>
+          <div class='tweet'><span class="tweet-body" data-tweet-id='<%= tweet[:id_str] %>'><span class="tweet-plain" title="Click to expand"><%= link_to "@#{screen_name}", "https://twitter.com/#{URI.encode(screen_name)}" %>: <%= text %> - <%= link_to l(Time.zone.parse(tweet[:created_at]), format: :long), "https://twitter.com/#{URI.encode(screen_name)}/status/#{URI.encode(tweet[:id_str])}" %></span></span> (<%= link_to 'event', event_path(id: event.id) %>)</div>
         <% end %>
       </div>
     <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,7 +10,7 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets (application.js.coffee.erb, application.css, and all non-JS/CSS are already added)
-Rails.application.config.assets.precompile += %w( diagram.js graphing.js map_marker.js ace.js )
+Rails.application.config.assets.precompile += %w( diagram.js graphing.js map_marker.js ace.js tweets.js )
 
 Rails.application.config.assets.precompile += %w(*.png *.jpg *.jpeg *.gif)
 Rails.application.config.assets.precompile += %w(*.woff *.eot *.svg *.ttf) # Bootstrap fonts


### PR DESCRIPTION
The tweets view of TwitterStreamAgent lacks some essential properties of each tweet necessary to identify the tweet and the corresponding event, so I'd like to enhance it.

- Use the `extended_tweet.full_text` property instead of `text`
- Show the time and links to the tweet and event for each tweet
- Clicking on the tweet text replaces it with the embedded tweet widget