### PR TITLE
Fix name of Twitter event field in TwitterUserAgent

### DIFF
--- a/app/models/agents/twitter_user_agent.rb
+++ b/app/models/agents/twitter_user_agent.rb
@@ -28,7 +28,7 @@ module Agents
       Events are the raw JSON provided by the [Twitter API](https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline). Should look something like:
           {
              ... every Tweet field, including ...
-            "text": "something",
+            "full_text": "something",
             "user": {
               "name": "Mr. Someone",
               "screen_name": "Someone",


### PR DESCRIPTION
The field is actually called `full_text`.