### PR TITLE
Default value not working.

### DIFF
--- a/app/models/agents/webhook_agent.rb
+++ b/app/models/agents/webhook_agent.rb
@@ -33,7 +33,7 @@ module Agents
         * `code` - The response code to the request. Defaults to '201'. If the code is '301' or '302' the request will automatically be redirected to the url defined in "response".
         * `recaptcha_secret` - Setting this to a reCAPTCHA "secret" key makes your agent verify incoming requests with reCAPTCHA.  Don't forget to embed a reCAPTCHA snippet including your "site" key in the originating form(s).
         * `recaptcha_send_remote_addr` - Set this to true if your server is properly configured to set REMOTE_ADDR to the IP address of each visitor (instead of that of a proxy server).
-        * `score_threshold` - Setting this when using reCAPTCHA v3 to define the treshold when a submission is verified. Defaults to 0.5
+        * `score_threshold` - Setting this when using reCAPTCHA v3 to define the threshold when a submission is verified. Defaults to 0.5
       MD
     end
 


### PR DESCRIPTION
For some reason the default option defined in following code fragment is not appearing in the `interpolated` object/array. I'm not familiar with ruby and not really sure how the `interpolated` works. Could you point me in the right direction, please? Fixed a typo along the way.
https://github.com/huginn/huginn/blob/a61924f90333b8305365273c1746bb9ea75ede57/app/models/agents/webhook_agent.rb#L47-L54