### PR TITLE
Fix Docker testing README for better GitHub readability

### DIFF
--- a/docker/test/README.md
+++ b/docker/test/README.md
@@ -10,6 +10,7 @@ In Development Mode, the source code of the current project directory is mounted
 ## Development Usage
 
 Build a docker image that contains huginn, as well as huginn test dependencies using `docker-compose`:
+
     cd docker/test
     docker-compose -f develop.yml build
 
@@ -26,5 +27,6 @@ Run all specs against a Postgres database using `docker-compose`:
     docker-compose -f develop.yml down
 
 Run a specific spec using `docker-compose`:
+
     docker-compose -f develop.yml run huginn_test_postgres rspec ./spec/helpers/dot_helper_spec.rb:82
     docker-compose -f develop.yml down


### PR DESCRIPTION
GitHub Markdown doesn't parse code blocks correctly unless there is a line break

Old:
https://github.com/huginn/huginn/blob/aebca456af36cd5c857d3346fc0ed31174d33576/docker/test/README.md

Fixed:
https://github.com/axsuul/huginn/blob/fix/docker-readme/docker/test/README.md
