### PR TITLE
Update Nokogiri for CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ GEM
     net-ssh (5.0.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
Update for Nokogiri for [CVE-2019-11068](https://nvd.nist.gov/vuln/detail/CVE-2019-11068#vulnCurrentDescriptionTitle)
