### PR TITLE
Upgrade ubuntu versions of docker images to 18.04

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 | DateOfChange   | Changes                                                                                                      |
 |----------------|--------------------------------------------------------------------------------------------------------------|
+| Apr 04, 2020   | Upgrade ubuntu versions of docker images to 18.04. [2603](https://github.com/huginn/huginn/pull/2603) **If you are using the `huginn/huginn` image with a internal MySQL database, back up your database volume before updating**  |
 | Mar 31, 2020   | Add FUNDING.yml [2728](https://github.com/huginn/huginn/pull/2728) |
 | Mar 30, 2020   | Improve formatting of OpenShift documentation [2724](https://github.com/huginn/huginn/pull/2724) |
 | Mar 30, 2020   | Fix deployment via OpenShift [2726](https://github.com/huginn/huginn/pull/2726) |

--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare

--- a/docker/multi-process/scripts/bootstrap.sh
+++ b/docker/multi-process/scripts/bootstrap.sh
@@ -12,9 +12,11 @@ if [ "${START_MYSQL}" = "true" ]; then
 
   # initialize MySQL data directory
   if [ ! -d /var/lib/mysql/mysql ]; then
-    mysql_install_db --user=$(whoami) --datadir=/tmp/mysql
+    mysql_install_db --admin-auth-plugin=mysql_native_password --insecure --user=$(whoami) --datadir=/tmp/mysql
     mv -f /tmp/mysql/* /var/lib/mysql/
   fi
+
+  echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${DATABASE_PASSWORD}';" > /app/tmp/mysql_init.sql
 
   echo "Starting mysql server..."
   supervisorctl start mysqld >/dev/null
@@ -31,9 +33,6 @@ if [ "${START_MYSQL}" = "true" ]; then
     echo -n .
     sleep 1
   done
-
-  if ! echo "USE ${DATABASE_NAME}" | mysql -u${DATABASE_USERNAME:-root} "${DATABASE_PASSWORD:+-p$DATABASE_PASSWORD}" >/dev/null 2>&1; then
-    echo "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('${DATABASE_PASSWORD}');" | mysql -u root
-  fi
 fi
+
 supervisorctl start foreman >/dev/null

--- a/docker/multi-process/scripts/mysqld.conf
+++ b/docker/multi-process/scripts/mysqld.conf
@@ -1,7 +1,7 @@
 [program:mysqld]
 priority=20
 directory=/tmp
-command=/usr/bin/mysqld_safe
+command=/usr/bin/mysqld_safe --init-file=/app/tmp/mysql_init.sql
 autostart=false
 autorestart=true
 stdout_events_enabled=true

--- a/docker/multi-process/scripts/standalone-packages
+++ b/docker/multi-process/scripts/standalone-packages
@@ -13,7 +13,11 @@ rm -rf /var/log/*
 mkdir -p /var/log/supervisor /var/log/mysql
 chgrp -R 0 /etc/supervisor /var/lib/mysql /var/log/supervisor /var/log/mysql
 chmod -R g=u /etc/supervisor /var/lib/mysql /var/log/supervisor /var/log/mysql
-sed -r -i /etc/mysql/my.cnf \
+sed -r -i /etc/mysql/mysql.conf.d/mysqld.cnf \
     -e 's/^ *user *.+/user=1001/' \
     -e 's#/var/run/mysqld/mysqld.sock#/app/tmp/sockets/mysqld.sock#' \
     -e 's#/var/run/mysqld/mysqld.pid#/app/tmp/pids/mysqld.pid#'
+sed -r -i /etc/mysql/debian.cnf \
+    -e 's#/var/run/mysqld/mysqld.sock#/app/tmp/sockets/mysqld.sock#'
+cp /etc/mysql/debian.cnf /etc/mysql/mysql.conf.d/client.cnf
+chmod 644 /etc/mysql/mysql.conf.d/client.cnf

--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -28,15 +28,15 @@ apt-get update
 $minimal_apt_get_install build-essential checkinstall git-core \
   zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \
   libncurses5-dev libffi-dev libxml2-dev libxslt-dev curl libcurl4-openssl-dev libicu-dev \
-  graphviz libgraphviz-dev \
-  libmysqlclient-dev libpq-dev libsqlite3-dev \
-  ruby2.5 ruby2.5-dev
+  graphviz libmysqlclient-dev libpq-dev libsqlite3-dev \
+  ruby2.5 ruby2.5-dev locales tzdata
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 gem install --no-document bundler -v 1.17.3
 
 apt-get purge -y python3* rsyslog rsync manpages
 apt-get -y clean
+apt-get -y autoremove
 rm -rf /var/lib/apt/lists/*
 rm -rf /usr/share/doc/
 rm -rf /usr/share/man/

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare


### PR DESCRIPTION
Upgrading the mysql version in the multi process container was a massive
pain. With version 5.7 mysql per-default requires the root user to be
logged in from a root shell. Since we start the container as non-root we
have to set the password of the mysql root user in a initialization
script and disable the `auth_socket` login method.