### PR TITLE
Fix `SMTP_DELIVERY_METHOD` being applied as default configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,7 +107,7 @@ IMPORT_DEFAULT_SCENARIO_FOR_ALL_USERS=true
 
 # Uncomment if you want to use `/usr/sbin/sendmail` to send email instead of SMTP.
 # This option is ignored unless RAILS_ENV=production, and setting it to `sendmail` causes the settings in the rest of this section (except EMAIL_FROM_ADDRESS) to be ignored.
-#SMTP_DELIVERY_METHOD=sendmail
+# SMTP_DELIVERY_METHOD=sendmail
 
 SMTP_DOMAIN=your-domain-here.com
 SMTP_USER_NAME=you@gmail.com


### PR DESCRIPTION
The docker initialization scripts (for some reason) require a space
after the `#` comment characters in the `.env.example` configuration to
not apply the configuration values for some reason.

Fixes #2846