### PR TITLE
Improve #2434 (Add HTTP Headers to Webhook Agent)

### DIFF
--- a/app/concerns/event_headers_concern.rb
+++ b/app/concerns/event_headers_concern.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module EventHeadersConcern
+  private
+
+  def validate_event_headers_options!
+    event_headers_payload({})
+  rescue ArgumentError => e
+    errors.add(:base, e.message)
+  rescue Liquid::Error => e
+    errors.add(:base, "has an error with Liquid templating: #{e.message}")
+  end
+
+  def event_headers_normalizer
+    case interpolated['event_headers_style']
+    when nil, '', 'capitalized'
+      ->name { name.gsub(/[^-]+/, &:capitalize) }
+    when 'downcased'
+      :downcase.to_proc
+    when 'snakecased', nil
+      ->name { name.tr('A-Z-', 'a-z_') }
+    when 'raw'
+      :itself.to_proc
+    else
+      raise ArgumentError, "if provided, event_headers_style must be 'capitalized', 'downcased', 'snakecased' or 'raw'"
+    end
+  end
+
+  def event_headers_key
+    case key = interpolated['event_headers_key']
+    when nil, String
+      key.presence
+    else
+      raise ArgumentError, "if provided, event_headers_key must be a string"
+    end
+  end
+
+  def event_headers_payload(headers)
+    key = event_headers_key or return {}
+
+    normalize = event_headers_normalizer
+
+    hash = headers.transform_keys(&normalize)
+
+    names =
+      case event_headers = interpolated['event_headers']
+      when Array
+        event_headers.map(&:to_s)
+      when String
+        event_headers.split(',')
+      when nil
+        nil
+      else
+        raise ArgumentError, "if provided, event_headers must be an array of strings or a comma separated string"
+      end
+
+    {
+      key => names ? hash.slice(*names.map(&normalize)) : hash
+    }
+  end
+end

--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -1,6 +1,7 @@
 module Agents
   class WebhookAgent < Agent
-    include WebRequestConcern
+    include EventHeadersConcern
+    include WebRequestConcern  # to make reCAPTCHA verification requests
 
     cannot_be_scheduled!
     cannot_receive_events!
@@ -22,8 +23,8 @@ module Agents
         * `payload_path` - JSONPath of the attribute in the POST body to be
           used as the Event payload.  Set to `.` to return the entire message.
           If `payload_path` points to an array, Events will be created for each element.
-        * `headers` - Comma-separated list of HTTP headers your agent will include in the payload.
-        * `header_key` - The key to use to store all the headers recieved
+        * `event_headers` - Comma-separated list of HTTP headers your agent will include in the payload.
+        * `event_headers_key` - The key to use to store all the headers received
         * `verbs` - Comma-separated list of http verbs your agent will accept.
           For example, "post,get" will enable POST and GET requests. Defaults
           to "post".
@@ -46,15 +47,20 @@ module Agents
       { "secret" => "supersecretstring",
         "expected_receive_period_in_days" => 1,
         "payload_path" => "some_key",
-        "headers" => "",
-        "header_key" => "X-HTTP-HEADERS"
+        "event_headers" => "",
+        "event_headers_key" => "headers"
       }
     end
 
     def receive_web_request(request)
       params = request.params.except(:action, :controller, :agent_id, :user_id, :format)
       method = request.method_symbol.to_s
-      headers = request.headers.select {|k,v| k.to_s[/^HTTP_/]}.to_h
+      headers = request.headers.each_with_object({}) { |(name, value), hash|
+        case name
+        when /\AHTTP_([A-Z0-9_]+)\z/
+          hash[$1.tr('_', '-').gsub(/[^-]+/, &:capitalize)] = value
+        end
+      }
 
       # check the secret
       secret = params.delete('secret')
@@ -94,11 +100,7 @@ module Agents
       end
 
       [payload_for(params)].flatten.each do |payload|
