### PR TITLE
Upgrade nokogiri to 1.10.4 for CVE-2019-5477

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,7 @@ GEM
     net-ssh (5.0.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
Upgrade nokogiri for CVE-2019-5477 (https://github.com/sparklemotion/nokogiri/issues/1915)