### PR TITLE
Docker - allow use of secrets when using Docker Swarm

### DIFF
--- a/docker/scripts/setup_env
+++ b/docker/scripts/setup_env
@@ -5,6 +5,29 @@ export LC_ALL=en_US.UTF-8
 
 cd /app
 
+# taken straight from mysql docker
+# https://github.com/docker-library/mysql/blob/master/5.7/docker-entrypoint.sh#L21-L40
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ -f /app/tmp/pids/delayed_job.pid ]; then
   rm /app/tmp/pids/delayed_job.pid
 fi
@@ -33,11 +56,33 @@ else
     START_MYSQL=${START_MYSQL:-true}
 fi
 
+# Initialize values that might be stored in a file
+file_env 'DATABASE_PASSWORD' ${HUGINN_DATABASE_PASSWORD:-${DATABASE_PASSWORD:-password}}
+file_env 'SMTP_USER_NAME'
+file_env 'SMTP_PASSWORD'
+file_env 'TWITTER_OAUTH_KEY'
+file_env 'TWITTER_OAUTH_SECRET'
+file_env 'APP_SECRET_TOKEN'
+file_env 'THIRTY_SEVEN_SIGNALS_OAUTH_KEY'
+file_env 'THIRTY_SEVEN_SIGNALS_OAUTH_SECRET'
+file_env 'GITHUB_OAUTH_KEY'
+file_env 'GITHUB_OAUTH_SECRET'
+file_env 'TUMBLR_OAUTH_KEY'
+file_env 'TUMBLR_OAUTH_SECRET'
+file_env 'DROPBOX_OAUTH_KEY'
+file_env 'DROPBOX_OAUTH_SECRET'
+file_env 'WUNDERLIST_OAUTH_KEY'
+file_env 'WUNDERLIST_OAUTH_SECRET'
+file_env 'EVERNOTE_OAUTH_KEY'
+file_env 'EVERNOTE_OAUTH_SECRET'
+file_env 'AWS_ACCESS_KEY_ID'
+file_env 'AWS_ACCESS_KEY'
+
 USE_GRAPHVIZ_DOT=${HUGINN_USE_GRAPHVIZ_DOT:-${USE_GRAPHVIZ_DOT:-dot}}
 DATABASE_HOST=${HUGINN_DATABASE_HOST:-${DATABASE_HOST:-localhost}}
 DATABASE_PORT=${HUGINN_DATABASE_PORT:-${DATABASE_PORT}}
 DATABASE_ENCODING=${HUGINN_DATABASE_ENCODING:-${DATABASE_ENCODING}}
-DATABASE_PASSWORD=${HUGINN_DATABASE_PASSWORD:-${DATABASE_PASSWORD:-password}}
+#DATABASE_PASSWORD=${HUGINN_DATABASE_PASSWORD:-${DATABASE_PASSWORD:-password}}
 DATABASE_NAME=${HUGINN_DATABASE_NAME:-${DATABASE_NAME:-huginn_production}}
 RAILS_ENV=${HUGINN_RAILS_ENV:-${RAILS_ENV:-production}}
 RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:-true}


### PR DESCRIPTION
This PR modifies `docker/scripts/setup_env` to allow a user to pass sensitive data via Docker Secrets, which when used reference a file within the container at `/run/secrets/` 

This method leverages code from the [mysql docker](https://github.com/docker-library/mysql/blob/master/5.7/docker-entrypoint.sh#L21-L40) which achieves the same objective.

An example use would be

1. first create some secrets
```
openssl rand -base64 20 | docker secret create huginn_mysql_root_password -
openssl rand -base64 20 | docker secret create huginn_mysql_huggin_password -

echo -n '[...snip...]' | docker secret create huginn_twitter_oauth_secret -
echo -n '[...snip...]' | docker secret create huginn_twitter_oauth_key -
echo -n '[...snip...]' | docker secret create huginn_smtp_password -
```
2.  map them into the container and start the services
```
docker service create --replicas 1 --name huginn_web \
    --publish published=80,target=3000 \
    --network=huginn-private \
    --env-file=/data/huginn.env \
    --secret huginn_mysql_root_password \
    --secret huginn_mysql_huginn_password \
    --secret huginn_twitter_oauth_secret \
    --secret huginn_twitter_oauth_key \
    --secret huginn_smtp_password \
    huginn/huginn-single-process

docker service create --replicas 5 --name huginn_delayed_job \
    --env-file=/data/huginn.env \
    --network=huginn-private \
    --secret huginn_mysql_huginn_password \
    --secret huginn_twitter_oauth_secret \
    --secret huginn_twitter_oauth_key \
    --secret huginn_smtp_password \
    huginn/huginn-single-process /scripts/init script/delayed_job run

docker service create --replicas 1 --name huginn_agent_runner \
    --env-file=/data/huginn.env \
    --network=huginn-private \
    --secret huginn_mysql_huginn_password \
    --secret huginn_twitter_oauth_secret \
    --secret huginn_twitter_oauth_key \
    --secret huginn_smtp_password \
    huginn/huginn-single-process /scripts/init bin/agent_runner.rb
```
