### PR TITLE
Prevent `GoogleCalendar.open` from raising exception in ensure block

### DIFF
--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -33,7 +33,7 @@ class GoogleCalendar
     instance = new(*args)
     block.call(instance)
   ensure
-    instance.cleanup!
+    instance&.cleanup!
   end
 
   def auth_as

--- a/spec/lib/google_calendar_spec.rb
+++ b/spec/lib/google_calendar_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe GoogleCalendar do
+  it '#open does not mask exception in initlize' do
+    stub(Google::Apis::CalendarV3::CalendarService).new do
+      raise "test exception"
+    end
+    expect {
+      GoogleCalendar.open({'google' => {}}, Rails.logger) {}
+    }.to raise_error(/test exception/)
+  end
+end


### PR DESCRIPTION
If `GoogleCalendar.new` fails with an exception `instance` will be `nil`
and trying to call `clanup!` on it will create another exception masking
the original one.

  #2633