### PR TITLE
FIX broken link to docker container

### DIFF
--- a/doc/docker/install.md
+++ b/doc/docker/install.md
@@ -34,7 +34,7 @@ Getting Huginn up and running using docker is quick and painless once you have d
 
 ## Configuration and linking to a database container
 
-Follow the [instructions on the docker hub registry](https://registry.hub.docker.com/u/huginn/huginn/) on how to configure Huginn using environment variables and linking the container to an external MySQL or PostgreSQL database.
+Follow the [instructions on the docker hub registry](https://registry.hub.docker.com/r/huginn/huginn/) on how to configure Huginn using environment variables and linking the container to an external MySQL or PostgreSQL database.
 
 ## Running each Huginn process in a seperate container
 


### PR DESCRIPTION
Original link gives weird blank page:

![Screenshot from 2019-12-13 18-45-16](https://user-images.githubusercontent.com/4094542/70839080-23907580-1dd9-11ea-9226-8a9e25f0e26a.png)

New link:

![Screenshot from 2019-12-13 18-45-38](https://user-images.githubusercontent.com/4094542/70839088-2a1eed00-1dd9-11ea-9f18-e86976579bd2.png)
