### PR TITLE
Upgrade rack to 2.0.8 to fix CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     public_suffix (3.0.2)
-    rack (2.0.6)
+    rack (2.0.8)
     rack-livereload (0.3.16)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
I am almost certain that we are not affected because we don't store the
session on the server, but as always, better safe than sorry.

https://github.com/advisories/GHSA-hrqr-hxpp-chr3