### PR TITLE
Allow usage of custom Liquid tags in LiquidOutputAgent

### DIFF
--- a/app/models/agents/liquid_output_agent.rb
+++ b/app/models/agents/liquid_output_agent.rb
@@ -176,8 +176,7 @@ EOF
     end
 
     def liquified_content
-      template = Liquid::Template.parse(options['content'] || "")
-      template.render(data_for_liquid_template)
+      interpolated(data_for_liquid_template)['content']
     end
 
     def data_for_liquid_template

--- a/spec/models/agents/liquid_output_agent_spec.rb
+++ b/spec/models/agents/liquid_output_agent_spec.rb
@@ -230,6 +230,12 @@ describe Agents::LiquidOutputAgent do
       expect(result).to eq(["The key is #{value}.", 200, mime_type, {"X-My-Custom-Header" => "hello"}])
     end
 
+    it 'should allow the usage custom liquid tags' do
+      agent.options['content'] = "{% credential aws_secret %}"
+      result = agent.receive_web_request params, method, format
+      expect(result).to eq(["1111111111-bob", 200, mime_type, nil])
+    end
+
     describe "and the mode is last event in" do
 
       before { agent.options['mode'] = 'Last event in' }


### PR DESCRIPTION
By using the `interpolated` helper method  our custom tags like
`credential` can be used in the LiquidOutputAgent.

Fixes #2042