### PR TITLE
Upgrade rake and nokogiri to fix CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem 'liquid', '~> 4.0.3'
 gem 'loofah', '~> 2.0'
 gem 'mini_magick', ">= 4.9.4"
 gem 'multi_xml'
-gem 'nokogiri'
+gem "nokogiri", ">= 1.10.8"
 gem 'omniauth', '~> 1.6.1'
 gem 'rails', '~> 5.2.0'
 gem 'sprockets', '~> 3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -419,7 +419,7 @@ GEM
     net-ssh (5.0.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -508,7 +508,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     raindrops (0.17.0)
-    rake (12.3.2)
+    rake (12.3.3)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -720,7 +720,7 @@ DEPENDENCIES
   multi_xml
   mysql2 (~> 0.5.2)
   net-ftp-list (~> 3.2.8)
-  nokogiri
+  nokogiri (>= 1.10.8)
   omniauth (~> 1.6.1)
   omniauth-37signals
   omniauth-dropbox-oauth2!


### PR DESCRIPTION
```
CVE-2020-8130
moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3

There is an OS command injection vulnerability in Ruby Rake before
12.3.3 in Rake::FileList when supplying a filename that begins with the
   pipe character |.
```

```
CVE-2020-7595
moderate severity
Vulnerable versions: < 1.10.8
Patched version: 1.10.8

xmlStringLenDecodeEntities in parser.c in libxml2 2.9.10 has an infinite
loop in a certain end-of-file situation.
The Nokogiri RubyGem has patched it's vendored copy of libxml2 in order
to prevent this issue from affecting nokogiri.
```