### PR TITLE
Fix DB connection retries functionality in docker container

### DIFF
--- a/docker/multi-process/scripts/foreman.sh
+++ b/docker/multi-process/scripts/foreman.sh
@@ -12,8 +12,8 @@ if [ -n "${DATABASE_INITIAL_CONNECT_MAX_RETRIES}" ]; then
   count=0
   while ! rake database_test:ping > /dev/null 2>&1 && [[ $count -le $max ]] ; do
     count=$[$count+1]
-    echo "Retry $count of $max attempting to connect to $DATABASE_HOST. Sleeping ${DATABASE_INITIAL_CONNECT_SLEEP:5}"
-    sleep ${DATABASE_INITIAL_CONNECT_SLEEP:5}
+    echo "Retry $count of $max attempting to connect to $DATABASE_HOST. Sleeping ${DATABASE_INITIAL_CONNECT_SLEEP:-5}"
+    sleep ${DATABASE_INITIAL_CONNECT_SLEEP:-5}
   done
 fi
 


### PR DESCRIPTION
Currently, if setting env var DATABASE_INITIAL_CONNECT_MAX_RETRIES when creating docker container, foreman fails with error:

sleep: missing operand
Try 'sleep --help' for more information.

The reason is that default value for variable DATABASE_INITIAL_CONNECT_SLEEP is set incorrectly in foreman.sh. According to https://tldp.org/LDP/abs/html/parameter-substitution.html, the correct format is "{variable:-default}", not "{variable:default}".

This PR resolves the issue.