### PR TITLE
Allow to create `LongRunnable` Agent gems

### DIFF
--- a/bin/pre_runner_boot.rb
+++ b/bin/pre_runner_boot.rb
@@ -9,5 +9,3 @@ end
 Rails.configuration.cache_classes = true
 
 Dotenv.load if ENV['APP_SECRET_TOKEN'].blank?
-
-require 'agent_runner'


### PR DESCRIPTION
Instead of explicitly requiring `agent_runner`, reply on the Rails
autoloader. This prevents the file being loaded twice if a Agent gem
uses `LongRunnable::Worker`.

Inheriting triggers auto loading of the `AgentRunner` class very early
in the boot process. This initializes the long runnable Agent registry
and fills the `@@agents` array with all LongRunnable agents.

When `lib/agent_runner` was then required again in `bin/pre_runner_boot.rb`,
the class is re-loaded and the long runnable Agent registry was empty.

 #2704