### PR TITLE
Make JavaScript Agent optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'forecast_io', '~> 2.0.0'     # WeatherAgent
 gem 'rturk', '~> 2.12.1'          # HumanTaskAgent
 gem 'erector', github: 'dsander/erector', branch: 'fix-fixnum-warning'
 gem 'hipchat', '~> 1.2.0'         # HipchatAgent
+gem 'mini_racer', '~> 0.2.4'      # JavaScriptAgent
 gem 'xmpp4r',  '~> 0.5.6'         # JabberAgent
 gem 'mqtt'                        # MQTTAgent
 gem 'slack-notifier', '~> 1.0.0'  # SlackAgent
@@ -124,7 +125,6 @@ gem 'rufus-scheduler', '~> 3.4.2', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
-gem 'mini_racer', '~> 0.2.4'
 gem 'execjs', '~> 2.7.0'
 gem 'typhoeus', '~> 0.6.3'
 gem 'uglifier', '~> 2.7.2'

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -9,8 +9,12 @@ module Agents
 
     default_schedule "never"
 
+    gem_dependency_check { defined?(MiniRacer) }
+
     description <<-MD
       The JavaScript Agent allows you to write code in JavaScript that can create and receive events.  If other Agents aren't meeting your needs, try this one!
+
+      #{'## Include `mini_racer` in your Gemfile to use this Agent!' if dependencies_missing?}
 
       You can put code in the `code` option, or put your code in a Credential and reference it from `code` with `credential:<name>` (recommended).
 


### PR DESCRIPTION
Allow user to opt it out by commenting out "mini_racer" in Gemfile.
Building and installing the libv8 gem is so much time consuming and is even unable on some unsupported platforms.  FreeBSD 12 is one of them.