### PR TITLE
respect WEB_CONCURRENCY env in unicorn.rb.example

### DIFF
--- a/config/unicorn.rb.example
+++ b/config/unicorn.rb.example
@@ -2,7 +2,7 @@ wd = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 app_path = wd
 
-worker_processes 2
+worker_processes Integer(ENV["WEB_CONCURRENCY"] || 2)
 preload_app true
 timeout 180
 listen "#{wd}/tmp/sockets/unicorn.socket"


### PR DESCRIPTION
...like the example unicorn config for heroku does: https://github.com/huginn/huginn/blob/5868c7b4b23516bce7f7a9867b2310d6ef85980b/deployment/heroku/unicorn.rb#L3