### PR TITLE
Making clearer text in postagent

### DIFF
--- a/app/models/agents/post_agent.rb
+++ b/app/models/agents/post_agent.rb
@@ -14,7 +14,7 @@ module Agents
 
     description do
       <<-MD
-        A Post Agent receives events from other agents (or runs periodically), merges those events with the [Liquid-interpolated](https://github.com/huginn/huginn/wiki/Formatting-Events-using-Liquid) contents of `payload`, and sends the results as POST (or GET) requests to a specified url.  To skip merging in the incoming event, but still send the interpolated payload, set `no_merge` to `true`.
+        A Post Agent receives events from other agents (or runs periodically), merges those events with the [Liquid-interpolated](https://github.com/huginn/huginn/wiki/Formatting-Events-using-Liquid) contents of the object `payload`, and sends the results as POST (or GET) requests to a specified url.  To skip merging in the incoming event, but still send the interpolated payload, set `no_merge` to `true`.
 
         The `post_url` field must specify where you would like to send requests. Please include the URI scheme (`http` or `https`).
 
@@ -22,11 +22,11 @@ module Agents
 
         By default, non-GETs will be sent with form encoding (`application/x-www-form-urlencoded`).
 
-        Change `content_type` to `json` to send JSON instead.
+        Change `content_type` to `json` to send `payload` as JSON instead.
 
-        Change `content_type` to `xml` to send XML, where the name of the root element may be specified using `xml_root`, defaulting to `post`.
+        Change `content_type` to `xml` to send `payload` as XML, where the name of the root element may be specified using `xml_root`, defaulting to `post`.
 
-        When `content_type` contains a [MIME](https://en.wikipedia.org/wiki/Media_type) type, and `payload` is a string, its interpolated value will be sent as a string in the HTTP request's body and the request's `Content-Type` HTTP header will be set to `content_type`. When `payload` is a string `no_merge` has to be set to `true`.
+        When `content_type` contains a [MIME](https://en.wikipedia.org/wiki/Media_type) type, and the object `payload` is a string, its interpolated value will be sent as a string in the HTTP request's body and the request's `Content-Type` HTTP header will be set to `content_type`. When `payload` is a string `no_merge` has to be set to `true`.
 
         If `emit_events` is set to `true`, the server response will be emitted as an Event and can be fed to a WebsiteAgent for parsing (using its `data_from_event` and `type` options). No data processing
         will be attempted by this Agent, so the Event's "body" value will always be raw text.


### PR DESCRIPTION
it's not totally clear the post content comes from the object `payload` since by default there's no payload item. Making clearer.