### PR TITLE
Set Heroku stack to `heroku-18` in app.json

### DIFF
--- a/.graphviz
+++ b/.graphviz
@@ -1,1 +1,0 @@
-http://www.graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz

--- a/app.json
+++ b/app.json
@@ -22,5 +22,5 @@
     },
     "addons": ["heroku-postgresql"],
     "success_url": "/users/sign_up",
-    "stack": "heroku-16"
+    "stack": "heroku-18"
 }


### PR DESCRIPTION
As https://github.com/weibeld/heroku-buildpack-graphviz/pull/7 is merged we can upgrade the herokiu stack to heroku-18.

My huginn on heroku build successfully with heroku 18.
![image](https://user-images.githubusercontent.com/876694/55942509-17b34900-5c77-11e9-9b8e-1c70ebc35725.png)
