### PR TITLE
Make the Mail gem use real-world encoders for some Japanese charsets

### DIFF
--- a/config/initializers/mail_encoding_patch.rb
+++ b/config/initializers/mail_encoding_patch.rb
@@ -1,0 +1,18 @@
+module Mail
+  class Ruby19
+    class ImprovedEncoder < BestEffortCharsetEncoder
+      def pick_encoding(charset)
+        case charset
+        when /\Aiso-2022-jp\z/i
+          Encoding::CP50220
+        when /\Ashift_jis\z/i
+          Encoding::Windows_31J
+        else
+          super
+        end
+      end
+    end
+
+    self.charset_encoder = ImprovedEncoder.new
+  end
+end


### PR DESCRIPTION
For historical reasons, Japanese mails in legacy encodings almost always use vendor extended character sets while they declare standard charset names in the Content-Type header.  That makes ImapFolderAgent fail in decoding some specific characters in those mails to UTF-8 as originally intended.

This patch tells the Mail gem to use real-world encoders instead of those literally declared.