### PR TITLE
Add an option to send email using `sendmail`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,10 @@ IMPORT_DEFAULT_SCENARIO_FOR_ALL_USERS=true
 # SMTP_USER_NAME must be set to none or else you will receive
 # errors that AUTH not enabled.
 
+# Uncomment if you want to use `/usr/sbin/sendmail` to send email instead of SMTP.
+# This option is ignored unless RAILS_ENV=production, and setting it to `sendmail` causes the settings in the rest of this section (except EMAIL_FROM_ADDRESS) to be ignored.
+#SMTP_DELIVERY_METHOD=sendmail
+
 SMTP_DOMAIN=your-domain-here.com
 SMTP_USER_NAME=you@gmail.com
 SMTP_PASSWORD=somepassword

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,7 @@ Huginn::Application.configure do
   end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = ENV.fetch('SMTP_DELIVERY_METHOD', 'smtp').to_sym
   config.action_mailer.perform_caching = false
   # smtp_settings moved to config/initializers/action_mailer.rb
 end


### PR DESCRIPTION
I hacked this up real quick in production to fix an operational problem I was having sending Huginn emails. I have verified that it works as intended (i.e. before flipping the option on Huginn emails were getting rejected by my mail server, but when I turned this on they started delivering).

Some notes:

* Is it ok that this only works in a production environment? I mostly did that because I didn't want to deal with the hassle of making it work in development
* I didn't run the test suite locally because I didn't feel like setting up a development environment and CI will run them anyway