### PR TITLE
Fix setup_heroku under Windows

### DIFF
--- a/bin/setup_heroku
+++ b/bin/setup_heroku
@@ -18,13 +18,20 @@ def set_env(key, value)
 end
 
 def check_login!
-  unless File.exists?(File.expand_path("~/.netrc")) && File.read(File.expand_path("~/.netrc")) =~ /heroku/
+  netrc = get_expanded_netrc_path
+  unless File.exists?(netrc) && File.read(netrc) =~ /heroku/
     puts "It looks like you need to log in to Heroku.  Please run 'heroku auth:login' before continuing."
     exit 1
   end
 
   puts "Welcome #{`heroku auth:whoami`.strip}!  It looks like you're logged into Heroku."
   puts
+end
+
+def get_expanded_netrc_path
+  is_windows = (ENV['OS'] == 'Windows_NT')
+  netrc_path = is_windows ? "~/_netrc" : "~/.netrc"
+  File.expand_path(netrc_path);
 end
 
 check_login!

--- a/lib/setup_tools.rb
+++ b/lib/setup_tools.rb
@@ -74,7 +74,29 @@ module SetupTools
   def ask(question, opts = {})
     print question + " "
     STDOUT.flush
-    (opts[:noecho] ? STDIN.noecho(&:gets) : gets).strip
+    if opts[:noecho] && is_noecho_unsupported
+      ask_without_echo.strip
+    else
+      (opts[:noecho] ? STDIN.noecho(&:gets) : gets).strip
+    end
+  end
+
+  def is_noecho_unsupported
+    return RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw32/
+  end
+
+  def ask_without_echo
+      # Due to MinTTY and Cygwin not supporting the no-echo TTY mode
+      # workaround is needed
+
+      # 8m is the control code to hide characters
+      print "\e[0;8m"
+      STDOUT.flush
+      input = gets
+      # 0m is the control code to reset formatting attributes
+      print "\e[0m"
+      STDOUT.flush
+      return input
   end
 
   def nag(question, opts = {})


### PR DESCRIPTION
`setup_heroku` failed when running from a Windows machine using the common terminal emulators.

Related issues: #489 and #1887 