### PR TITLE
Force SNI support in Net modules for IMAP/POP3/SMTP

### DIFF
--- a/config/initializers/force_sni.rb
+++ b/config/initializers/force_sni.rb
@@ -1,0 +1,11 @@
+require 'net/protocol'
+
+class Net::Protocol
+  module ForceSNI
+    def ssl_socket_connect(*)
+      @sock.hostname = @host if @sock.respond_to? :hostname=
+      super
+    end
+  end
+  prepend ForceSNI
+end


### PR DESCRIPTION
Ruby's Net::IMAP/POP3/SMTP modules currently do not enable SNI support when using SSL/TLS, resulting in failing to connect to services like Gmail when using an SSL library with TLSv3 support (OpenSSL >=1.1, for example).

This monkey patch forces Ruby's Net modules to set a hostname to enable SNI.