### PR TITLE
slack] Add support for blocks

### DIFF
--- a/app/models/agents/slack_agent.rb
+++ b/app/models/agents/slack_agent.rb
@@ -1,7 +1,7 @@
 module Agents
   class SlackAgent < Agent
     DEFAULT_USERNAME = 'Huginn'
-    ALLOWED_PARAMS = ['channel', 'username', 'unfurl_links', 'attachments']
+    ALLOWED_PARAMS = ['channel', 'username', 'unfurl_links', 'attachments', 'blocks']
 
     can_dry_run!
     cannot_be_scheduled!


### PR DESCRIPTION
Slack is replacing attachments with blocks.  
Just adding them to the list of allowed parameters :-)

https://api.slack.com/messaging/composing/layouts#adding-blocks