### PR TITLE
Do not seed when a user exists

### DIFF
--- a/db/seeds/seeder.rb
+++ b/db/seeds/seeder.rb
@@ -1,11 +1,11 @@
 class Seeder
   def self.seed
-    user = User.find_or_initialize_by(:email => ENV['SEED_EMAIL'].presence || "admin@example.com")
-    if user.persisted?
-      puts "User with email '#{user.email}' already exists, not seeding."
+    if User.any?
+      puts "At least one User already exists, not seeding."
       exit
     end
 
+    user = User.find_or_initialize_by(:email => ENV['SEED_EMAIL'].presence || "admin@example.com")
     user.username = ENV['SEED_USERNAME'].presence || "admin"
     user.password = ENV['SEED_PASSWORD'].presence || "password"
     user.password_confirmation = ENV['SEED_PASSWORD'].presence || "password"


### PR DESCRIPTION
Previously the seed logic ran when `SEED_EMAIL` was unset and the `admin`
users email address was changed, or if `SEED_EMAIL` did not match it
anymore.

We run `db:seed` on every docker container start to make it easy to get
started with Huginn. That could lead to situations in which the
container did not start if the admin users email address was changed (the
Seeder failed due to the uniqueness constraint on `username`).

Since we "seed" the database I think it is best to bail out of the
seeding logic as long as at least one user exists.

Fixes #2362