### PR TITLE
Update manual installation instructions

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -59,6 +59,11 @@ Since Debian Stretch, `runit` isn't started anymore automatically, but this gets
 
      sudo apt-get install -y runit-systemd libssl1.0-dev
 
+### Ubuntu 18.04 Bionic
+
+To start `runit` automatically on Ubuntu Bionic, we need to install `runit-systemd`:
+
+    sudo apt-get install -y runit-systemd
 
 ## 2. Ruby
 
@@ -80,6 +85,10 @@ Download Ruby and compile it:
 Install the bundler and foreman gems:
 
     sudo gem install rake bundler foreman --no-document
+
+Update rubygems:
+
+    sudo gem update --system --no-document
 
 ## 3. System Users
 

--- a/doc/manual/requirements.md
+++ b/doc/manual/requirements.md
@@ -4,7 +4,7 @@
 
 ### Supported Unix distributions by this guide
 
-- Ubuntu (16.04, 14.04 and 12.04)
+- Ubuntu (18.04, 16.04 and 14.04)
 - Debian (Jessie and Wheezy)
 
 ### Unsupported Unix distributions

--- a/doc/manual/update.md
+++ b/doc/manual/update.md
@@ -52,6 +52,15 @@ sudo -u huginn -H cp Procfile.bak Procfile
 
 ### 4. Install gems, migrate and precompile assets
 
+Ensure you have rubygems 2.7.0+ installed:
+
+```
+gem -v
+
+# Update rubygems if the version is too old
+sudo gem update --system --no-document
+```
+
 ```
 cd /home/huginn/huginn
 


### PR DESCRIPTION
* Update rubygems to fix [bundle install not working with bunlder 2][1]
* Fix installation on Ubuntu 18

[1]: https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html