### PR TITLE
Update README.md about dockers images, adds details about seeding

### DIFF
--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -41,6 +41,7 @@ It will also seed the database (rake db:seed) unless this is defined:
     DO_NOT_SEED
 
 This same seeding initially defines the "admin" user with a default password of "password" as per the standard Huginn documentation.
+You can customize the admin account name with the environment variable ``SEED_USERNAME`` and ``SEED_PASSWORD``.
 
 If you do not wish to have the default 6 agents, you will want to set the above environment variable after your initially deploy, otherwise they will be added automatically the next time a container pointing at the database is spun up.
 

--- a/docker/single-process/README.md
+++ b/docker/single-process/README.md
@@ -35,6 +35,7 @@ It will also seed the database (rake db:seed) unless this is defined:
     DO_NOT_SEED
 
 This same seeding initially defines the "admin" user with a default password of "password" as per the standard Huginn documentation.
+You can customize the admin account name with the environment variable ``SEED_USERNAME`` and ``SEED_PASSWORD``.
 
 If you do not wish to have the default 6 agents, you will want to set the above environment variable after your initially deploy, otherwise they will be added automatically the next time a container pointing at the database is spun up.
 


### PR DESCRIPTION
Add details about initial seeding of admin account.
Linked to #2667 as I was a bit confused about the admin user.