### PR TITLE
fix: password prompt at sql secure step

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -98,16 +98,13 @@ Install the database packages
 
     sudo apt-get install -y mysql-server mysql-client libmysqlclient-dev
 
-    # Pick a MySQL root password (can be anything), type it and press enter,
-    # retype the MySQL root password and press enter
-
 For Debian Stretch, replace `libmysqlclient-dev` with `default-libmysqlclient-dev`. See the [additional notes section](#additional-notes) for more information.
 
 Check the installed MySQL version (remember if its >= 5.5.3 for the `.env` configuration done later):
 
     mysql --version
 
-Secure your installation
+Secure your installation. During this step, you will be prompted to pick a MySQL root password (can be anything)
 
     sudo mysql_secure_installation
 


### PR DESCRIPTION
You are not prompted to pick a MySQL root password until you run the `sudo mysql_secure_installation` command. The documentation comment seemed a little out of place/misleading. 

Also, I needed to take some extra steps to get the mysql install and config to work by following the steps outlined here: https://stackoverflow.com/questions/39281594/error-1698-28000-access-denied-for-user-rootlocalhost. Should I add that as a note as part of this pull request? 

I am on Ubuntu 18.10 (cosmic).