### PR TITLE
Add Liquid based rule support to TriggerAgent

### DIFF
--- a/spec/models/agents/trigger_agent_spec.rb
+++ b/spec/models/agents/trigger_agent_spec.rb
@@ -87,6 +87,14 @@ describe Agents::TriggerAgent do
       @checker.options['rules'].last.delete('value')
       expect(@checker).not_to be_valid
     end
+
+    it "should validate non-hash rules" do
+      @checker.options['rules'] << "{% if status == 'ok' %}true{% endif %}"
+      expect(@checker).to be_valid
+
+      @checker.options['rules'] << []
+      expect(@checker).not_to be_valid
+    end
   end
 
   describe "#working?" do


### PR DESCRIPTION
Sometimes you want to write such a condition in TriggerAgent as "if the time value of `created_at` is within 24 hours from now", but that kind of comparison is not provided by the agent.

With this enhancement, one can describe a rule in Liquid that counts as a match when it expands to `true`.