### PR TITLE
Use smarter type detection for AssignableTypes

### DIFF
--- a/app/concerns/assignable_types.rb
+++ b/app/concerns/assignable_types.rb
@@ -16,10 +16,9 @@ module AssignableTypes
 
   module ClassMethods
     def load_types_in(module_name, my_name = module_name.singularize)
-      mod = module_name.constantize
       const_set(:MODULE_NAME, module_name)
       const_set(:BASE_CLASS_NAME, my_name)
-      types = mod.constants
+      types = module_name.constantize.constants
         .select {|t| t.to_s.include?(my_name)}
         .map {|t| "#{module_name}::#{t}"}
       const_set(:TYPES, types)

--- a/app/concerns/assignable_types.rb
+++ b/app/concerns/assignable_types.rb
@@ -16,9 +16,13 @@ module AssignableTypes
 
   module ClassMethods
     def load_types_in(module_name, my_name = module_name.singularize)
+      mod = module_name.constantize
       const_set(:MODULE_NAME, module_name)
       const_set(:BASE_CLASS_NAME, my_name)
-      const_set(:TYPES, Dir[Rails.root.join("app", "models", module_name.underscore, "*.rb")].map { |path| module_name + "::" + File.basename(path, ".rb").camelize })
+      types = mod.constants
+        .select {|t| t.to_s.include?(my_name)}
+        .map {|t| "#{module_name}::#{t}"}
+      const_set(:TYPES, types)
     end
 
     def types


### PR DESCRIPTION
Hi there,

This PR stems from an issue I've asked about in [Gitter](https://gitter.im/huginn/huginn?at=5ffbbe53d5f4bf2965db5118) but didn't end up with a response, so I figured I'd submit the fix myself.

When developing agents locally and importing them via the `ADDITIONAL_GEMS=some_agent(path:../some_agent)` pathway, I noticed that any agents within the gems wouldn't end up in the agents list of the agent creation page. Doing some digging, I found that the reason was that the dropdown was being populated, via various layers of the stack, by this line in `assignable_types.rb`:

```ruby
const_set(:TYPES, Dir[Rails.root.join("app", "models", module_name.underscore, "*.rb")].map { |path| module_name + "::" + File.basename(path, ".rb").camelize })
```

Searching through the `app/models/agents` directory naturally omits agents provided by gems, as they're stored not only outside of that directory, but even outside of the Huginn project root. This PR fixes this by populating the `TYPES` constant with the actual list of constants contained by the namespace at runtime.

The one thing I'm a little stumped on is how this list ends up getting populated properly (ie including agens in gems) when in production, as this is an issue I've only been able to replicate on my development instance. Perhaps there's something I'm missing here, but otherwise this seems like a pretty straightforward fix.