### PR TITLE
WebsiteAgent: allow to configure HTTP verb, body and headers

### DIFF
--- a/spec/controllers/agents/dry_runs_controller_spec.rb
+++ b/spec/controllers/agents/dry_runs_controller_spec.rb
@@ -98,7 +98,7 @@ describe Agents::DryRunsController do
         [users(:bob).agents.count, users(:bob).events.count, users(:bob).logs.count, agent.name, agent.updated_at]
       }
       results = assigns(:results)
-      expect(results[:log]).to match(/^\[\d\d:\d\d:\d\d\] INFO -- : Fetching #{Regexp.quote(url_from_event)}$/)
+      expect(results[:log]).to match(/^\[\d\d:\d\d:\d\d\] INFO -- : Fetching #{Regexp.quote(url_from_event)}/)
     end
 
     it "uses the memory of an existing Agent" do


### PR DESCRIPTION
This PR allows to use the `WebsiteAgent` for POST, PUT and DELETE requests.

The default behavior (i.e., `GET` with default headers) of the agent has not been changed.

Agent documentation has been updated with the new options available:
  * `http_verb` - request type (e.g. `post`, `put`, `delete`)
  * `headers` - hash of strings (e.g., `"content-type" => "application/json"`)
  * `post_data` - body in `POST` requests, if a string it will be used as is, if a hash it will be transformed to JSON and the appropriate `content-type` header will be added.
