### PR TITLE
Pass URLs to Telegram API directly

### DIFF
--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -113,16 +113,7 @@ module Agents
     def load_field(event, field)
       payload = event.payload[field]
       return false unless payload.present?
-      return payload if field == :text
-      load_file payload
-    end
-
-    def load_file(url)
-      file = Tempfile.new [File.basename(url), File.extname(url)]
-      file.binmode
-      file.write open(url).read
-      file.rewind
-      file
+      payload
     end
 
     def receive_event(event)
@@ -131,7 +122,6 @@ module Agents
           payload = load_field event, field
           next unless payload
           send_telegram_messages field, configure_params(field => payload)
-          unlink_file payload if payload.is_a? Tempfile
           true
         end
         error("No valid key found in event #{event.payload.inspect}") if messages_send.zero?
@@ -168,11 +158,6 @@ module Agents
 
     def telegram_bot_uri(method)
       "https://api.telegram.org/bot#{interpolated['auth_token']}/#{method}"
-    end
-
-    def unlink_file(file)
-      file.close
-      file.unlink
     end
 
     def update_to_complete(update)

--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -1,5 +1,4 @@
 require 'httmultiparty'
-require 'open-uri'
 
 module Agents
   class TelegramAgent < Agent

--- a/app/models/agents/telegram_agent.rb
+++ b/app/models/agents/telegram_agent.rb
@@ -1,6 +1,5 @@
 require 'httmultiparty'
 require 'open-uri'
-require 'tempfile'
 
 module Agents
   class TelegramAgent < Agent
@@ -110,17 +109,11 @@ module Agents
       params
     end
 
-    def load_field(event, field)
-      payload = event.payload[field]
-      return false unless payload.present?
-      payload
-    end
-
     def receive_event(event)
       interpolate_with event do
         messages_send = TELEGRAM_ACTIONS.count do |field, _method|
-          payload = load_field event, field
-          next unless payload
+          payload = event.payload[field]
+          next unless payload.present?
           send_telegram_messages field, configure_params(field => payload)
           true
         end

--- a/spec/models/agents/telegram_agent_spec.rb
+++ b/spec/models/agents/telegram_agent_spec.rb
@@ -26,10 +26,6 @@ describe Agents::TelegramAgent do
   end
 
   def stub_methods
-    stub.any_instance_of(Agents::TelegramAgent).load_file do |_url|
-      :stubbed_file
-    end
-
     stub.any_instance_of(Agents::TelegramAgent).send_message do |method, params|
       @sent_messages << { method => params }
     end
@@ -104,7 +100,7 @@ describe Agents::TelegramAgent do
       event = event_with_payload audio: 'https://example.com/sound.mp3', caption: 'a' * 250
       @checker.receive [event]
 
-      expect(@sent_messages).to eq([{ audio: { audio: :stubbed_file, caption: 'a'* 200, chat_id: 'xxxxxxxx' } }])
+      expect(@sent_messages).to eq([{ audio: { audio: 'https://example.com/sound.mp3', caption: 'a'* 200, chat_id: 'xxxxxxxx' } }])
     end
 
     it 'accepts document key and uses :send_document to send the file and the full caption' do
@@ -112,7 +108,7 @@ describe Agents::TelegramAgent do
       @checker.receive [event]
 
       expect(@sent_messages).to eq([
-                                    { document: { caption: 'a' * 199, chat_id: 'xxxxxxxx', document: :stubbed_file } },
+                                    { document: { caption: 'a' * 199, chat_id: 'xxxxxxxx', document: 'https://example.com/document.pdf' } },
                                     { text: { chat_id: 'xxxxxxxx', parse_mode: 'html', text: 'b' * 6 } }
                                    ])
     end
@@ -121,14 +117,14 @@ describe Agents::TelegramAgent do
       event = event_with_payload photo: 'https://example.com/image.png'
       @checker.receive [event]
 
-      expect(@sent_messages).to eq([{ photo: { chat_id: 'xxxxxxxx', photo: :stubbed_file } }])
+      expect(@sent_messages).to eq([{ photo: { chat_id: 'xxxxxxxx', photo: 'https://example.com/image.png' } }])
     end
 
     it 'accepts video key and uses :send_video to send the file' do
       event = event_with_payload video: 'https://example.com/video.avi'
       @checker.receive [event]
 
-      expect(@sent_messages).to eq([{ video: { chat_id: 'xxxxxxxx', video: :stubbed_file } }])
+      expect(@sent_messages).to eq([{ video: { chat_id: 'xxxxxxxx', video: 'https://example.com/video.avi' } }])
     end
 
     it 'creates a log entry when no key of the received event was useable' do


### PR DESCRIPTION
Downloading files to temporary files to re-upload them to Telegram is not necessary.
Telegram accepts URLs (and `file_id`s) in all the media keys (photo, video, document, etc.)
