### PR TITLE
Hopefully fix ruby segfault in docker with Rails 6

### DIFF
--- a/docker/scripts/prepare
+++ b/docker/scripts/prepare
@@ -16,7 +16,7 @@ EOF
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
 
-CLEAR_DOCKER_CACHE=2018-08-07
+CLEAR_DOCKER_CACHE=2020-05-28
 
 minimal_apt_get_install='apt-get install -y --no-install-recommends'
 


### PR DESCRIPTION
Something in the docker layer cache must be too old or incompatible with
previous layers. This change should force a full rebuild of the
container.

It is possible that we need to abandon the layer caching optimizations
on all CI systems to ensure we are actually validating changes based on
similar (enough) images.

 #2605