### PR TITLE
Add ping util to Docker container

### DIFF
--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -29,7 +29,7 @@ $minimal_apt_get_install build-essential checkinstall git-core \
   zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \
   libncurses5-dev libffi-dev libxml2-dev libxslt-dev curl libcurl4-openssl-dev libicu-dev \
   graphviz libmysqlclient-dev libpq-dev libsqlite3-dev \
-  ruby2.5 ruby2.5-dev locales tzdata
+  ruby2.5 ruby2.5-dev locales tzdata iputils-ping
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 gem install --no-document bundler -v 1.17.3


### PR DESCRIPTION
This change adds the ping util back to the Docker container which was a regression from https://github.com/huginn/huginn/commit/9d3b5ec326a1792ddd4482bd64f23022cfef92c9.

Ubuntu 18.04 does not include this in the base image anymore.