### PR TITLE
Install Node 10 instead of Node 0.12 in the install guide

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -44,10 +44,6 @@ up-to-date and install it.
     sudo apt-get install -y vim
     sudo update-alternatives --set editor /usr/bin/vim.basic
 
-Import node.js repository (can be skipped on Ubuntu and Debian Jessie):
-
-    curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
-
 Install the required packages (needed to compile Ruby and native extensions to Ruby gems):
 
     sudo apt-get install -y runit build-essential git zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev curl openssh-server checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev logrotate python-docutils pkg-config cmake nodejs graphviz


### PR DESCRIPTION
Note in particular that Node 0.12 has not received security updates for over two years.