### PR TITLE
Add `drop_pending_events` option to AgentControllerConcern

### DIFF
--- a/app/concerns/agent_controller_concern.rb
+++ b/app/concerns/agent_controller_concern.rb
@@ -55,6 +55,9 @@ module AgentControllerConcern
           when 'enable'
             case
             when target.disabled?
+              if options['drop_pending_events']
+                target.drop_pending_events = true
+              end
               target.update!(disabled: false)
               log "Agent '#{target.name}' is enabled"
             else

--- a/app/concerns/agent_controller_concern.rb
+++ b/app/concerns/agent_controller_concern.rb
@@ -55,7 +55,7 @@ module AgentControllerConcern
           when 'enable'
             case
             when target.disabled?
-              if options['drop_pending_events']
+              if boolify(interpolated['drop_pending_events'])
                 target.drop_pending_events = true
               end
               target.update!(disabled: false)

--- a/app/models/agents/commander_agent.rb
+++ b/app/models/agents/commander_agent.rb
@@ -16,6 +16,7 @@ module Agents
       * `disable`: Target Agents are disabled (if not) when this agent is triggered.
 
       * `enable`: Target Agents are enabled (if not) when this agent is triggered.
+        * If the option `drop_pending_events` is set to `true`, pending events will be cleared before the agent is enabled.
 
       * `configure`: Target Agents have their options updated with the contents of `configure_options`.
 

--- a/app/models/agents/scheduler_agent.rb
+++ b/app/models/agents/scheduler_agent.rb
@@ -24,6 +24,7 @@ module Agents
       * `disable`: Target Agents are disabled (if not) at intervals.
 
       * `enable`: Target Agents are enabled (if not) at intervals.
+        * If the option `drop_pending_events` is set to `true`, pending events will be cleared before the agent is enabled.
 
       # Targets
 

--- a/spec/support/shared_examples/agent_controller_concern.rb
+++ b/spec/support/shared_examples/agent_controller_concern.rb
@@ -99,16 +99,16 @@ shared_examples_for AgentControllerConcern do
       expect(control_target_ids).to eq [agent.control_targets.last.id]
     end
 
-    it "should enable targets" do
+    it "should disable targets" do
       agent.options['action'] = 'disable'
       agent.save!
-      agent.control_targets.first.update!(disabled: true)
+      agent.control_targets.first.update!(disabled: false)
 
       agent.control!
       expect(agent.control_targets.reload).to all(be_disabled)
     end
 
-    it "should disable targets" do
+    it "should enable targets" do
       agent.options['action'] = 'enable'
       agent.save!
       agent.control_targets.first.update!(disabled: true)


### PR DESCRIPTION
Hi there, Huginn maintainers! 👋 I've added the ability to drop pending events to the Scheduler and Commander Agents, via the `AgentControllerConcern`, and would love to submit this change upstream!

### But why?
I'm submitting this PR because I recently got a weather station setup at my house. I was excited to start scraping data from the API and triggering events within Huginn. I quickly got a great scenario setup: I'd scrape data, determine if the outdoor temperature is greater than the indoor temperature in order to send a push notification telling me to close my windows and then disable the agent so I didn't keep getting spammed. Finally, I'd use a Scheduler Agent to re-enable the Trigger Agent at midnight so the process could repeat the next day. This worked out perfectly, until I woke up the next morning to find over 50 push notifications letting me know that it was hotter outside than it is inside.

It turns out that I didn't account for the fact that all of the events triggered from scraping the API were still "queued up" to be processed by the Trigger Agent. I could've _sworn_ that pending events would be deleted once you re-enabled an agent, but after poking around the UI and source I quickly discovered that this is only the case if you re-enable an agent through the web interface and enable a checkbox. So, this PR mimicks the behavior of that checkbox!

## Concerns
I wanted to call out a few things to get your thoughts on them:
- [ ] I didn't see anything in either the Scheduler or Commander Agent specs that seemed like a good place to test this new functionality.
- [ ] Does the documentation make sense? I couldn't determine the best place to put it, given that the option is only relevant if `action: enable`. 

If you've got any suggestions as to how to handle ☝️ these concerns, I'm all ears and would love to address them before merging. 💕 Thanks for your time and thanks for making Huginn!