### PR TITLE
Add mail template param

### DIFF
--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -8,10 +8,13 @@ class SystemMailer < ActionMailer::Base
 
     mail_options = { to: options[:to], subject: options[:subject] }
     mail_options[:from] = options[:from] if options[:from].present?
+
+    template = options[:template] if options[:template].present?
+
     if options[:content_type].present?
       mail(mail_options) do |format|
-        format.text if options[:content_type] == "text/plain"
-        format.html if options[:content_type] == "text/html"
+        format.text { render template } if options[:content_type] == "text/plain"
+        format.html { render template } if options[:content_type] == "text/html"
       end
     else
       mail(mail_options)

--- a/app/mailers/system_mailer.rb
+++ b/app/mailers/system_mailer.rb
@@ -13,8 +13,10 @@ class SystemMailer < ActionMailer::Base
 
     if options[:content_type].present?
       mail(mail_options) do |format|
-        format.text { render template } if options[:content_type] == "text/plain"
-        format.html { render template } if options[:content_type] == "text/html"
+        format.text if !template && options[:content_type] == "text/plain"
+        format.html if !template && options[:content_type] == "text/html"
+        format.text { render inline: template } if template && options[:content_type] == "text/plain"
+        format.html { render inline: template } if template && options[:content_type] == "text/html"
       end
     else
       mail(mail_options)

--- a/app/models/agents/email_agent.rb
+++ b/app/models/agents/email_agent.rb
@@ -28,8 +28,8 @@ module Agents
       You can provide a `content_type` for the email and specify `text/plain` or `text/html` to be sent.
       If you do not specify `content_type`, then the recipient email server will determine the correct rendering.
 
-      For more complex message formatting, if you specify a `content_type` then you can also provide an alternate message `template` name.  A user-defined
-      `template` matching the name which must be located in `'../huginn/app/views/system_mailer'` as `<template_name>.html.erb` or `<template_name>.text.erb`.
+      For more complex message formatting, if you specify a `content_type` then you can also provide an alternate message `template`.
+      It is best to use the liquid `credential` tag like so `{% credential message_template %}` to define the template format.
 
       Set `expected_receive_period_in_days` to the maximum amount of time that you'd expect to pass between Events being received by this Agent.
     MD

--- a/app/models/agents/email_agent.rb
+++ b/app/models/agents/email_agent.rb
@@ -28,6 +28,9 @@ module Agents
       You can provide a `content_type` for the email and specify `text/plain` or `text/html` to be sent.
       If you do not specify `content_type`, then the recipient email server will determine the correct rendering.
 
+      For more complex message formatting, if you specify a `content_type` then you can also provide an alternate message `template` name.  A user-defined
+      `template` matching the name which must be located in `'../huginn/app/views/system_mailer'` as `<template_name>.html.erb` or `<template_name>.text.erb`.
+
       Set `expected_receive_period_in_days` to the maximum amount of time that you'd expect to pass between Events being received by this Agent.
     MD
 
@@ -54,6 +57,7 @@ module Agents
               headline: interpolated(event)['headline'],
               body: interpolated(event)['body'],
               content_type: interpolated(event)['content_type'],
+              template: interpolated(event)['template'],
               groups: [present(event.payload)]
             ).deliver_now
             log "Sent mail to #{recipient} with event #{event.id}"


### PR DESCRIPTION
Proposing the following to allow complex/custom html or text email templates.

May be an alternate solution to #2541 

This allows for a complete custom template to be defined and referenced in the EmailAgent options