### PR TITLE
Issue with access denied while DB creation

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -193,7 +193,7 @@ If you are using a local MySQL server the database configuration should look lik
     DATABASE_RECONNECT=true
     DATABASE_NAME=huginn_production
     DATABASE_POOL=20
-    DATABASE_USERNAME=huginn
+    DATABASE_USERNAME=root
     DATABASE_PASSWORD='$password'
     #DATABASE_HOST=your-domain-here.com
     #DATABASE_PORT=3306


### PR DESCRIPTION
The default .env has huginn set as the database username. This causes the below access denied while executing 
`sudo -u huginn -H bundle exec rake db:create RAILS_ENV=production`
```
Mysql2::Error::ConnectionError: Access denied for user 'huginn'@'localhost' to database 'huginn_development': CREATE DATABASE `huginn_development` DEFAULT CHARACTER SET `utf8mb4`
Couldn't create database for {"adapter"=>"mysql2", "encoding"=>"utf8mb4", "reconnect"=>true, "database"=>"huginn_development", "pool"=>20, "username"=>"huginn", "password"=>"password", "host"=>nil, "port"=>nil, "socket"=>"/var/run/mysqld/mysqld.sock", "strict"=>false}
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error::ConnectionError: Access denied for user 'huginn'@'localhost' to database 'huginn_development': CREATE DATABASE `huginn_development` DEFAULT CHARACTER SET `utf8mb4`
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `_query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `block in query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `handle_interrupt'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:187:in `block (2 levels) in execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:186:in `block in execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block (2 levels) in log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:578:in `block in log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:569:in `log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:185:in `execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/mysql/database_statements.rb:28:in `execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:254:in `create_database'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/mysql_database_tasks.rb:14:in `create'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:119:in `create'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:139:in `block in create_current'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:316:in `block in each_current_configuration'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:313:in `each'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:313:in `each_current_configuration'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:138:in `create_current'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/railties/databases.rake:29:in `block (2 levels) in <main>'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'

Caused by:
Mysql2::Error::ConnectionError: Access denied for user 'huginn'@'localhost' to database 'huginn_development'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `_query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `block in query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `handle_interrupt'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `query'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:187:in `block (2 levels) in execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:186:in `block in execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block (2 levels) in log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:578:in `block in log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.1.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:569:in `log'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:185:in `execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/mysql/database_statements.rb:28:in `execute'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:254:in `create_database'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/mysql_database_tasks.rb:14:in `create'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:119:in `create'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:139:in `block in create_current'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:316:in `block in each_current_configuration'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:313:in `each'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:313:in `each_current_configuration'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/tasks/database_tasks.rb:138:in `create_current'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.1.1/lib/active_record/railties/databases.rake:29:in `block (2 levels) in <main>'
/home/huginn/huginn/vendor/bundle/ruby/2.5.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => db:create
(See full trace by running task with --trace)
```