### PR TITLE
Add ability to reemit all of an agent's events from the UI

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -219,7 +219,7 @@ span.not-applicable:after {
   font-size: 14px;
 }
 
-// Position tweeks
+// Position tweaks
 
 .hover-help {
   top: 2px;
@@ -229,6 +229,12 @@ span.not-applicable:after {
   dd {
     margin-left: 1em;
   }
+}
+
+.page-header .btn-group {
+  position: relative;
+  top: -5px;
+  left: 4px;
 }
 
 h2 .scenario, a span.label.scenario {

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -78,6 +78,7 @@ class AgentsController < ApplicationController
   def reemit_events
     @agent = current_user.agents.find(params[:id])
 
+    # `find_each` orders by PK, so events get re-created in the same order
     @agent.events.find_each do |event|
       event.reemit!
     end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -75,6 +75,19 @@ class AgentsController < ApplicationController
     render :json => { :description_html => html }
   end
 
+  def reemit_events
+    @agent = current_user.agents.find(params[:id])
+
+    @agent.events.find_each do |event|
+      event.reemit!
+    end
+
+    respond_to do |format|
+      format.html { redirect_back "All events reemitted for '#{@agent.name}'" }
+      format.json { head :ok }
+    end
+  end
+
   def remove_events
     @agent = current_user.agents.find(params[:id])
     @agent.events.delete_all

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -79,7 +79,7 @@ class AgentsController < ApplicationController
     @agent = current_user.agents.find(params[:id])
 
     AgentReemitJob.perform_later(@agent, @agent.most_recent_event.id,
-                                 params[:delete_old_events] == '1' || false)
+                                 params[:delete_old_events] == '1')
 
     respond_to do |format|
       format.html { redirect_back "Enqueued job to re-emit all events for '#{@agent.name}'" }

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -78,13 +78,10 @@ class AgentsController < ApplicationController
   def reemit_events
     @agent = current_user.agents.find(params[:id])
 
-    # `find_each` orders by PK, so events get re-created in the same order
-    @agent.events.find_each do |event|
-      event.reemit!
-    end
+    AgentReemitJob.perform_later(@agent, @agent.most_recent_event.id)
 
     respond_to do |format|
-      format.html { redirect_back "All events reemitted for '#{@agent.name}'" }
+      format.html { redirect_back "Enqueued job to re-emit all events for '#{@agent.name}'" }
       format.json { head :ok }
     end
   end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -78,7 +78,8 @@ class AgentsController < ApplicationController
   def reemit_events
     @agent = current_user.agents.find(params[:id])
 
-    AgentReemitJob.perform_later(@agent, @agent.most_recent_event.id)
+    AgentReemitJob.perform_later(@agent, @agent.most_recent_event.id,
+                                 params[:delete_old_events] == '1' || false)
 
     respond_to do |format|
       format.html { redirect_back "Enqueued job to re-emit all events for '#{@agent.name}'" }

--- a/app/jobs/agent_reemit_job.rb
+++ b/app/jobs/agent_reemit_job.rb
@@ -1,9 +1,10 @@
 class AgentReemitJob < ActiveJob::Base
   # Given an Agent, re-emit all of agent's events up to (and including) `most_recent_event_id`
-  def perform(agent, most_recent_event_id)
+  def perform(agent, most_recent_event_id, delete_old_events = false)
     # `find_each` orders by PK, so events get re-created in the same order
     agent.events.where("id <= ?", most_recent_event_id).find_each do |event|
       event.reemit!
+      event.destroy if delete_old_events
     end
   end
 end

--- a/app/jobs/agent_reemit_job.rb
+++ b/app/jobs/agent_reemit_job.rb
@@ -1,0 +1,9 @@
+class AgentReemitJob < ActiveJob::Base
+  # Given an Agent, re-emit all of agent's events up to (and including) `most_recent_event_id`
+  def perform(agent, most_recent_event_id)
+    # `find_each` orders by PK, so events get re-created in the same order
+    agent.events.where("id <= ?", most_recent_event_id).find_each do |event|
+      event.reemit!
+    end
+  end
+end

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -49,6 +49,14 @@
 
   <% if agent.can_create_events? && agent.events_count > 0 %>
     <li>
+      <%= link_to icon_tag('glyphicon-refresh') + ' Re-emit all events', reemit_events_agent_path(agent, return: return_to), method: :post, data: {confirm: 'Are you sure you want to reemit ALL emitted events for this Agent?'}, tabindex: "-1" %>
+    </li>
+  <% end %>
+
+  <li class="divider"></li>
+
+  <% if agent.can_create_events? && agent.events_count > 0 %>
+    <li>
       <%= link_to icon_tag('glyphicon-trash', class: 'color-danger') + ' Delete all events', remove_events_agent_path(agent, return: return_to), method: :delete, data: {confirm: 'Are you sure you want to delete ALL emitted events for this Agent?'}, tabindex: "-1" %>
     </li>
   <% end %>

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -26,7 +26,7 @@
   </li>
 
   <li>
-    <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent#{agent.id}" do %>
+    <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-enable-disable#{agent.id}" do %>
       <% if agent.disabled? %>
         <%= icon_tag('glyphicon-play') %> Enable agent
       <% else %>
@@ -49,7 +49,9 @@
     <li class="divider"></li>
 
     <li>
-      <%= link_to icon_tag('glyphicon-refresh') + ' Re-emit all events', reemit_events_agent_path(agent, return: return_to), method: :post, data: {confirm: 'Are you sure you want to reemit and duplicate ALL emitted events for this Agent?'}, tabindex: "-1" %>
+      <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-reemit-events#{agent.id}" do %>
+        <%= icon_tag('glyphicon-refresh') %> Re-emit all events
+      <% end %>
     </li>
   <% end %>
 
@@ -66,7 +68,7 @@
   </li>
 </ul>
 
-<div id="confirm-agent<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
+<div id="confirm-agent-enable-disable<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm">
     <div class="modal-content">
       <div class="modal-header">
@@ -94,3 +96,30 @@
   </div>
 </div>
 
+<div id="confirm-agent-reemit-events<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
+  <div class="modal-dialog modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title">Confirm</h4>
+      </div>
+      <div class="modal-body">
+        <p>Re-emit all events for &quot;<%= agent.name %>&quot;?</p>
+      </div>
+      <div class="modal-footer">
+        <%= form_for(agent, as: :agent, url: reemit_events_agent_path(agent, return: return_to), method: 'POST') do |f| %>
+          <% if agent.can_create_events? && agent.events_count > 0 %>
+            <div class="form-group">
+              <%= check_box_tag :delete_old_events %>
+              <%= label_tag :delete_old_events, 'Delete old events' %>
+              <span class="glyphicon glyphicon-question-sign hover-help" data-content="If this is checked, the original copies of the events will be deleted once they are re-emitted."></span>
+            </div>
+          <% end %>
+          <%= f.hidden_field :disabled, value: (!agent.disabled).to_s %>
+          <%= f.button 'Cancel', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
+          <%= f.submit 'Re-emit all events', class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -115,7 +115,6 @@
               <span class="glyphicon glyphicon-question-sign hover-help" data-content="If this is checked, the original copies of the events will be deleted once they are re-emitted."></span>
             </div>
           <% end %>
-          <%= f.hidden_field :disabled, value: (!agent.disabled).to_s %>
           <%= f.button 'Cancel', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
           <%= f.submit 'Re-emit all events', class: 'btn btn-primary' %>
         <% end %>

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -45,11 +45,11 @@
     <% end %>
   <% end %>
 
-  <li class="divider"></li>
-
   <% if agent.can_create_events? && agent.events_count > 0 %>
+    <li class="divider"></li>
+
     <li>
-      <%= link_to icon_tag('glyphicon-refresh') + ' Re-emit all events', reemit_events_agent_path(agent, return: return_to), method: :post, data: {confirm: 'Are you sure you want to reemit ALL emitted events for this Agent?'}, tabindex: "-1" %>
+      <%= link_to icon_tag('glyphicon-refresh') + ' Re-emit all events', reemit_events_agent_path(agent, return: return_to), method: :post, data: {confirm: 'Are you sure you want to reemit and duplicate ALL emitted events for this Agent?'}, tabindex: "-1" %>
     </li>
   <% end %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -4,13 +4,15 @@
   <div class='row'>
     <div class='col-md-12'>
       <div class="page-header">
-        <h2>
+        <span class='h2'>
           Your Events
           <% if @agent %>
             from <%= @agent.name %>
-            <%= render 'agents/mini_action_menu', agent: @agent, return_to: request.path %>
           <% end %>
-        </h2>
+        </span>
+        <% if @agent %>
+          <%= render 'agents/mini_action_menu', agent: @agent, return_to: request.path %>
+        <% end %>
       </div>
 
       <div class='table-responsive'>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,10 +4,10 @@
   <div class='row'>
     <div class='col-md-12'>
       <div class="page-header">
-        <h2>
+        <span class='h2'>
           Event from <%= @event.agent.name %>
-          <%= render 'agents/mini_action_menu', agent: @event.agent, return_to: event_path(@event) %>
-        </h2>
+        </span>
+        <%= render 'agents/mini_action_menu', agent: @event.agent, return_to: event_path(@event) %>
       </div>
 
       <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Huginn::Application.routes.draw do
       post :run
       post :handle_details_post
       put :leave_scenario
+      post :reemit_events
       delete :remove_events
       delete :memory, action: :destroy_memory
     end
@@ -100,12 +101,12 @@ Huginn::Application.routes.draw do
   post  "/users/:user_id/update_location/:secret" => "web_requests#update_location" # legacy
 
   devise_for :users,
-             controllers: { 
+             controllers: {
                omniauth_callbacks: 'omniauth_callbacks',
                registrations: 'users/registrations'
              },
              sign_out_via: [:post, :delete]
-  
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -58,11 +58,21 @@ describe AgentsController do
   end
 
   describe "POST reemit_events" do
+    let(:agent) { agents(:bob_website_agent) }
+    let(:params) { { :id => agent.to_param } }
+
     it "enqueues an AgentReemitJob" do
-      agent = agents(:bob_website_agent)
-      mock(AgentReemitJob).perform_later(agent, agent.most_recent_event.id)
+      mock(AgentReemitJob).perform_later(agent, agent.most_recent_event.id, false)
       sign_in users(:bob)
-      post :reemit_events, params: {:id => agent.to_param}
+      post :reemit_events, params: params
+    end
+
+    context "when delete_old_events passed" do
+      it "enqueues an AgentReemitJob with delete_old_events set to true" do
+        mock(AgentReemitJob).perform_later(agent, agent.most_recent_event.id, true)
+        sign_in users(:bob)
+        post :reemit_events, params: params.merge('delete_old_events' => '1')
+      end
     end
 
     it "can only be accessed by the Agent's owner" do

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -58,20 +58,11 @@ describe AgentsController do
   end
 
   describe "POST reemit_events" do
-    it "reemits all events created by the given Agent" do
+    it "enqueues an AgentReemitJob" do
+      agent = agents(:bob_website_agent)
+      mock(AgentReemitJob).perform_later(agent, agent.most_recent_event.id)
       sign_in users(:bob)
-      agent_event = events(:bob_website_agent_event)
-
-      2.times { agent_event.dup.save! }
-
-      expect {
-        post :reemit_events, params: {:id => agents(:bob_website_agent).to_param}
-      }.to change(Event, :count).by(3)
-
-      last_event = Event.last
-      expect(last_event.user).to eq(agent_event.user)
-      expect(last_event.agent).to eq(agent_event.agent)
-      expect(last_event.payload).to eq(agent_event.payload)
+      post :reemit_events, params: {:id => agent.to_param}
     end
 
     it "can only be accessed by the Agent's owner" do

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -6,4 +6,4 @@ bob_website_agent_event:
 jane_website_agent_event:
   user: jane
   agent: jane_website_agent
-  payload: <%= { :title => "foo", :url => "http://foo.com" }.to_json.inspect %>
+  payload: <%= { :title => "bar", :url => "http://bar.com" }.to_json.inspect %>

--- a/spec/jobs/agent_reemit_job_spec.rb
+++ b/spec/jobs/agent_reemit_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe AgentReemitJob do
+  subject { described_class.new }
+  let(:agent) { agents(:bob_website_agent) }
+  let(:agent_event) { events(:bob_website_agent_event) }
+
+  it "re-emits all events created by the given Agent" do
+
+    2.times { agent_event.dup.save! }
+
+    expect {
+      subject.perform(agent, agent.most_recent_event.id)
+    }.to change(Event, :count).by(3)
+
+    last_event = Event.last
+    expect(last_event.user).to eq(agent_event.user)
+    expect(last_event.agent).to eq(agent_event.agent)
+    expect(last_event.payload).to eq(agent_event.payload)
+  end
+
+  it "doesn't re-emit events created after the the most_recent_event_id" do
+    2.times { agent_event.dup.save! }
+
+    # create one more
+    most_recent_event = agent.most_recent_event.id
+    agent_event.dup.save!
+
+    expect {
+      subject.perform(agent, most_recent_event)
+    }.to change(Event, :count).by(3)
+
+    last_event = Event.last
+    expect(last_event.user).to eq(agent_event.user)
+    expect(last_event.agent).to eq(agent_event.agent)
+    expect(last_event.payload).to eq(agent_event.payload)
+  end
+end

--- a/spec/jobs/agent_reemit_job_spec.rb
+++ b/spec/jobs/agent_reemit_job_spec.rb
@@ -6,7 +6,6 @@ describe AgentReemitJob do
   let(:agent_event) { events(:bob_website_agent_event) }
 
   it "re-emits all events created by the given Agent" do
-
     2.times { agent_event.dup.save! }
 
     expect {
@@ -27,12 +26,32 @@ describe AgentReemitJob do
     agent_event.dup.save!
 
     expect {
-      subject.perform(agent, most_recent_event)
+      subject.perform(agent, most_recent_event, false)
     }.to change(Event, :count).by(3)
 
     last_event = Event.last
     expect(last_event.user).to eq(agent_event.user)
     expect(last_event.agent).to eq(agent_event.agent)
     expect(last_event.payload).to eq(agent_event.payload)
+  end
+
+  context "when delete_old_events set to true" do
+    it "re-emits all events created by the given Agent and destroys originals" do
+      original_events = [agent_event]
+      2.times do
+        original_events << agent_event.dup.tap{ |e| e.save! }
+      end
+
+      expect {
+        subject.perform(agent, agent.most_recent_event.id, true)
+      }.to change(Event, :count).by(0)
+
+      original_events.each { |e| expect(e.destroyed?) }
+
+      last_event = Event.last
+      expect(last_event.user).to eq(agent_event.user)
+      expect(last_event.agent).to eq(agent_event.agent)
+      expect(last_event.payload).to eq(agent_event.payload)
+    end
   end
 end


### PR DESCRIPTION
Closes: https://github.com/huginn/huginn/issues/2570

Adds "Re-emit all events" option to `/agents/:agent_id/events` screen:

<img width="176" alt="image" src="https://user-images.githubusercontent.com/50223/62166343-ccee3780-b320-11e9-8a02-2c0701e70faf.png">
