### PR TITLE
Bump sprockets version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ gem 'multi_xml'
 gem 'nokogiri'
 gem 'omniauth', '~> 1.6.1'
 gem 'rails', '~> 5.2.0'
+gem 'sprockets', '~> 3.7.2'
 gem 'rails-html-sanitizer', '~> 1.0.4'
 gem 'rufus-scheduler', '~> 3.4.2', require: false
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-livereload (0.3.16)
       rack
     rack-test (1.0.0)
@@ -593,7 +593,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -756,6 +756,7 @@ DEPENDENCIES
   spring (~> 2.0.2)
   spring-commands-rspec (~> 1.0.4)
   spring-watcher-listen (~> 2.0.1)
+  sprockets (~> 3.7.2)
   therubyracer (~> 0.12.3)
   tumblr_client!
   twilio-ruby (~> 3.11.5)
@@ -777,4 +778,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
This ensures all users are protected against [CVE-2018-3760][1]. Per
default Huginn was not affected by this vulnerability, but users could
have changed `config.assets.compile` to `true` manually.

The new sprockets version fixes the CVE.

#2319

[1]: http://seclists.org/oss-sec/2018/q2/210