### PR TITLE
Upgrade typhoeus to fix obscure error SSL validation error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'select2-rails', '~> 3.5.4'
 gem 'spectrum-rails'
 gem 'execjs', '~> 2.7.0'
-gem 'typhoeus', '~> 0.6.3'
+gem 'typhoeus', '~> 1.3.1'
 gem 'uglifier', '~> 2.7.2'
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     erubis (2.7.0)
     et-orbi (1.0.9)
       tzinfo
-    ethon (0.7.1)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     evernote-thrift (1.25.1)
@@ -622,8 +622,8 @@ GEM
       builder (>= 2.1.2)
       jwt (>= 0.1.2)
       multi_json (>= 1.3.0)
-    typhoeus (0.6.9)
-      ethon (>= 0.7.1)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -760,7 +760,7 @@ DEPENDENCIES
   twilio-ruby (~> 3.11.5)
   twitter!
   twitter-stream!
-  typhoeus (~> 0.6.3)
+  typhoeus (~> 1.3.1)
   tzinfo (>= 1.2.0)
   tzinfo-data
   uglifier (~> 2.7.2)


### PR DESCRIPTION
The main motivation for updating `typhoeus` was that the older version
simply stopped the request when the SSL certificate could not be
validated due outdated CA certificates. The result was a response with
status 0 and not additional error information.

The newser typhoeus returns a proper error:

> Peer certificate cannot be authenticated with given CA certificates

 #2601