### PR TITLE
Upgrade mysql and pg gems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 | DateOfChange   | Changes                                                                                                      |
 |----------------|--------------------------------------------------------------------------------------------------------------|
+| Oct 03, 2018   | Added support for MySQL 8 and MariaDB 10.3. Dropped support for MySQL < 5.5 and PostgreSQL < 9.2 [2384](https://github.com/huginn/huginn/pull/2384) |
 | Sep 15, 2017   | Tweets view of `TwitterStreamAgent` has been enhanced. [2122](https://github.com/huginn/huginn/pull/2122) |
 | Sep 09, 2017   | Agent objects in Liquid templating now have new properties `working` and `url`. [2118](https://github.com/huginn/huginn/pull/2118) |
 | Sep 06, 2017   | `DataOutputAgent` includes an icon in a podcast feed. [2114](https://github.com/huginn/huginn/pull/2114) |

--- a/Gemfile
+++ b/Gemfile
@@ -200,11 +200,11 @@ ENV['DATABASE_ADAPTER'] ||=
   end
 
 if_true(ENV['DATABASE_ADAPTER'].strip == 'postgresql') do
-  gem 'pg', '~> 0.18.3'
+  gem 'pg', '~> 1.1.3'
 end
 
 if_true(ENV['DATABASE_ADAPTER'].strip == 'mysql2') do
-  gem 'mysql2', ">= 0.3.18", "< 0.5"
+  gem 'mysql2' , "~> 0.5.2"
 end
 
 GemfileHelper.parse_each_agent_gem(ENV['ADDITIONAL_GEMS']) do |args|

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.8)
+    mysql2 (0.5.2)
     naught (1.1.0)
     nenv (0.3.0)
     net-ftp-list (3.2.8)
@@ -454,7 +454,7 @@ GEM
       omniauth-oauth2 (~> 1.1)
     orm_adapter (0.5.0)
     os (0.9.6)
-    pg (0.18.3)
+    pg (1.1.3)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -721,7 +721,7 @@ DEPENDENCIES
   mini_magick
   mqtt
   multi_xml
-  mysql2 (>= 0.3.18, < 0.5)
+  mysql2 (~> 0.5.2)
   net-ftp-list (~> 3.2.8)
   nokogiri
   omniauth (~> 1.6.1)
@@ -731,7 +731,7 @@ DEPENDENCIES
   omniauth-tumblr (~> 1.2)
   omniauth-twitter (~> 1.3.0)
   omniauth-wunderlist
-  pg (~> 0.18.3)
+  pg (~> 1.1.3)
   poltergeist
   pry-byebug
   pry-rails


### PR DESCRIPTION
The new `mysql` version adds support for MySQL 8 and MariaDB 10.x,
support for MySQL 5.0 and 5.1 was dropped, but those have been EOL for
years now.

The new `pg` gem has some compatibility updates for PostgreSQL 10 (which
worked before) and dropped support for PostgreSQL 9.1 which hit its EOL
in 2016.

Fixes #2347