### PR TITLE
Delete stale delayed_job pid file when starting docker containers

### DIFF
--- a/docker/scripts/setup_env
+++ b/docker/scripts/setup_env
@@ -5,6 +5,10 @@ export LC_ALL=en_US.UTF-8
 
 cd /app
 
+if [ -f /app/tmp/pids/delayed_job.pid ]; then
+  rm /app/tmp/pids/delayed_job.pid
+fi
+
 export HOME=/app
 if ! whoami &> /dev/null; then
     if [ -w /etc/passwd ]; then


### PR DESCRIPTION
When a (single-process) docker container is not shut down cleanly
delayed_job does not have a chance to delete it's PID. When restarting
this container delayed_job refused to boot because it found the old PID.

Since we always start from a clean state in docker containers we can
remove the PID.

Fixes #2269