### PR TITLE
Fix default scenario links

### DIFF
--- a/data/default_scenario.json
+++ b/data/default_scenario.json
@@ -33,7 +33,7 @@
       "disabled": false,
       "guid": "505c9bba65507c40e5786afff36f688c",
       "options": {
-        "url": "http://xkcd.com",
+        "url": "https://xkcd.com",
         "mode": "on_change",
         "expected_update_period_in_days": 5,
         "extract": {
@@ -97,7 +97,7 @@
       "disabled": false,
       "guid": "e9afa65457d0a736b9ec20a8dd452fc8",
       "options": {
-        "url": "http://trailers.apple.com/trailers/home/rss/newtrailers.rss",
+        "url": "https://trailers.apple.com/trailers/home/rss/newtrailers.rss",
         "mode": "on_change",
         "type": "xml",
         "expected_update_period_in_days": 5,


### PR DESCRIPTION
The http links for XKCD and Apple trailers don't work. Unforunately that gives a bad first impression when the default config doesn't work
Using HTTPS they work fine.

Edit: wording