### PR TITLE
Add link for darksky api key since wunderground no longer free

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ See [private development instructions](https://github.com/huginn/huginn/wiki/Pri
 
 In order to use the WeatherAgent you need an [API key with Wunderground](http://www.wunderground.com/weather/api/). Signup for one and then change the value of `api_key: your-key` in your seeded WeatherAgent.
 
+Note, Wunderground no longer offers free API keys. You can still use the WeatherAgent by setting the service key to darksky, and getting an [API key from DarkSky](https://darksky.net/dev).
+
 #### Disable SSL
 
 We assume your deployment will run over SSL. This is a very good idea! However, if you wish to turn this off, you'll probably need to edit `config/initializers/devise.rb` and modify the line containing `config.rememberable_options = { :secure => true }`.  You will also need to edit `config/environments/production.rb` and modify the value of `config.force_ssl`.


### PR DESCRIPTION
Noticed that following [the wunderground link](http://www.wunderground.com/weather/api/) shows they no longer issue free API keys, preferring instead that you use their "curated" offerings. I thought we might update the readme with a link to darksky, since they still do offer free API keys.