### PR TITLE
Sql installation info

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -104,11 +104,11 @@ Check the installed MySQL version (remember if its >= 5.5.3 for the `.env` confi
 
     mysql --version
 
-Secure your installation. During this step, you will be prompted to pick a MySQL root password (can be anything). 
+Secure your installation. During this step, you will be prompted to pick a MySQL root password (can be anything)
 
     sudo mysql_secure_installation
 
-The `mysql_secure_installation` script does not apply the user-provided password to the MySQL root user on Ubuntu systems -- to apply a password to the MySQL root user on Ubuntu systems, see the [additional notes section](#set-password-for-root-MySQL-user-on-Ubuntu) for more information before proceeding
+The `mysql_secure_installation` script does not apply the user-provided password to the MySQL root user on Ubuntu systems. To apply a password to the MySQL root user on Ubuntu systems, see the [additional notes section](#set-password-for-root-MySQL-user-on-Ubuntu) for more information before proceeding.
 
 Login to MySQL using the root password you set in the previous steps
 
@@ -427,13 +427,13 @@ Debian Stretch switched from MySQL to [MariaDB](https://mariadb.org/). All packa
 
 #### Set password for root MySQL user on Ubuntu
 
-MySQL installations (>= version 5.7.26) on Ubuntu use the UNIX `auth_socket` plugin by default, such that authentication is handled by system user credientials. In order to access the MySQL root user from any system user, you have to set the MySQL root user password in user database. Sign into the MySQL shell 
+MySQL installations (>= 5.7.26) on Ubuntu use the UNIX `auth_socket` plugin by default, such that authentication is handled by system user credientials. In order to access the MySQL root user from any system user, you have to set the MySQL root user password in the user database. Sign into the MySQL shell 
 
     sudo mysql -u root -p
 
 Once in the MySQL shell, run the following command to set the password for the root user by replacing `new-password` with a password of your choice
 
-    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root-pass';
+    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'new-password';
 
 After the change has been made, exit the MySQL shell with `\q`. 
 

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -104,11 +104,13 @@ Check the installed MySQL version (remember if its >= 5.5.3 for the `.env` confi
 
     mysql --version
 
-Secure your installation. During this step, you will be prompted to pick a MySQL root password (can be anything)
+Secure your installation. During this step, you will be prompted to pick a MySQL root password (can be anything). 
 
     sudo mysql_secure_installation
 
-Login to MySQL
+The `mysql_secure_installation` script does not apply the user-provided password to the MySQL root user on Ubuntu systems -- to apply a password to the MySQL root user on Ubuntu systems, see the [additional notes section](#set-password-for-root-MySQL-user-on-Ubuntu) for more information before proceeding
+
+Login to MySQL using the root password you set in the previous steps
 
     mysql -u root -p
 
@@ -422,3 +424,19 @@ You probably found an error message or exception backtrace you could not resolve
 ### Additional notes
 
 Debian Stretch switched from MySQL to [MariaDB](https://mariadb.org/). All packages with `mysql` in the name are just wrappers around the MariaDB ones, with some containing some compatibility symlinks. Huginn should also work fine with the MariaDB packages directly, although to keep the installation instructions more compact, they still use the MySQL packages.
+
+#### Set password for root MySQL user on Ubuntu
+
+MySQL installations (>= version 5.7.26) on Ubuntu use the UNIX `auth_socket` plugin by default, such that authentication is handled by system user credientials. In order to access the MySQL root user from any system user, you have to set the MySQL root user password in user database. Sign into the MySQL shell 
+
+    sudo mysql -u root -p
+
+Once in the MySQL shell, run the following command to set the password for the root user by replacing `new-password` with a password of your choice
+
+    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root-pass';
+
+After the change has been made, exit the MySQL shell with `\q`. 
+
+For the change to propogate, restart the MySQL server
+
+    sudo service mysql restart

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -431,6 +431,8 @@ MySQL installations (>= 5.7.26) on Ubuntu use the UNIX `auth_socket` plugin by d
 
     sudo mysql -u root -p
 
+    # The default password upon installation is blank
+
 Once in the MySQL shell, run the following command to set the password for the root user by replacing `new-password` with a password of your choice
 
     ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'new-password';


### PR DESCRIPTION
A follow-up to #2643. When installing mysql-server on Ubuntu, the `mysql_secure_installation` doesn't apply the user-provided password to the MySQL root user. Instead, the installation uses the UNIX `auth_socket` plugin, which handles authentication to the db through system user credentials.

When doing a fresh installation of mysql-server and signing into the db using `sudo mysql -u root -p` (the password is blank by default on a fresh installation):
```
mysql> select user, plugin from user;
+------------------+-----------------------+
| user             | plugin                |
+------------------+-----------------------+
| root             | auth_socket           |
| mysql.session    | mysql_native_password |
| mysql.sys        | mysql_native_password |
| debian-sys-maint | mysql_native_password |
+------------------+-----------------------+
4 rows in set (0.00 sec)
```

We can update the  MySQL root user password through the following:
```
mysql> ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'new-password';
```

After updating the root user password through the db, we can access the root user from any system user  by providing the proper password and follow along with the rest of the steps in the installation guide. 
```
mysql> select user, plugin from user;
+------------------+-----------------------+
| user             | plugin                |
+------------------+-----------------------+
| root             | mysql_native_password |
| mysql.session    | mysql_native_password |
| mysql.sys        | mysql_native_password |
| debian-sys-maint | mysql_native_password |
+------------------+-----------------------+
4 rows in set (0.00 sec)
```
Because I think this may be an Ubuntu specific quirk, I point users to the additional-info section to see how to set the MySQL root user password. 