-        if interpolated['header_key'].present?
-          acceptedheaders = interpolated['headers'].split(/,/).map { |x| x.strip }
-          payload[interpolated['header_key']] = headers.slice(*acceptedheaders)
-        end
-        create_event(payload: payload)
+        create_event(payload: payload.merge(event_headers_payload(headers)))
       end
 
       if interpolated['response_headers'].presence
@@ -124,6 +126,8 @@ module Agents
       if options['code'].to_s.in?(['301', '302']) && !options['response'].present?
         errors.add(:base, "Must specify a url for request redirect")
       end
+
+      validate_event_headers_options!
     end
 
     def payload_for(params)

--- a/spec/models/agents/post_agent_spec.rb
+++ b/spec/models/agents/post_agent_spec.rb
@@ -52,7 +52,7 @@ describe Agents::PostAgent do
           raise "unexpected Content-Type: #{content_type}"
         end
       end
-      { status: 200, body: "<html>a webpage!</html>", headers: { 'Content-type' => 'text/html' } }
+      { status: 200, body: "<html>a webpage!</html>", headers: { 'Content-type' => 'text/html', 'X-Foo-Bar' => 'baz' } }
     }
   end
 
@@ -272,23 +272,30 @@ describe Agents::PostAgent do
 
         it "emits the response headers capitalized by default" do
           @checker.check
-          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html' })
+          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html', 'X-Foo-Bar' => 'baz' })
         end
 
         it "emits the response headers capitalized" do
           @checker.options['event_headers_style'] = 'capitalized'
           @checker.check
-          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html' })
+          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'text/html', 'X-Foo-Bar' => 'baz' })
         end
 
         it "emits the response headers downcased" do
           @checker.options['event_headers_style'] = 'downcased'
           @checker.check
-          expect(@checker.events.last.payload['headers']).to eq({ 'content-type' => 'text/html' })
+          expect(@checker.events.last.payload['headers']).to eq({ 'content-type' => 'text/html', 'x-foo-bar' => 'baz' })
         end
 
         it "emits the response headers snakecased" do
           @checker.options['event_headers_style'] = 'snakecased'
+          @checker.check
+          expect(@checker.events.last.payload['headers']).to eq({ 'content_type' => 'text/html', 'x_foo_bar' => 'baz' })
+        end
+
+        it "emits the response headers only including those specified by event_headers" do
+          @checker.options['event_headers_style'] = 'snakecased'
+          @checker.options['event_headers'] = 'content-type'
           @checker.check
           expect(@checker.events.last.payload['headers']).to eq({ 'content_type' => 'text/html' })
         end

--- a/spec/models/agents/webhook_agent_spec.rb
+++ b/spec/models/agents/webhook_agent_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Agents::WebhookAgent do
   let(:agent) do
     _agent = Agents::WebhookAgent.new(:name => 'webhook',
-                                      :options => { 'secret' => 'foobar', 'payload_path' => 'some_key' })
+                                      :options => { 'secret' => 'foobar', 'payload_path' => 'some_key', 'headers' => 'HTTP_ACCEPT, HTTP_X_HELLO_WORLD', 'header_key' => 'X-HTTP-HEADERS' })
     _agent.user = users(:bob)
     _agent.save!
     _agent
@@ -12,82 +12,143 @@ describe Agents::WebhookAgent do
 
   describe 'receive_web_request' do
     it 'should create event if secret matches' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(1)
       expect(out).to eq(['Event Created', 201])
