### PR TITLE
Revert "Update DataOutputAgent accept header for browser compatibilit…

### DIFF
--- a/app/models/agents/data_output_agent.rb
+++ b/app/models/agents/data_output_agent.rb
@@ -27,7 +27,7 @@ module Agents
           * `ttl` - A value for the \\<ttl\\> element in RSS output. (default: `60`)
           * `ns_media` - Add [yahoo media namespace](https://en.wikipedia.org/wiki/Media_RSS) in output xml
           * `ns_itunes` - Add [itunes compatible namespace](http://lists.apple.com/archives/syndication-dev/2005/Nov/msg00002.html) in output xml
-          * `rss_content_type` - Content-Type for RSS output (default: `application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4`)
+          * `rss_content_type` - Content-Type for RSS output (default: `application/rss+xml`)
           * `response_headers` - An object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
           * `push_hubs` - Set to a list of PubSubHubbub endpoints you want to publish an update to every time this agent receives an event. (default: none)  Popular hubs include [Superfeedr](https://pubsubhubbub.superfeedr.com/) and [Google](https://pubsubhubbub.appspot.com/).  Note that publishing updates will make your feed URL known to the public, so if you want to keep it secret, set up a reverse proxy to serve your feed via a safe URL and specify it in `template.self`.
 
@@ -174,7 +174,7 @@ module Agents
     end
 
     def rss_content_type
-      interpolated['rss_content_type'].presence || 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4'
+      interpolated['rss_content_type'].presence || 'application/rss+xml'
     end
 
     def xml_namespace

--- a/spec/models/agents/data_output_agent_spec.rb
+++ b/spec/models/agents/data_output_agent_spec.rb
@@ -154,7 +154,7 @@ describe Agents::DataOutputAgent do
         stub(agent).feed_link { "https://yoursite.com" }
         content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
         expect(status).to eq(200)
-        expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+        expect(content_type).to eq('application/rss+xml')
         expect(content.gsub(/\s+/, '')).to eq Utils.unindent(<<-XML).gsub(/\s+/, '')
           <?xml version="1.0" encoding="UTF-8" ?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
@@ -218,7 +218,7 @@ describe Agents::DataOutputAgent do
         agent.options[:push_hubs] = %w[https://pubsubhubbub.superfeedr.com/ https://pubsubhubbub.appspot.com/]
         content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
         expect(status).to eq(200)
-        expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+        expect(content_type).to eq('application/rss+xml')
         xml = Nokogiri::XML(content)
         expect(xml.xpath('/rss/channel/atom:link[@rel="hub"]/@href').map(&:text).sort).to eq agent.options[:push_hubs].sort
       end
@@ -350,7 +350,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
           expect(Nokogiri(content).at('/rss/channel/title/text()').text).to eq('XKCD comics as a feed (XKCD)')
         end
 
@@ -394,7 +394,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
           expect(Nokogiri(content).at('/rss/channel/atom:icon/text()').text).to eq('https://somesite.com/icon.png')
         end
       end
@@ -409,7 +409,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
 
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -427,7 +427,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
 
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -447,7 +447,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
 
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -465,7 +465,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
           
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -484,7 +484,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
           
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -505,7 +505,7 @@ describe Agents::DataOutputAgent do
           stub(agent).feed_link { "https://yoursite.com" }
           content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
           expect(status).to eq(200)
-          expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+          expect(content_type).to eq('application/rss+xml')
 
           doc = Nokogiri(content)
           namespaces = doc.collect_namespaces
@@ -609,7 +609,7 @@ describe Agents::DataOutputAgent do
         stub(agent).feed_link { "https://yoursite.com" }
         content, status, content_type = agent.receive_web_request({ 'secret' => 'secret1' }, 'get', 'text/xml')
         expect(status).to eq(200)
-        expect(content_type).to eq('application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4')
+        expect(content_type).to eq('application/rss+xml')
         expect(content.gsub(/\s+/, '')).to eq Utils.unindent(<<-XML).gsub(/\s+/, '')
           <?xml version="1.0" encoding="UTF-8" ?>
           <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" >


### PR DESCRIPTION
…y (#2338)"

`application/rss+xml, application/rdf+xml;q=0.8,
application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4` is
not a valid `content-type.

Ref:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
* https://stackoverflow.com/questions/5809099/does-the-http-protocol-support-multiple-content-types-in-response-headers

The official mime parser in Go can't parse current content-type (since
it's not in the correct format), thus some Feed Reader can't consume
Huginn's RSS output ( [Miniflux](https://miniflux.app/) in my case )

This reverts commit 2c9b9bb29c9505f737be86a83d51c536bf17135d.