### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ services:
   - mysql
   - postgresql
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem install bundler -v '< 2' --conservative --force
 env:
   global:
     - APP_SECRET_TOKEN=b2724973fd81c2f4ac0f92ac48eb3f0152c4a11824c122bcf783419a4c51d8b9bba81c8ba6a66c7de599677c7f486242cf819775c433908e77c739c5c8ae118d


### PR DESCRIPTION
Remove the rubygems update and force the installation of bundler 1
(which seems to be a noop at the moment because Travis defaults to
bundler 1 still).

* We can't update rubygems because it's bundler version conflicts with
  the default bundler installation and there is no command line argument
  to force the installation https://travis-ci.org/huginn/huginn/jobs/626595793
* We can't uninstall bundler before updating rubygems because it's a
  default gem https://travis-ci.org/huginn/huginn/jobs/627174885