-      expect(Event.last.payload).to eq(payload)
+      expect(Event.last.payload).to eq( {"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{"HTTP_ACCEPT"=>"application/xml", "HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
     end
 
     it 'should be able to create multiple events when given an array' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
       out = nil
       agent.options['payload_path'] = 'some_key.people'
       expect {
-        out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(2)
       expect(out).to eq(['Event Created', 201])
-      expect(Event.last.payload).to eq({ 'name' => 'jon' })
+      expect(Event.last.payload).to eq({"name"=>"jon", "X-HTTP-HEADERS"=>{"HTTP_ACCEPT"=>"application/xml", "HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
     end
 
     it 'should not create event if secrets do not match' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "bazbat", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       out = nil
       expect {
-        out = agent.receive_web_request({ 'secret' => 'bazbat', 'some_key' => payload }, "post", "text/html")
+        out = agent.receive_web_request(webpayload)
       }.to change { Event.count }.by(0)
       expect(out).to eq(['Not Authorized', 401])
     end
 
     it 'should respond with customized response message if configured with `response` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = 'That Worked'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['That Worked', 201])
 
       # Empty string is a valid response
       agent.options['response'] = ''
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['', 201])
     end
 
     it 'should respond with interpolated response message if configured with `response` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = '{{some_key.people[1].name}}'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['jon', 201])
     end
 
     it 'should respond with custom response header if configured with `response_headers` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
       agent.options['response_headers'] = {"X-My-Custom-Header" => 'hello'}
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201, "text/plain", {"X-My-Custom-Header" => 'hello'}])
     end
 
     it 'should respond with `Event Created` if the response option is nil or missing' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['response'] = nil
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
 
       agent.options.delete('response')
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
     end
 
     it 'should respond with customized response code if configured with `code` option' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['code'] = '200'
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 200])
     end
 
     it 'should respond with `201` if the code option is empty, nil or missing' do
+      webpayload = ActionDispatch::Request.new({
+          'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+          'REQUEST_METHOD' => "POST",
+          'HTTP_ACCEPT' => 'application/xml',
+          'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+        })
+
       agent.options['code'] = ''
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
-      
+
       agent.options['code'] = nil
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
 
       agent.options.delete('code')
-      out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+      out = agent.receive_web_request(webpayload)
       expect(out).to eq(['Event Created', 201])
     end
 
@@ -96,17 +157,31 @@ describe Agents::WebhookAgent do
       context "default settings" do
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use POST requests only', 401])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
@@ -118,25 +193,46 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'get,post' }
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use GET/POST requests only', 401])
         end
@@ -148,17 +244,31 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'get' }
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use GET requests only', 401])
         end
@@ -170,17 +280,31 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'post' }
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use POST requests only', 401])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
@@ -192,25 +316,46 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = 'put' }
 
         it "should accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT requests only', 401])
         end
 
         it "should not accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT requests only', 401])
         end
@@ -222,33 +367,61 @@ describe Agents::WebhookAgent do
         before { agent.options['verbs'] = ',,  PUT,POST, gEt , ,' }
 
         it "should accept PUT" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "PUT",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "put", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept GET" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "GET",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "get", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should accept POST" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(1)
           expect(out).to eq(['Event Created', 201])
         end
 
         it "should not accept DELETE" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "DELETE",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           out = nil
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "delete", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { Event.count }.by(0)
           expect(out).to eq(['Please use PUT/POST/GET requests only', 401])
         end
@@ -257,6 +430,13 @@ describe Agents::WebhookAgent do
 
       context "with reCAPTCHA" do
         it "should not check a reCAPTCHA response unless recaptcha_secret is set" do
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           checked = false
           out = nil
 
@@ -266,7 +446,7 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out= agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out= agent.receive_web_request(webpayload)
           }.not_to change { checked }
 
           expect(out).to eq(["Event Created", 201])
@@ -275,6 +455,13 @@ describe Agents::WebhookAgent do
         it "should reject a request if recaptcha_secret is set but g-recaptcha-response is not given" do
           agent.options['recaptcha_secret'] = 'supersupersecret'
 
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
+
           checked = false
           out = nil
 
@@ -284,7 +471,7 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload }, "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.not_to change { checked }
 
           expect(out).to eq(["Not Authorized", 401])
