### PR TITLE
Ruby Gemfile requires ruby >= 2.4, OCP Templates still referenced 2.3 for the image

### DIFF
--- a/openshift/templates/huginn-mysql.json
+++ b/openshift/templates/huginn-mysql.json
@@ -102,7 +102,7 @@
                     "from": {
                         "kind": "ImageStreamTag",
                         "namespace": "${NAMESPACE}",
-                        "name": "ruby:2.3"
+                        "name": "ruby:latest"
                     },
                     "env": [{
                         "name": "APP_SECRET_TOKEN",

--- a/openshift/templates/huginn-mysql.json
+++ b/openshift/templates/huginn-mysql.json
@@ -102,7 +102,7 @@
                     "from": {
                         "kind": "ImageStreamTag",
                         "namespace": "${NAMESPACE}",
-                        "name": "ruby:latest"
+                        "name": "ruby:4.5"
                     },
                     "env": [{
                         "name": "APP_SECRET_TOKEN",

--- a/openshift/templates/huginn-postgresql.json
+++ b/openshift/templates/huginn-postgresql.json
@@ -102,7 +102,7 @@
                     "from": {
                         "kind": "ImageStreamTag",
                         "namespace": "${NAMESPACE}",
-                        "name": "ruby:2.3"
+                        "name": "ruby:latest"
                     },
                     "env": [{
                         "name": "APP_SECRET_TOKEN",

--- a/openshift/templates/huginn-postgresql.json
+++ b/openshift/templates/huginn-postgresql.json
@@ -102,7 +102,7 @@
                     "from": {
                         "kind": "ImageStreamTag",
                         "namespace": "${NAMESPACE}",
-                        "name": "ruby:latest"
+                        "name": "ruby:4.5"
                     },
                     "env": [{
                         "name": "APP_SECRET_TOKEN",


### PR DESCRIPTION


* huginn-mysql.json: increased ruby version to latest (2.5 at time of editing)
* huginn-postgresql.json: increased ruby version to latest (2.5 at time of editing)

Signed-off-by: Brian Tannous <brian@briantannous.com>
Signed-off-by: Brian Tannous <btannous@redhat.com>

Co-authored-by: Jason Dobies  <jdobies@redhat.com>
Co-authored-by: JJ Asghar <awesome@ibm.com>