### PR TITLE
Upgrade jquery.jsoneditor to handle null values

### DIFF
--- a/vendor/assets/javascripts/jquery.json-editor.js
+++ b/vendor/assets/javascripts/jquery.json-editor.js
@@ -544,6 +544,9 @@
         bq.append($('<div class="bracers">}</div>'));
         node.append(bq);
       } else {
+        if (json === null) {
+          json = '';
+        }
         elem = this.editable(json.toString(), key, parent, root, 'value').wrap('<span class="val"></span>').parent();
         node.append(elem);
         node.prepend(this.braceUI(key, parent));


### PR DESCRIPTION
Fixes the editor in dry-runs when working with events that include `null` values.

https://github.com/cantino/jsoneditor/pull/3