### PR TITLE
Set inbound_event when creating AgentLog entries

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -71,6 +71,7 @@ module LiquidInterpolatable
   def interpolate_with_each(array)
     array.each do |object|
       interpolate_with(object) do
+        self.current_event = object
         yield object
       end
     end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -222,7 +222,7 @@ class Agent < ActiveRecord::Base
   end
 
   def log(message, options = {})
-    AgentLog.log_for_agent(self, message, options)
+    AgentLog.log_for_agent(self, message, options.merge(inbound_event: current_event))
   end
 
   def error(message, options = {})
@@ -265,7 +265,9 @@ class Agent < ActiveRecord::Base
   #Validation Methods
   
   private
-  
+
+  attr_accessor :current_event
+
   def validate_schedule
     unless cannot_be_scheduled?
       errors.add(:schedule, "is not a valid schedule") unless SCHEDULES.include?(schedule.to_s)

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -462,26 +462,24 @@ module Agents
     end
 
     def receive(incoming_events)
-      incoming_events.each do |event|
-        interpolate_with(event) do
-          existing_payload = interpolated['mode'].to_s == "merge" ? event.payload : {}
+      interpolate_with_each(incoming_events) do |event|
+        existing_payload = interpolated['mode'].to_s == "merge" ? event.payload : {}
 
-          if data_from_event = options['data_from_event'].presence
-            data = interpolate_options(data_from_event)
-            if data.present?
-              handle_event_data(data, event, existing_payload)
-            else
-              error "No data was found in the Event payload using the template #{data_from_event}", inbound_event: event
-            end
+        if data_from_event = options['data_from_event'].presence
+          data = interpolate_options(data_from_event)
+          if data.present?
+            handle_event_data(data, event, existing_payload)
           else
-            url_to_scrape =
-              if url_template = options['url_from_event'].presence
-                interpolate_options(url_template)
-              else
-                interpolated['url']
-              end
-            check_urls(url_to_scrape, existing_payload)
+            error "No data was found in the Event payload using the template #{data_from_event}", inbound_event: event
           end
+        else
+          url_to_scrape =
+            if url_template = options['url_from_event'].presence
+              interpolate_options(url_template)
+            else
+              interpolated['url']
+            end
+          check_urls(url_to_scrape, existing_payload)
         end
       end
     end
@@ -500,7 +498,7 @@ module Agents
         handle_data(data, event.payload['url'].presence, existing_payload)
       }
     rescue => e
-      error "Error when handling event data: #{e.message}\n#{e.backtrace.join("\n")}", inbound_event: event
+      error "Error when handling event data: #{e.message}\n#{e.backtrace.join("\n")}"
     end
 
     # This method returns true if the result should be stored as a new event.

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -1075,6 +1075,7 @@ fire: hot
             'url' => 'http://foo.com',
             'link' => 'Random'
           }
+          @event.save!
         end
 
         it "should use url_from_event as the url to scrape" do
@@ -1177,6 +1178,19 @@ fire: hot
             @checker.receive([@event])
           }.to change { Event.count }.by(1)
           expect(Event.last.payload['nav_links']).to eq(["Archive", "What If?", "Blag", "Store", "About"])
+        end
+
+        it "should set the inbound_event when logging errors" do
+          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+           @valid_options['extract'] = {
+            'url' => { 'css' => "div", 'value' => "@src" },
+            'title' => { 'css' => "#comic img", 'value' => "@alt" },
+          }
+          @checker.options = @valid_options
+          @checker.receive([@event])
+          log = @checker.logs.first
+          expect(log.message).to match(/Got an uneven number of matches/)
+          expect(log.inbound_event).to eq(@event)
         end
       end
 


### PR DESCRIPTION
If an Agent is using `interpolate_with_each` to when can automatically
set the `inbound_event` for every `AgentLog` entry the Agent creates.

This is especially useful when using a `WebsiteAgent` to work on
different sites. Before this changes error log entries lacked to
context of the incoming Event to debug the failure.