### PR TITLE
Fix IMAP encoding issues

### DIFF
--- a/app/models/agents/imap_folder_agent.rb
+++ b/app/models/agents/imap_folder_agent.rb
@@ -55,7 +55,7 @@ module Agents
 
       Set `mark_as_read` to true to mark found mails as read.
 
-      Set `include_raw_mail` to true to add a `raw_mail` value to each created event, which contains a *Base64-encoded* "RFC822" blob defined in [the IMAP4 standard](https://tools.ietf.org/html/rfc3501).  Note that while the result of Base64 encoding will be LF-terminated, its raw content will often be CRLF-terminated because of the nature of the e-mail protocols and formats.  Its primary use case is to pass to a Shell Command Agent with a command like `openssl enc -d -base64 | tr -d '\r' | procmail -Yf-`.
+      Set `include_raw_mail` to true to add a `raw_mail` value to each created event, which contains a *Base64-encoded* blob in the "RFC822" format defined in [the IMAP4 standard](https://tools.ietf.org/html/rfc3501).  Note that while the result of Base64 encoding will be LF-terminated, its raw content will often be CRLF-terminated because of the nature of the e-mail protocols and formats.  The primary use case for a raw mail blob is to pass to a Shell Command Agent with a command like `openssl enc -d -base64 | tr -d '\r' | procmail -Yf-`.
 
       Each agent instance memorizes the highest UID of mails that are found in the last run for each watched folder, so even if you change a set of conditions so that it matches mails that are missed previously, or if you alter the flag status of already found mails, they will not show up as new events.
 

--- a/app/models/agents/imap_folder_agent.rb
+++ b/app/models/agents/imap_folder_agent.rb
@@ -319,7 +319,7 @@ module Agents
         interpolated['folders'].each { |folder|
           log "Selecting the folder: %s" % folder
 
-          imap.select(folder)
+          imap.select(Net::IMAP.encode_utf7(folder))
           uidvalidity = imap.uidvalidity
 
           lastseenuid = lastseen[uidvalidity]

--- a/app/models/agents/imap_folder_agent.rb
+++ b/app/models/agents/imap_folder_agent.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'delegate'
 require 'net/imap'
 require 'mail'
@@ -54,7 +55,7 @@ module Agents
 
       Set `mark_as_read` to true to mark found mails as read.
 
-      Set `include_raw_mail` to true to add to each created event a raw unencoded mail text, in the so-called "RFC822" format defined in the [IMAP4 standard](https://tools.ietf.org/html/rfc3501).
+      Set `include_raw_mail` to true to add a `raw_mail` value to each created event, which contains a *Base64-encoded* "RFC822" blob defined in [the IMAP4 standard](https://tools.ietf.org/html/rfc3501).  Note that while the result of Base64 encoding will be LF-terminated, its raw content will often be CRLF-terminated because of the nature of the e-mail protocols and formats.  Its primary use case is to pass to a Shell Command Agent with a command like `openssl enc -d -base64 | tr -d '\r' | procmail -Yf-`.
 
       Each agent instance memorizes the highest UID of mails that are found in the last run for each watched folder, so even if you change a set of conditions so that it matches mails that are missed previously, or if you alter the flag status of already found mails, they will not show up as new events.
 
@@ -284,7 +285,7 @@ module Agents
           }
 
           if boolify(interpolated['include_raw_mail'])
-            payload['raw_mail'] = mail.raw_mail
+            payload['raw_mail'] = Base64.encode64(mail.raw_mail)
           end
 
           create_event payload: payload

--- a/spec/models/agents/imap_folder_agent_spec.rb
+++ b/spec/models/agents/imap_folder_agent_spec.rb
@@ -308,8 +308,10 @@ describe Agents::ImapFolderAgent do
               seen[mail.uidvalidity] = mail.uid
             })
 
-          expect(Event.last(2).map(&:payload)).to eq expected_payloads.map.with_index { |payload, i|
-            payload.merge('raw_mail' => mails[i].encoded)
+          expect(Event.last(2).map(&:payload)).to match expected_payloads.map.with_index { |payload, i|
+            payload.merge(
+              'raw_mail' => satisfy { |d| Base64.decode64(d) == mails[i].encoded }
+            )
           }
 
           expect { @checker.check }.not_to change { Event.count }


### PR DESCRIPTION
- Fix handling of non-ASCII folders
- Encode `raw_mail` in Base 64 as discussed in: https://github.com/huginn/huginn/pull/2076