### PR TITLE
[docker] Fix mysql volume usage for new multi-process containers

### DIFF
--- a/docker/multi-process/scripts/bootstrap.sh
+++ b/docker/multi-process/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ if [ "${START_MYSQL}" = "true" ]; then
 
   # initialize MySQL data directory
   if [ ! -d /var/lib/mysql/mysql ]; then
-    mysql_install_db --admin-auth-plugin=mysql_native_password --insecure --user=$(whoami) --datadir=/tmp/mysql
+    mysqld --initialize-insecure --user=$(whoami) --datadir=/tmp/mysql
     mv -f /tmp/mysql/* /var/lib/mysql/
   fi
 


### PR DESCRIPTION
The Ubuntu upgrade (or changes to MySQL after the update was initially
tested) broke the usage of mounting a directory as the MySQL data volume
for the multi-process image.

Why `--admin-auth-plugin=mysql_native_password` was needed (or I thought
it was needed) is beyond me now. Passing the `mysqld` process the
`--init-file` option which creates our database user seems to work in
all use cases.

 #2745
 #2757