### PR TITLE
Allow Agents injected as GEMs to define a UI

### DIFF
--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -1,9 +1,8 @@
 module AgentHelper
+
   def agent_show_view(agent)
-    name = agent.short_type.underscore
-    if File.exist?(Rails.root.join("app", "views", "agents", "agent_views", name, "_show.html.erb"))
-      File.join("agents", "agent_views", name, "show")
-    end
+    path = File.join('agents', 'agent_views', @agent.short_type.underscore, 'show')
+    return self.controller.template_exists?(path, [], true) ? path : nil
   end
 
   def toggle_disabled_text


### PR DESCRIPTION
While building an agent as a GEM I found some difficulties adding a [custom UI](https://github.com/huginn/huginn/wiki/Creating-a-new-agent#ui) due to the views paths scope.

With a [small change](https://github.com/alessio-signorini/huginn_agent/commit/5a943eba239e80496094108420bc8d7299c85108) in `huginn_agent` agents can be defined as Rails Engine and thus be able to define additional models, views, controller and routes in them.

This PR cleans up the code in `AgentHelper.agent_show_view` and allows external agent gems to define their own partial in `app/views/agents/agent_views/<agent_name>/_show.html.erb` exactly as if they were located in the main codebase.