### PR TITLE
Allow to explicitly inflate `WebRequestConcern` responses using deflate

### DIFF
--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -29,6 +29,8 @@ module WebRequestConcern
         case @unzip
         when 'gzip'.freeze
           body.replace(ActiveSupport::Gzip.decompress(body))
+        when 'deflate'.freeze
+          body.replace(Zlib::Inflate.inflate(body))
         end
 
         case

--- a/app/models/agents/post_agent.rb
+++ b/app/models/agents/post_agent.rb
@@ -49,6 +49,7 @@ module Agents
           * `basic_auth` - Specify HTTP basic auth parameters: `"username:password"`, or `["username", "password"]`.
           * `disable_ssl_verification` - Set to `true` to disable ssl verification.
           * `user_agent` - A custom User-Agent name (default: "Faraday v#{Faraday::VERSION}").
+          * `unzip` - set to `gzip` to inflate the resource using gzip or to `deflate` to inflate using deflate.
 
         #{receiving_file_handling_agent_description}
 

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -165,7 +165,7 @@ module Agents
 
       Set `disable_ssl_verification` to `true` to disable ssl verification.
 
-      Set `unzip` to `gzip` to inflate the resource using gzip.
+      Set `unzip` to `gzip` to inflate the resource using gzip or to `deflate` to inflate using deflate.
 
       Set `http_success_codes` to an array of status codes (e.g., `[404, 422]`) to treat HTTP response codes beyond 200 as successes.
 

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -291,6 +291,35 @@ describe Agents::WebsiteAgent do
         expect(event.payload['version']).to eq(2)
       end
 
+      it 'should use deflate when specified in unzip option' do
+        json = {
+          'response' => {
+            'version' => 2,
+            'title' => "hello!"
+          }
+        }
+        zipped = Zlib::Deflate.deflate(json.to_json)
+        stub_request(:any, /deflate/).to_return(body: zipped, status: 200)
+        site = {
+          'name' => "Some JSON Response",
+          'expected_update_period_in_days' => "2",
+          'type' => "json",
+          'url' => "http://deflate.com",
+          'mode' => 'on_change',
+          'extract' => {
+            'version' => { 'path' => 'response.version' },
+          },
+          'unzip' => 'deflate',
+        }
+        checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+        checker.user = users(:bob)
+        checker.save!
+
+        checker.check
+        event = Event.last
+        expect(event.payload['version']).to eq(2)
+      end
+
       it 'should either avoid or support a raw deflate stream (#1018)' do
         stub_request(:any, /deflate/).with(headers: { 'Accept-Encoding' => /\A(?!.*deflate)/ }).
           to_return(body: 'hello',


### PR DESCRIPTION
Some website do not send the correct header values, the new option value
allows the user to explicitly inflate the response using deflate.