### PR TITLE
Fix Run Event Propagation search action

### DIFF
--- a/app/assets/javascripts/components/search.js.coffee
+++ b/app/assets/javascripts/components/search.js.coffee
@@ -11,7 +11,7 @@ $ ->
       if !(navigationData instanceof Object) || !navigationData.method || navigationData.method == 'GET'
         window.location = navigationData.url || navigationData
       else
-        $("<a href='#{navigationData.url}' data-method='#{navigationData.method}'></a>").appendTo($("body")).click()
+        $.rails.handleMethod.apply $("<a href='#{navigationData.url}' data-method='#{navigationData.method}'></a>").appendTo($("body")).get(0)
 
   # substring matcher for typeahead
   substringMatcher = (strings) ->

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1063,8 +1063,8 @@ describe AgentDrop do
 
   it 'should have .url' do
     t = '{{ agent.url }}'
-    expect(interpolate(t, @wsa1)).to eq("http://localhost/agents/#{@wsa1.id}")
-    expect(interpolate(t, @wsa2)).to eq("http://localhost/agents/#{@wsa2.id}")
-    expect(interpolate(t, @efa)).to  eq("http://localhost/agents/#{@efa.id}")
+    expect(interpolate(t, @wsa1)).to match(/http:\/\/localhost(?::\d+)?\/agents\/#{@wsa1.id}/)
+    expect(interpolate(t, @wsa2)).to match(/http:\/\/localhost(?::\d+)?\/agents\/#{@wsa2.id}/)
+    expect(interpolate(t, @efa)).to  match(/http:\/\/localhost(?::\d+)?\/agents\/#{@efa.id}/)
   end
 end


### PR DESCRIPTION
Browsers no longer allow synthetic clicks with `$.click` on a link, so we can co-opt the `$.rails` method instead.

I also fixed a spec that wasn't expecting a port in the URL. I'm not sure why I'm getting this failing spec locally:

```
1) Agents::ShellCommandAgent#check with unbundle set to true should be run outside of our bundler context
     Failure/Error: expect(Event.last.payload[:output].strip).to eq('') # not_to eq(ENV['BUNDLE_GEMFILE']

       expected: ""
            got: "/Users/andrew/projects/oss/huginn/Gemfile"

       (compared using ==)
     # ./spec/models/agents/shell_command_agent_spec.rb:167:in `block (5 levels) in <top (required)>'
```