### PR TITLE
Update rubies: 2017-09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,26 +29,26 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.3.4
+    - rvm: 2.3.5
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
 rvm:
-- 2.2
-- 2.3.4
-- 2.4.1
+- 2.2.8
+- 2.3.5
+- 2.4.2
 cache: bundler
 bundler_args: --without development production
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -748,7 +748,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.4p301
+   ruby 2.4.2p198
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -71,8 +71,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2 | tar xj
-    cd ruby-2.4.1
+    curl -L --progress http://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2 | tar xj
+    cd ruby-2.4.2
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install


### PR DESCRIPTION
2.4.2, 2.3.5 and 2.2.8  are out.

Specifying "2.4" and "2.3" still does not work on Travis. 😞