### PR TITLE
Add HTTP Headers to Webhook Agent

### DIFF
--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -90,16 +90,15 @@ module Agents
         JSON.parse(response.body)['success'] or
           return ["Not Authorized", 401]
       end
-        
 
       [payload_for(params)].flatten.each do |payload|
-        if interpolated['header_key'].presence 
-          acceptedheaders = (interpolated['headers']).split(/,/).map { |x| x.strip }.select
+        if interpolated['header_key'].present?
+          acceptedheaders = interpolated['headers'].split(/,/).map { |x| x.strip }
           payload[interpolated['header_key']] = headers.slice(*acceptedheaders)
         end
         create_event(payload: payload)
       end
-      
+
       if interpolated['response_headers'].presence
         [interpolated(params)['response'] || 'Event Created', code, "text/plain", interpolated['response_headers'].presence]
       else

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -1,12 +1,12 @@
 module Agents
-  class Webhook2Agent < Agent
+  class WebhookAgent < Agent
     include WebRequestConcern
 
     cannot_be_scheduled!
     cannot_receive_events!
 
     description do <<-MD
-      The Webhook2 Agent will create events by receiving webhooks from any source. In order to create events with this agent, make a POST request to:
+      The Webhook Agent will create events by receiving webhooks from any source. In order to create events with this agent, make a POST request to:
 
       ```
          https://#{ENV['DOMAIN']}/users/#{user.id}/web_requests/#{id || ':id'}/#{options['secret'] || ':secret'}

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -548,7 +548,7 @@ describe Agents::WebhookAgent do
         expect(out).to eq(['Event Created', 201])
         expect(Event.last.payload).to eq(payload)
       end
-      it "should not pass selected headers specified in Header_Key" do
+      it "should pass selected headers specified in Header_Key" do
         webpayload = ActionDispatch::Request.new({
             'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
             'REQUEST_METHOD' => "POST",
@@ -567,7 +567,7 @@ describe Agents::WebhookAgent do
         expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{"HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
       end
       
-      it "should not pass empty header_key if none of the headers exist" do
+      it "should pass empty header_key if none of the headers exist" do
         webpayload = ActionDispatch::Request.new({
             'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
             'REQUEST_METHOD' => "POST",
@@ -586,7 +586,7 @@ describe Agents::WebhookAgent do
         expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{}})
       end
 
-      it "should not pass empty header_key if headers is empty" do
+      it "should pass empty header_key if headers is empty" do
         webpayload = ActionDispatch::Request.new({
             'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
             'REQUEST_METHOD' => "POST",

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Agents::WebhookAgent do
   let(:agent) do
     _agent = Agents::WebhookAgent.new(:name => 'webhook',
-                                      :options => { 'secret' => 'foobar', 'payload_path' => 'some_key' })
+                                      :options => { 'secret' => 'foobar', 'payload_path' => 'some_key', 'headers' => 'HTTP_ACCEPT, HTTP_X_HELLO_WORLD', 'header_key' => 'X-HTTP-HEADERS' })
     _agent.user = users(:bob)
     _agent.save!
     _agent
@@ -12,82 +12,143 @@ describe Agents::WebhookAgent do
 
   describe 'receive_web_request' do
     it 'should create event if secret matches' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(1)
       expect(out).to eq(['Event Created', 201])
       expect(Event.last.payload).to eq(payload)
     end
 
     it 'should be able to create multiple events when given an array' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
       out = nil
       agent.options['payload_path'] = 'some_key.people'
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(2)
       expect(out).to eq(['Event Created', 201])
       expect(Event.last.payload).to eq({ 'name' => 'jon' })
     end
 
     it 'should not create event if secrets do not match' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "bazbat", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'bazbat', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(0)
       expect(out).to eq(['Not Authorized', 401])
     end
 
     it 'should respond with customized response message if configured with `response` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = 'That Worked'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['That Worked', 201])
 
       # Empty string is a valid response
       agent.options['response'] = ''
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['', 201])
     end
 
     it 'should respond with interpolated response message if configured with `response` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = '{{some_key.people[1].name}}'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['jon', 201])
     end
 
     it 'should respond with custom response header if configured with `response_headers` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
       agent.options['response_headers'] = {"X-My-Custom-Header" => 'hello'}
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201, "text/plain", {"X-My-Custom-Header" => 'hello'}])
     end
 
     it 'should respond with `Event Created` if the response option is nil or missing' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = nil
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
 
       agent.options.delete('response')
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
     end
 
     it 'should respond with customized response code if configured with `code` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['code'] = '200'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 200])
     end
 
     it 'should respond with `201` if the code option is empty, nil or missing' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['code'] = ''
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
       
       agent.options['code'] = nil
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
 
       agent.options.delete('code')
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
     end
 
@@ -96,17 +157,31 @@ describe Agents::WebhookAgent do
       context "default settings" do
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use POST requests only', 401])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
@@ -118,25 +193,46 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'get,post' }
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use GET/POST requests only', 401])
         end
@@ -148,17 +244,31 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'get' }
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use GET requests only', 401])
         end
@@ -170,17 +280,31 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'post' }
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use POST requests only', 401])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
@@ -192,25 +316,46 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'put' }
 
         it "should accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT requests only', 401])
         end
 
         it "should not accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT requests only', 401])
         end
@@ -222,33 +367,61 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = ',,  PUT,POST, gEt , ,' }
 
         it "should accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept DELETE" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "DELETE",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "delete", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT/POST/GET requests only', 401])
         end
@@ -257,6 +430,13 @@ describe Agents::WebhookAgent do
 
       context "with reCAPTCHA" do
         it "should not check a reCAPTCHA response unless recaptcha_secret is set" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           checked = false
           out = nil
 
@@ -266,7 +446,7 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out= agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out= agent.receive_web_request(webpayload)
           }.not_to change { checked }
 
           expect(out).to eq(["Event Created", 201])
@@ -275,6 +455,13 @@ describe Agents::WebhookAgent do
         it "should reject a request if recaptcha_secret is set but g-recaptcha-response is not given" do
           agent.options['recaptcha_secret'] = 'supersupersecret'
 
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           checked = false
           out = nil
 
@@ -284,7 +471,7 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.not_to change { checked }
 
           expect(out).to eq(["Not Authorized", 401])
@@ -292,18 +479,25 @@ describe Agents::WebhookAgent do
 
         it "should reject a request if recaptcha_secret is set and g-recaptcha-response given is not verified" do
           agent.options['recaptcha_secret'] = 'supersupersecret'
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload, 'g-recaptcha-response' => 'somevalue'}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
 
           checked = false
           out = nil
 
           stub_request(:any, /verify/).to_return { |request|
+            puts gotrequest
             checked = true
-            { status: 200, body: '{"success":false}' }
+           { status: 200, body: '{"success":false}' }
           }
-
-          expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload, 'g-recaptcha-response' => 'somevalue' }, "post", "text/html")
+         expect {
+            out = agent.receive_web_request(webpayload)
           }.to change { checked }
+          
 
           expect(out).to eq(["Not Authorized", 401])
         end
@@ -311,6 +505,12 @@ describe Agents::WebhookAgent do
         it "should accept a request if recaptcha_secret is set and g-recaptcha-response given is verified" do
           agent.options['payload_path'] = '.'
           agent.options['recaptcha_secret'] = 'supersupersecret'
+          webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'g-recaptcha-response' => 'somevalue'}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
 
           checked = false
           out = nil
@@ -321,12 +521,88 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out = agent.receive_web_request(payload.merge({ 'secret' => 'foobar', 'g-recaptcha-response' => 'somevalue' }), "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { checked }
 
           expect(out).to eq(["Event Created", 201])
           expect(Event.last.payload).to eq(payload)
         end
+      end
+    end
+    context "with Headers" do
+      it "should not pass any headers if Header_Key is not set" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['header_key'] = ''
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq(payload)
+      end
+      it "should not pass selected headers specified in Header_Key" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = 'HTTP_X_HELLO_WORLD'
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{"HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
+      end
+      
+      it "should not pass empty header_key if none of the headers exist" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = 'HTTP_X_HELLO_WORLD1'
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{}})
+      end
+
+      it "should not pass empty header_key if headers is empty" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = ''
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{}})
       end
 
     end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -24,7 +24,7 @@ describe Agents::WebhookAgent do
         out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(1)
       expect(out).to eq(['Event Created', 201])
-      expect(Event.last.payload).to eq(payload)
+      expect(Event.last.payload).to eq( {"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{"HTTP_ACCEPT"=>"application/xml", "HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
     end
 
     it 'should be able to create multiple events when given an array' do
@@ -40,7 +40,7 @@ describe Agents::WebhookAgent do
         out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(2)
       expect(out).to eq(['Event Created', 201])
-      expect(Event.last.payload).to eq({ 'name' => 'jon' })
+      expect(Event.last.payload).to eq({"name"=>"jon", "X-HTTP-HEADERS"=>{"HTTP_ACCEPT"=>"application/xml", "HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
     end
 
     it 'should not create event if secrets do not match' do
@@ -490,9 +490,8 @@ describe Agents::WebhookAgent do
           out = nil
 
           stub_request(:any, /verify/).to_return { |request|
-            puts gotrequest
             checked = true
-           { status: 200, body: '{"success":false}' }
+            { status: 200, body: '{"success":false}' }
           }
          expect {
             out = agent.receive_web_request(webpayload)
@@ -543,7 +542,7 @@ describe Agents::WebhookAgent do
         out = nil
 
         expect {
-          out= agent.receive_web_request(webpayload)
+          out = agent.receive_web_request(webpayload)
         }.to change { Event.count }.by(1)
         expect(out).to eq(['Event Created', 201])
         expect(Event.last.payload).to eq(payload)


### PR DESCRIPTION
This adds the received HTTP_* headers to the Webhook Agent. This is useful for services such as GitHub that sent the Webhook Type as a header.

As Per issue #2431 

