### PR TITLE
Fix for Bundler 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,8 @@ ruby '>=2.3.0'
 
 # Ensure github repositories are fetched using HTTPS
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"
-end if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2')
+end
 
 # Load vendored dotenv gem and .env file
 require File.join(File.dirname(__FILE__), 'lib/gemfile_helper.rb')

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-# Ruby 2.2.2 is the minimum requirement
-ruby [Gem::Version.new('2.2.2'), Gem::Version.new(RUBY_VERSION)].max
+ruby '>=2.3.0'
 
 # Ensure github repositories are fetched using HTTPS
 git_source(:github) do |repo_name|


### PR DESCRIPTION
`bundle install` fails as below if bundler >=2 is installed (along with 1.17) because of the "if" clause of the `git_source(:github)` override.  We need to enable it also for bundler >=2.

```
The git source `git://github.com/dsander/erector.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
The git source `git://github.com/albertsun/weibo_2.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
...
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

If this is a development machine, remove the /path/to/huginn/Gemfile freeze
by running `bundle install --no-deployment`.

Bundler is unlocking ruby: (version
2.5.3
2.6.0)

You have added to the Gemfile:
* source: git://github.com/Hirurg103/capybara_select2.git (at fbf22fb)
* source: git://github.com/albertsun/tumblr_client.git (at e046fe6)
* source: git://github.com/albertsun/weibo_2.git (at master)
* source: git://github.com/bamorim/omniauth-dropbox-oauth2.git (at 3504670)
* source: git://github.com/cantino/twitter-stream.git (at huginn)
* source: git://github.com/dsander/delayed_job_active_record.git (at rails52)
* source: git://github.com/dsander/dropbox-api.git (at 86cb7b5)
* source: git://github.com/dsander/erector.git (at fix-fixnum-warning)
* source: git://github.com/sferik/twitter.git (at master)

You have deleted from the Gemfile:
* source: https://github.com/Hirurg103/capybara_select2.git (at fbf22fb@fbf22fb)
* source: https://github.com/albertsun/tumblr_client.git (at e046fe6@e046fe6)
* source: https://github.com/albertsun/weibo_2.git (at master@ac38d04)
* source: https://github.com/bamorim/omniauth-dropbox-oauth2.git (at 3504670@3504670)
* source: https://github.com/cantino/twitter-stream.git (at huginn@a80822d)
* source: https://github.com/dsander/delayed_job_active_record.git (at rails52@8efc7b1)
* source: https://github.com/dsander/dropbox-api.git (at 86cb7b5@86cb7b5)
* source: https://github.com/dsander/erector.git (at fix-fixnum-warning@9ee3667)
* source: https://github.com/sferik/twitter.git (at master@d11707e)
```