@@ -292,6 +479,12 @@ describe Agents::WebhookAgent do
 
         it "should reject a request if recaptcha_secret is set and g-recaptcha-response given is not verified" do
           agent.options['recaptcha_secret'] = 'supersupersecret'
+          webpayload = ActionDispatch::Request.new({
+              'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload, 'g-recaptcha-response' => 'somevalue'}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
 
           checked = false
           out = nil
@@ -300,9 +493,8 @@ describe Agents::WebhookAgent do
             checked = true
             { status: 200, body: '{"success":false}' }
           }
-
-          expect {
-            out = agent.receive_web_request({ 'secret' => 'foobar', 'some_key' => payload, 'g-recaptcha-response' => 'somevalue' }, "post", "text/html")
+         expect {
+            out = agent.receive_web_request(webpayload)
           }.to change { checked }
 
           expect(out).to eq(["Not Authorized", 401])
@@ -311,6 +503,12 @@ describe Agents::WebhookAgent do
         it "should accept a request if recaptcha_secret is set and g-recaptcha-response given is verified" do
           agent.options['payload_path'] = '.'
           agent.options['recaptcha_secret'] = 'supersupersecret'
+          webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'g-recaptcha-response' => 'somevalue'}),
+              'REQUEST_METHOD' => "POST",
+              'HTTP_ACCEPT' => 'application/xml',
+              'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+            })
 
           checked = false
           out = nil
@@ -321,12 +519,88 @@ describe Agents::WebhookAgent do
           }
 
           expect {
-            out = agent.receive_web_request(payload.merge({ 'secret' => 'foobar', 'g-recaptcha-response' => 'somevalue' }), "post", "text/html")
+            out = agent.receive_web_request(webpayload)
           }.to change { checked }
 
           expect(out).to eq(["Event Created", 201])
           expect(Event.last.payload).to eq(payload)
         end
+      end
+    end
+    context "with Headers" do
+      it "should not pass any headers if Header_Key is not set" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['header_key'] = ''
+
+        out = nil
+
+        expect {
+          out = agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq(payload)
+      end
+      it "should pass selected headers specified in Header_Key" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = 'HTTP_X_HELLO_WORLD'
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{"HTTP_X_HELLO_WORLD"=>"Hello Huginn"}})
+      end
+
+      it "should pass empty header_key if none of the headers exist" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = 'HTTP_X_HELLO_WORLD1'
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{}})
+      end
+
+      it "should pass empty header_key if headers is empty" do
+        webpayload = ActionDispatch::Request.new({
+            'action_dispatch.request.request_parameters' => payload.merge({"secret" => "foobar", 'some_key' => payload}),
+            'REQUEST_METHOD' => "POST",
+            'HTTP_ACCEPT' => 'application/xml',
+            'HTTP_X_HELLO_WORLD' => "Hello Huginn"
+          })
+
+        agent.options['headers'] = ''
+
+        out = nil
+
+        expect {
+          out= agent.receive_web_request(webpayload)
+        }.to change { Event.count }.by(1)
+        expect(out).to eq(['Event Created', 201])
+        expect(Event.last.payload).to eq({"people"=>[{"name"=>"bob"}, {"name"=>"jon"}], "X-HTTP-HEADERS"=>{}})
       end
 
     end


### PR DESCRIPTION
This PR is based on and adds some improvements to #2434.  Here's a list of what I've done:

- Use the real header names instead of those in the `HTTP_FOO_BAR` format
- Extract a logic for including a header hash in event payloads from PostAgent, with the `event_headers_style` option
- Rename `headers` to `event_headers` (and accept an array of strings also)
- Rename `header_key` to `event_headers_key`
- Introduce EventHeadersConcern which implements all above to be shared among PostAgent and WebhookAgent
  - I'm also working on making ImapAgent use it to add email headers to its event payloads.
- Squash the commits into one removing file mode changes and whitespace diffs

/cc @Fishwaldo