### PR TITLE
Update installation.md with non-ambiguous --progress-bar  flag for curl

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -72,7 +72,7 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2 | tar xj
+    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2 | tar xj
     cd ruby-2.6.5
     ./configure --disable-install-rdoc
     make -j`nproc`


### PR DESCRIPTION
using the `--progress` flag for `curl` to install Ruby yields: 

```
kathyreid@kathyreid-zenbook-ux533fd:/tmp/ruby$ curl -L --progress https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2 | tar xj
curl: option --progress: is ambiguous
curl: try 'curl --help' or 'curl --man
```
This PR is a minor change to use `--progress-bar` flag instead.