### PR TITLE
Add `array` extraction option to WebsiteAgent in HTML/XML mode

### DIFF
--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -1167,6 +1167,16 @@ fire: hot
           last_payload = Event.last.payload
           expect(last_payload['link']).to eq('Random')
         end
+
+        it 'returns an array of found nodes when the array extract_option is true' do
+          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+
+          @checker.options['extract']['nav_links'] = {'css' => '#topLeft li', 'value' => 'normalize-space(.)', 'array' => 'true'}
+          expect {
+            @checker.receive([@event])
+          }.to change { Event.count }.by(1)
+          expect(Event.last.payload['nav_links']).to eq(["Archive", "What If?", "Blag", "Store", "About"])
+        end
       end
 
       describe "with a data_from_event" do


### PR DESCRIPTION
Setting `array` to `true` for an extractor allows the extraction of list
elements into an array or when working with websites that have varying
amount of elements matching a specific selector:

Response A:
```html
<h1>header</h1>
<div id="content">
  <div></div>
  <div></div>
  <div class="bogus"></div>
<div>
```

Response B:
```html
<h1>header</h1>
<div id="content">
  <div></div>
  <div></div>
  <div class="bogus"></div>
  <div></div>
<div>
```

The goal is to extract the header and all `div`s inside `#content` that
are not `.bogus` into one Event. Having the `array` option makes this
possible with `css: '#content div:not(.bogus) ', array: true` which
would otherwise fail with an uneven amount of matches exception.

Currently the work around would be the extract the header and `#content`
in one WebsiteAgent and extract the `div`s in a second Agent. This does
not work in my use case because the HTML inside `#content` is
malformatted and leads to Nokogiri paring errors.