### PR TITLE
Upgrade mini_magic, fix focus rspec filter limiting test suit on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem 'kaminari', '~> 1.1.1'
 gem 'kramdown', '~> 1.3.3'
 gem 'liquid', '~> 4.0.3'
 gem 'loofah', '~> 2.0'
-gem 'mini_magick'
+gem 'mini_magick', ">= 4.9.4"
 gem 'multi_xml'
 gem 'nokogiri'
 gem 'omniauth', '~> 1.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,7 +401,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.3)
-    mini_magick (4.2.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     mini_racer (0.2.4)
@@ -720,7 +720,7 @@ DEPENDENCIES
   liquid (~> 4.0.3)
   listen (~> 3.0.5)
   loofah (~> 2.0)
-  mini_magick
+  mini_magick (>= 4.9.4)
   mini_racer (~> 0.2.4)
   mqtt
   multi_xml

--- a/spec/models/agents/telegram_agent_spec.rb
+++ b/spec/models/agents/telegram_agent_spec.rb
@@ -47,7 +47,7 @@ describe Agents::TelegramAgent do
     end
 
     it 'should validate value of caption' do
-      @checker.options[:caption] = 'a' * 250
+      @checker.options[:caption] = 'a' * 1025
       expect(@checker).not_to be_valid
     end
 
@@ -97,18 +97,18 @@ describe Agents::TelegramAgent do
     end
 
     it 'accepts audio key and uses :send_audio to send the file with truncated caption' do
-      event = event_with_payload audio: 'https://example.com/sound.mp3', caption: 'a' * 250
+      event = event_with_payload audio: 'https://example.com/sound.mp3', caption: 'a' * 1025
       @checker.receive [event]
 
-      expect(@sent_messages).to eq([{ audio: { audio: 'https://example.com/sound.mp3', caption: 'a'* 200, chat_id: 'xxxxxxxx' } }])
+      expect(@sent_messages).to eq([{ audio: { audio: 'https://example.com/sound.mp3', caption: 'a'* 1024, chat_id: 'xxxxxxxx' } }])
     end
 
     it 'accepts document key and uses :send_document to send the file and the full caption' do
-      event = event_with_payload caption: "#{'a' * 199}  #{'b' * 6}", document: 'https://example.com/document.pdf', long: 'split'
+      event = event_with_payload caption: "#{'a' * 1023}  #{'b' * 6}", document: 'https://example.com/document.pdf', long: 'split'
       @checker.receive [event]
 
       expect(@sent_messages).to eq([
-                                    { document: { caption: 'a' * 199, chat_id: 'xxxxxxxx', document: 'https://example.com/document.pdf' } },
+                                    { document: { caption: 'a' * 1023, chat_id: 'xxxxxxxx', document: 'https://example.com/document.pdf' } },
                                     { text: { chat_id: 'xxxxxxxx', parse_mode: 'html', text: 'b' * 6 } }
                                    ])
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,7 +54,9 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
+  if ENV['CI'] != 'true'
+    config.filter_run :focus
+  end
   config.run_all_when_everything_filtered = true
 
   # Run specs in random order to surface order dependencies. If you find an

--- a/spec/support/shared_examples/agent_controller_concern.rb
+++ b/spec/support/shared_examples/agent_controller_concern.rb
@@ -117,7 +117,7 @@ shared_examples_for AgentControllerConcern do
       expect(agent.control_targets.reload).to all(satisfy { |a| !a.disabled? })
     end
 
-    it "should enable targets and drop pending events", focus: true do
+    it "should enable targets and drop pending events" do
       agent.options['action'] = 'enable'
       agent.options['drop_pending_events'] = 'true'
       agent.save!


### PR DESCRIPTION
Upgrade mini_magick to fix [CVE-2019-13574](https://nvd.nist.gov/vuln/detail/CVE-2019-13574)

More information
high severity
Vulnerable versions: < 4.9.4
Patched version: 4.9.4

In lib/mini_magick/image.rb in MiniMagick before 4.9.4, a fetched remote
image filename could cause remote command execution because Image.open
input is directly passed to Kernel#open, which accepts a '|' character
followed by a command.

-------------------------------

Un-focus specs and ensure the whole test suits always runs on CI


-------------------------------


Fix TelegramAgent specs