### PR TITLE
Clarifying no authentication scenario

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,11 @@ IMPORT_DEFAULT_SCENARIO_FOR_ALL_USERS=true
 # you must also set SEND_EMAIL_IN_DEVELOPMENT to true below.
 #
 # If you have trouble with port 587 on Gmail, you can also try setting
-# SMTP_AUTHENTICATION to login and the SMTP_PORT to 465.
+# SMTP_AUTHENTICATION to login and the SMTP_PORT to 465.  
+# 
+# If you use a local SMTP server without authentication such as Postfix,
+# SMTP_USER_NAME must be set to none or else you will receive
+# errors that AUTH not enabled.
 
 SMTP_DOMAIN=your-domain-here.com
 SMTP_USER_NAME=you@gmail.com


### PR DESCRIPTION
A bit of a counterintuitive solution as I'd logically expect SMTP_AUTHENTICATION to be set to 'none' vs SMTP_USER_NAME but regardless clarifying for local Postfix configs like mine that don't require auth from localhost.