### PR TITLE
Add a "payload" option to ManualEventAgent

### DIFF
--- a/app/models/agents/manual_event_agent.rb
+++ b/app/models/agents/manual_event_agent.rb
@@ -6,14 +6,18 @@ module Agents
     description <<-MD
       The Manual Event Agent is used to manually create Events for testing or other purposes.
 
-      Do not set options for this Agent.  Instead, connect it to other Agents and create Events
-      using the UI provided on this Agent's Summary page.
+      Connect this Agent to other Agents and create Events using the UI provided on this Agent's Summary page.
+
+      You can set the default event payload via the "payload" option.
     MD
 
-    event_description "User determined"
+    event_description do
+      "Events are editable in the UI.  The default value is this:\n\n    " +
+        Utils.pretty_print(options["payload"].presence || {})
+    end
 
     def default_options
-      { "no options" => "are needed" }
+      { "payload" => {} }
     end
 
     def handle_details_post(params)

--- a/app/views/agents/agent_views/manual_event_agent/_show.html.erb
+++ b/app/views/agents/agent_views/manual_event_agent/_show.html.erb
@@ -16,7 +16,7 @@
 <%= form_tag handle_details_post_agent_path(@agent), :id => "create-event-form" do %>
   <div class="form-group">
     <textarea rows="10" id="payload" name="payload" class="payload-editor" data-height="200">
-      {}
+      <%= (@agent.options["payload"].presence || {}).to_json %>
     </textarea>
   </div>
 


### PR DESCRIPTION
The option gives an agent a default payload to make it easier to repeatedly test a workflow.

This addresses #1943.