### PR TITLE
Allow email agent to run on schedule

### DIFF
--- a/app/models/agents/email_agent.rb
+++ b/app/models/agents/email_agent.rb
@@ -3,7 +3,7 @@ module Agents
     include EmailConcern
 
     can_dry_run!
-    cannot_be_scheduled!
+    default_schedule "never"
     cannot_create_events!
     no_bulk_receive!
 


### PR DESCRIPTION
This small change will allow the email agent to send emails on a schedule.

Useful for sending pings out with the same data every so often.