### PR TITLE
Extend Twilio Message Length

### DIFF
--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -54,7 +54,7 @@ module Agents
           end
 
           if boolify(interpolated['receive_text'])
-            message = message.slice 0..160
+            message = message.slice 0..1600
             send_message message
           end
         end


### PR DESCRIPTION
Twilio supports messages up to 1600 characters in length. This patches the previous hardcoded 160-char length in the Agent to be 1600 characters.

This addresses https://github.com/huginn/huginn/issues/2755

I tested it out a few times with SMSes to myself. They were:
1. Emitted by my Huginn's Twilio Agent as 212 character strings
2. Segmented by Twilio into two separate messages
3. Re-concatenated on my device by the carrier (or OS?)

Either way, they came through as expected in a single message. Please review and test out a bit more though :)

https://support.twilio.com/hc/en-us/articles/360033806753-Maximum-Message-Length-with-Twilio-Programmable-Messaging

Most carriers will concatenate messages into a single message on the device https://support.twilio.com/hc/en-us/articles/223181508-Does-Twilio-support-concatenated-SMS-messages-or-messages-over-160-characters-