### PR TITLE
Bump rails-html-sanitizer to 1.0.4 to address CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ gem 'multi_xml'
 gem 'nokogiri'
 gem 'omniauth', '~> 1.6.1'
 gem 'rails', '~> 5.1.1'
+gem 'rails-html-sanitizer', '~> 1.0.4'
 gem 'rufus-scheduler', '~> 3.4.2', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     daemons (1.1.9)
     debug_inspector (0.0.2)
     declarative (0.0.9)
@@ -372,7 +372,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
@@ -483,8 +483,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.1)
       actionpack (= 5.1.1)
       activesupport (= 5.1.1)
@@ -725,6 +725,7 @@ DEPENDENCIES
   rack-livereload (~> 0.3.16)
   rails (~> 5.1.1)
   rails-controller-testing
+  rails-html-sanitizer (~> 1.0.4)
   rb-kqueue (>= 0.2)
   rr
   rspec (~> 3.5)
@@ -760,7 +761,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.5.0p0
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Versions below 1.0.4 had a XSS vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2018-3741