### PR TITLE
let map_marker can return arrow

### DIFF
--- a/app/assets/javascripts/map_marker.js.coffee
+++ b/app/assets/javascripts/map_marker.js.coffee
@@ -12,14 +12,7 @@ window.map_marker = (map, options = {}) ->
       center: pos
       radius: options.radius
     return marker
-  else
-    marker = new google.maps.Marker
-      map: map
-      position: pos
-      title: 'Recorded Location'
-    return marker
-
-  if options.course
+  else if options.course
     p1 = new LatLon(pos.lat(), pos.lng())
     speed = options.speed ? 1
     p2 = p1.destinationPoint(options.course, Math.max(0.2, speed) * 0.1)
@@ -41,5 +34,10 @@ window.map_marker = (map, options = {}) ->
           offset: '100%'
         }
       ]
-
     return arrow
+  else
+    marker = new google.maps.Marker
+      map: map
+      position: pos
+      title: 'Recorded Location'
+    return marker


### PR DESCRIPTION
By now, the function `map_marker` will never return an arrow, which means no direction arrow can show on a map.

This PR will make a location with a `course` attribute return as an arrow.

Here is a preview:
![image](https://user-images.githubusercontent.com/1995921/76216134-62588f00-6253-11ea-8012-93272496c6a3.png)

Also, I made a docker image for test https://hub.docker.com/r/gimo/huginn
