### PR TITLE
Handle lazy loading of Agents in gems during Agent.receive!

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -383,7 +383,14 @@ class Agent < ActiveRecord::Base
 
         agents_to_events = {}
         Agent.connection.select_rows(sql).each do |receiver_agent_id, source_agent_type, receiver_agent_type, event_id|
-          next unless const_defined?(source_agent_type) && const_defined?(receiver_agent_type)
+
+          begin
+            Object.const_get(source_agent_type)
+            Object.const_get(receiver_agent_type)
+          rescue NameError
+            next
+          end
+
           agents_to_events[receiver_agent_id.to_i] ||= []
           agents_to_events[receiver_agent_id.to_i] << event_id
         end


### PR DESCRIPTION
I was having Events fail to propagate and traced it back to my Agent Gem not showing up as `const_defined?` in `Agent.receive!`. Inspired by https://github.com/rails-api/active_model_serializers/pull/615/files, I updated this, and it seems to have fixed the issue for me.