### PR TITLE
Fix dry-run modal when clicking on icon in 'Dry Run' button

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js.coffee
+++ b/app/assets/javascripts/pages/agent-edit-page.js.coffee
@@ -220,7 +220,7 @@ class @AgentEditPage
   invokeDryRun: (e) =>
     e.preventDefault()
     @updateFromEditors()
-    Utils.handleDryRunButton(e.target)
+    Utils.handleDryRunButton(e.currentTarget)
 
   formatAgentForSelect = (agent) ->
     originalOption = agent.element

--- a/spec/features/dry_running_spec.rb
+++ b/spec/features/dry_running_spec.rb
@@ -23,6 +23,12 @@ describe "Dry running an Agent", js: true do
         to_return(:status => 200, :body => File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), :headers => {})
     end
 
+    it 'opens the dry run modal even when clicking on the refresh icon' do
+      visit edit_agent_path(agent)
+      find('.agent-dry-run-button span.glyphicon').click
+      expect(page).to have_text('Event to send (Optional)')
+    end
+
     it 'shows the dry run pop up without previous events and selects the events tab when a event was created' do
       open_dry_run_modal(agent)
       click_on("Dry Run")


### PR DESCRIPTION
tl;dr: By using `e.currentTarget` instead of `e.target` we ensure to always pass the `button` element to `Utils.handleDryRunButton`.

`target` refers to the actual element the user clicked on, we then passed the glyphicon span to `Utils.handleDryRunButton` which requested `window.location` via ajax because `$(button).data('action-url')` returned `undefined`.
Evaluating the whole page then triggered `Error: rails-ujs has already been loaded!`, as a result the user can not interact with anything that requires `rails-ujs`, `jquery` or bootstrap javascript.