### PR TITLE
Escape MySQL database name during migration

### DIFF
--- a/db/migrate/20140813110107_set_charset_for_mysql.rb
+++ b/db/migrate/20140813110107_set_charset_for_mysql.rb
@@ -59,7 +59,7 @@ class SetCharsetForMysql < ActiveRecord::Migration[4.2]
           execute 'ALTER TABLE %s CHARACTER SET utf8 COLLATE utf8_unicode_ci' % table_name
         }
 
-        execute 'ALTER DATABASE %s CHARACTER SET utf8 COLLATE utf8_unicode_ci' % connection.current_database
+        execute 'ALTER DATABASE `%s` CHARACTER SET utf8 COLLATE utf8_unicode_ci' % connection.current_database
       end
 
       dir.down do


### PR DESCRIPTION
This should fix #2480.

Since the migration is only run for MySQL, the solution is to just wrap the database name inside backtick character.