### PR TITLE
Upgrade rubies to the latest minor releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ matrix:
     - env: DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
     - env: DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
   include:
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn-single-process DOCKERFILE=docker/single-process/Dockerfile
-    - rvm: 2.6.0
+    - rvm: 2.6.5
       env: DATABASE_ADAPTER=mysql2 DOCKER_IMAGE=huginn/huginn DOCKERFILE=docker/multi-process/Dockerfile
 rvm:
 - 2.3.8
-- 2.4.5
-- 2.5.3
-- 2.6.0
+- 2.4.9
+- 2.5.7
+- 2.6.5
 cache: bundler
 bundler_args: --without development production
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -770,7 +770,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.6.5p114
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
The latest teeny versions are 2.6.5, 2.5.7 and 2.4.9.