### PR TITLE
Note about Email Agent and Gmail with 2-Step-Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Note, Wunderground no longer offers free API keys. You can still use the Weather
 
 We assume your deployment will run over SSL. This is a very good idea! However, if you wish to turn this off, you'll probably need to edit `config/initializers/devise.rb` and modify the line containing `config.rememberable_options = { :secure => true }`.  You will also need to edit `config/environments/production.rb` and modify the value of `config.force_ssl`.
 
+#### Using Email Agent with Gmail and 2-Step-Verification
+
+If you'd like to use the Email Agent with Gmail but your account has 2-Step-Verification enabled, you'll need to [create an App Password](https://support.google.com/accounts/answer/185833) and set SMTP_PASSWORD to the generated value.
+
 ## License
 
 Huginn is provided under the MIT License.


### PR DESCRIPTION
Hi, I've added a small note to the Readme with a small step to make sure Email Agent is working when you have 2-factor authentication enabled in your Google account.
I've wasted a lot of time fixing this issue and couldn't find any related information on this since the error message is not really helpful.

This is a fix for when Email Agent logs this error:
`Exception during receive. 534-5.7.9 Application-specific password required. Learn more at :`