### PR TITLE
Upgrade rubies to their latest patch release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,31 +29,31 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
     - env: RSPEC_TASK=spec:features
   include:
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=cantino/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
-    - rvm: 2.3.6
+    - rvm: 2.3.7
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=mysql2
-    - rvm: 2.3.6
+    - rvm: 2.3.7
       env: RSPEC_TASK=spec:features DATABASE_ADAPTER=postgresql DATABASE_USERNAME=postgres
 rvm:
-- 2.2.9
-- 2.3.6
-- 2.4.3
-- 2.5.0
+- 2.2.10
+- 2.3.7
+- 2.4.4
+- 2.5.1
 cache: bundler
 bundler_args: --without development production
 script:

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -71,8 +71,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2 | tar xj
-    cd ruby-2.5.0
+    curl -L --progress https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2 | tar xj
+    cd ruby-2.5.1
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install

--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -15,6 +15,9 @@ EOF
 
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
+
+CLEAR_DOCKER_CACHE=2018-04-21
+
 minimal_apt_get_install='apt-get install -y --no-install-recommends'
 
 apt-get update


### PR DESCRIPTION
We use Ruby 2.5.1 for the manual installation guide and the docker
containers and run the specs on the latest 2.5,2.4,2.3 and 2.2 patch
releases.

Fixes #2210