### PR TITLE
Fix Liquid interpolation in TwilioAgent helper methods

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -66,6 +66,14 @@ module LiquidInterpolatable
     end
   end
 
+  def interpolate_with_each(array)
+    array.each do |object|
+      interpolate_with(object) do
+        yield object
+      end
+    end
+  end
+
   def interpolate_options(options, self_object = nil)
     interpolate_with(self_object) do
       case options

--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -44,16 +44,16 @@ module Agents
 
     def receive(incoming_events)
       memory['pending_calls'] ||= {}
-      incoming_events.each do |event|
+      interpolate_with_each(incoming_events) do |event|
         message = (event.payload['message'].presence || event.payload['text'].presence || event.payload['sms'].presence).to_s
         if message.present?
-          if boolify(interpolated(event)['receive_call'])
+          if boolify(interpolated['receive_call'])
             secret = SecureRandom.hex 3
             memory['pending_calls'][secret] = message
             make_call secret
           end
 
-          if boolify(interpolated(event)['receive_text'])
+          if boolify(interpolated['receive_text'])
             message = message.slice 0..160
             send_message message
           end


### PR DESCRIPTION
The Agent did not use `interpolate_with` in it's `receive` method,
which lead to `interpolated[...]` calls in `send_message` and
`make_call` always returning empty strings.

The new `interpolate_with_each` helper iterates over an array of
objects and yields each object in a `interpolated_with(object)`
context.

Fixes #2186