### PR TITLE
Split long Telegram messages

### DIFF
--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -151,11 +151,11 @@ module Agents
         params[:text] = params[:text][0..4095] if params[:text]
         send_message field, params
       elsif field == :text
-        params[:text].scan(/\G(?:\w{4096}|.{1,4096}(?<=\s)|.{1,4096}(?=\b|\z))/m) do |message|
+        params[:text].scan(/\G(?:\w{4096}|.{1,4096}(?=\b|\z))/m) do |message|
           send_message field, configure_params(field => message.strip) unless message.strip.blank?
         end
       else
-        caption_array = params[:caption].scan(/\G(?:\w{200}|.{1,200}(?<=\s)|.{1,200}(?=\b|\z))/m)
+        caption_array = params[:caption].scan(/\G(?:\w{200}|.{1,200}(?=\b|\z))/m)
         params[:caption] = caption_array.first.strip
         send_message field, params
         caption_array.drop(1).each do |caption|

--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -33,10 +33,10 @@ module Agents
 
       **Options**
 
-      * `caption`: caption for a media content, 0-200 characters
+      * `caption`: caption for a media content (0-200 characters)
       * `disable_notification`: send a message silently in a channel
       * `disable_web_page_preview`: disable link previews for links in a text message
-      * `long_message`: split or truncate long text messages or captions
+      * `long_message`: split or truncate text messages or captions that exceeds Telegram API limits
       * `parse_mode`: parse policy of a text message
 
       See the official [Telegram Bot API documentation](https://core.telegram.org/bots/api#available-methods) for detailed info.

--- a/spec/models/agents/telegram_agent_spec.rb
+++ b/spec/models/agents/telegram_agent_spec.rb
@@ -87,13 +87,6 @@ describe Agents::TelegramAgent do
                                    ])
     end
 
-    it 'accepts photo key and uses :send_photo to send the file with correct caption' do
-      event = event_with_payload caption: 'a' * 250, photo: 'https://example.com/image.png'
-      @checker.receive [event]
-
-      expect(@sent_messages).to eq([{ sendPhoto: { caption: 'a'* 200, photo: :stubbed_file } }])
-    end
-
     it 'accepts audio key and uses :send_audio to send the file' do
       event = event_with_payload audio: 'https://example.com/sound.mp3'
       @checker.receive [event]
@@ -106,6 +99,13 @@ describe Agents::TelegramAgent do
       @checker.receive [event]
 
       expect(@sent_messages).to eq([{ sendDocument: { document: :stubbed_file } }])
+    end
+
+    it 'accepts photo key and uses :send_photo to send the file with correct caption' do
+      event = event_with_payload caption: 'a' * 250, photo: 'https://example.com/image.png'
+      @checker.receive [event]
+
+      expect(@sent_messages).to eq([{ sendPhoto: { caption: 'a'* 200, photo: :stubbed_file } }])
     end
 
     it 'accepts video key and uses :send_video to send the file' do

--- a/spec/models/agents/telegram_agent_spec.rb
+++ b/spec/models/agents/telegram_agent_spec.rb
@@ -85,12 +85,18 @@ describe Agents::TelegramAgent do
     it 'processes multiple events properly' do
       event_0 = event_with_payload silent: 'true', text: 'Looks like it is going to rain'
       event_1 = event_with_payload disable_web_page_preview: 'true', long: 'split', text: "#{'a' * 4095} #{'b' * 6}"
-      @checker.receive [event_0, event_1]
+      event_2 = event_with_payload disable_web_page_preview: 'true', long: 'split', text: "#{'a' * 4096}#{'b' * 6}"
+      event_3 = event_with_payload long: 'split', text: "#{'a' * 2142} #{'b' * 2142}"
+      @checker.receive [event_0, event_1, event_2, event_3]
 
       expect(@sent_messages).to eq([
                                     { text: { chat_id: 'xxxxxxxx', disable_notification: 'true', parse_mode: 'html', text: 'Looks like it is going to rain' } },
                                     { text: { chat_id: 'xxxxxxxx', disable_web_page_preview: 'true', parse_mode: 'html', text: 'a' * 4095 } },
-                                    { text: { chat_id: 'xxxxxxxx', disable_web_page_preview: 'true', parse_mode: 'html', text: 'b' * 6 } }
+                                    { text: { chat_id: 'xxxxxxxx', disable_web_page_preview: 'true', parse_mode: 'html', text: 'b' * 6 } },
+                                    { text: { chat_id: 'xxxxxxxx', disable_web_page_preview: 'true', parse_mode: 'html', text: 'a' * 4096 } },
+                                    { text: { chat_id: 'xxxxxxxx', disable_web_page_preview: 'true', parse_mode: 'html', text: 'b' * 6 } },
+                                    { text: { chat_id: 'xxxxxxxx', parse_mode: 'html', text: 'a' * 2142 } },
+                                    { text: { chat_id: 'xxxxxxxx', parse_mode: 'html', text: 'b' * 2142 } }
                                    ])
     end
 


### PR DESCRIPTION
Adds the option to split Telegram messages that exceeds current API limits (4096 characters for texts, 200 for captions) into two or more messages.

Pull request #1793 started to dealing with the same issue, but it appears to be abandoned.

Closes #1750