### PR TITLE
Add digest filters to our Liquid engine

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -243,6 +243,26 @@ module LiquidInterpolatable
       JSON.dump(input)
     end
 
+    def md5(input)
+      Digest::MD5.hexdigest(input.to_s)
+    end
+
+    def sha1(input)
+      Digest::SHA1.hexdigest(input.to_s)
+    end
+
+    def sha256(input)
+      Digest::SHA256.hexdigest(input.to_s)
+    end
+
+    def hmac_sha1(input, key)
+      OpenSSL::HMAC.hexdigest('sha1', key.to_s, input.to_s)
+    end
+
+    def hmac_sha256(input, key)
+      OpenSSL::HMAC.hexdigest('sha256', key.to_s, input.to_s)
+    end
+
     # Returns a Ruby object
     #
     # It can be used as a JSONPath replacement for Agents that only support Liquid:

--- a/spec/concerns/liquid_interpolatable_spec.rb
+++ b/spec/concerns/liquid_interpolatable_spec.rb
@@ -370,4 +370,28 @@ HTML
       expect(agent.interpolated['template']).to eq(replaced_fragment)
     end
   end
+
+  describe 'digest filters' do
+    let(:agent) { Agents::InterpolatableAgent.new(name: "test") }
+
+    it 'computes digest values from string input' do
+      agent.interpolation_context['value'] = 'Huginn'
+      agent.interpolation_context['key'] = 'Muninn'
+
+      agent.options['template'] = "{{ value | md5 }}"
+      expect(agent.interpolated['template']).to eq('5fca9fe120027bc87fa9923cc926f8fe')
+
+      agent.options['template'] = "{{ value | sha1 }}"
+      expect(agent.interpolated['template']).to eq('647d81f6dae6ff474cdcef3e9b74f038206af680')
+
+      agent.options['template'] = "{{ value | sha256 }}"
+      expect(agent.interpolated['template']).to eq('62c6099ec14502176974aadf0991525f50332ba552500556fea583ffdf0ba076')
+
+      agent.options['template'] = "{{ value | hmac_sha1: key }}"
+      expect(agent.interpolated['template']).to eq('9bd7cdebac134e06ba87258c28d2deea431407ac')
+
+      agent.options['template'] = "{{ value | hmac_sha256: key }}"
+      expect(agent.interpolated['template']).to eq('38b98bc2625a8cac33369f6204e784482be5e172b242699406270856a841d1ec')
+    end
+  end
 end


### PR DESCRIPTION
These filters are not part of the vanilla Liquid, but Shopify [provides them](https://help.shopify.com/en/themes/liquid/filters/string-filters) in their own service.

- `md5`
- `sha1`
- `sha256`
- `hmac_sha1`
- `hmac_sha256`

They are useful when you need a unique digest value for a data item or when checking the integrity of external data.