### PR TITLE
Email Agent: Add support for adding a local file attachment 

### DIFF
--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -6,6 +6,11 @@ class SystemMailer < ActionMailer::Base
     @headline = options[:headline]
     @body = options[:body]
 
+    if options[:attachment] and !options[:attachment].empty? and File.file?(options[:attachment])
+      filename = File.basename(options[:attachment])
+      attachments[filename] = File.read(options[:attachment])
+    end
+
     mail_options = { to: options[:to], subject: options[:subject] }
     mail_options[:from] = options[:from] if options[:from].present?
     if options[:content_type].present?

--- a/app/models/agents/email_agent.rb
+++ b/app/models/agents/email_agent.rb
@@ -28,6 +28,8 @@ module Agents
       You can provide a `content_type` for the email and specify `text/plain` or `text/html` to be sent.
       If you do not specify `content_type`, then the recipient email server will determine the correct rendering.
 
+      You can specify a local file `attachment` for the email by providing the fully qualified path and filename.
+
       Set `expected_receive_period_in_days` to the maximum amount of time that you'd expect to pass between Events being received by this Agent.
     MD
 
@@ -54,6 +56,7 @@ module Agents
               headline: interpolated(event)['headline'],
               body: interpolated(event)['body'],
               content_type: interpolated(event)['content_type'],
+              attachment: interpolated(event)['attachment'],
               groups: [present(event.payload)]
             ).deliver_now
             log "Sent mail to #{recipient} with event #{event.id}"

--- a/spec/models/agents/email_agent_spec.rb
+++ b/spec/models/agents/email_agent_spec.rb
@@ -91,6 +91,26 @@ describe Agents::EmailAgent do
       expect(get_message_part(ActionMailer::Base.deliveries.last, /html/).strip).to match(/<body>\s*#{Regexp.escape("console.log('hello, world.')<strong>rain!</strong>")}\s*<\/body>/)
     end
 
+    it "can take attachment option for attaching a file to the email" do
+      @checker.update :options => @checker.options.merge({
+                                                             'subject' => '{{foo.subject}}',
+                                                             'attachment' => '{{attachment}}'
+                                                         })
+      event = Event.new
+      event.agent = agents(:bob_rain_notifier_agent)
+      event.payload = { :foo => { :subject => "Something you should know about" }, :attachment => Rails.root.join('spec', 'data_fixtures', 'podcast.rss') }
+      event.save!
+
+      Agents::EmailAgent.async_receive(@checker.id, [event.id])
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq(["bob@example.com"])
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Something you should know about")
+
+      attachment_part = ActionMailer::Base.deliveries.last.body.parts.find { |p| p.content_type.match /application\/rss/ }
+      expect(attachment_part.filename).to eq("podcast.rss")
+    end
+
     it "can take content type option to set content type of email sent" do
       @checker.update :options => @checker.options.merge({
         'content_type' => 'text/plain'


### PR DESCRIPTION
This PR adds the ability to attach a file to the outgoing email.

<img width="496" alt="Huginn Email Attachment Example 2020-06-01 at 10 46 41 PM" src="https://user-images.githubusercontent.com/395132/83456174-7cbf9480-a45f-11ea-83ff-ca83f7c1b98a.png">

Fixes #2449