### PR TITLE
Install the latest jq for JqAgent

### DIFF
--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -28,7 +28,7 @@ apt-get update
 $minimal_apt_get_install build-essential checkinstall git-core \
   zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \
   libncurses5-dev libffi-dev libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev \
-  graphviz libgraphviz-dev jq \
+  graphviz libgraphviz-dev \
   libmysqlclient-dev libpq-dev libsqlite3-dev \
   ruby2.5 ruby2.5-dev
 locale-gen en_US.UTF-8
@@ -42,6 +42,10 @@ rm -rf /usr/share/doc/
 rm -rf /usr/share/man/
 rm -rf /usr/share/locale/
 rm -rf /var/log/*
+
+# Install the latest jq for JqAgent
+curl -fsSL -o /usr/local/bin/jq https://stedolan.github.io/jq/download/linux64/jq
+chmod +x /usr/local/bin/jq
 
 mkdir -p /app
 chmod -R g=u /etc/passwd /app

--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -27,7 +27,7 @@ add-apt-repository -y ppa:brightbox/ruby-ng
 apt-get update
 $minimal_apt_get_install build-essential checkinstall git-core \
   zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \
-  libncurses5-dev libffi-dev libxml2-dev libxslt-dev libcurl4-openssl-dev libicu-dev \
+  libncurses5-dev libffi-dev libxml2-dev libxslt-dev curl libcurl4-openssl-dev libicu-dev \
   graphviz libgraphviz-dev \
   libmysqlclient-dev libpq-dev libsqlite3-dev \
   ruby2.5 ruby2.5-dev


### PR DESCRIPTION
This should fix #2672.  Ubuntu 14.04 only has jq 1.3 which cannot be detected by JqAgent because of the output format of `jq --version` in that ancient version.