### PR TITLE
Update Twilio API Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 
 # Optional libraries.  To conserve RAM, comment out any that you don't need,
 # then run `bundle` and commit the updated Gemfile and Gemfile.lock.
-gem 'twilio-ruby', '~> 3.11.5'    # TwilioAgent
+gem 'twilio-ruby', '~> 5.48.0'    # TwilioAgent
 gem 'ruby-growl', '~> 4.1.0'      # GrowlAgent
 gem 'net-ftp-list', '~> 3.2.8'    # FtpsiteAgent
 gem 'forecast_io', '~> 2.0.0'     # WeatherAgent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -639,10 +639,10 @@ GEM
     to_regexp (0.2.1)
     treetop (1.6.10)
       polyglot (~> 0.3)
-    twilio-ruby (3.11.6)
-      builder (>= 2.1.2)
-      jwt (>= 0.1.2)
-      multi_json (>= 1.3.0)
+    twilio-ruby (5.48.0)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
@@ -779,7 +779,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.1)
   sprockets (~> 3.7.2)
   tumblr_client!
-  twilio-ruby (~> 3.11.5)
+  twilio-ruby (~> 5.48.0)
   twitter!
   twitter-stream!
   typhoeus (~> 1.3.1)
@@ -797,4 +797,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.2.13

--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -83,9 +83,9 @@ module Agents
 
     def receive_web_request(params, method, format)
       if memory['pending_calls'].has_key? params['secret']
-        response = Twilio::TwiML::Response.new {|r| r.Say memory['pending_calls'][params['secret']], :voice => 'woman'}
+        response = Twilio::TwiML::VoiceResponse.new {|r| r.say( message: memory['pending_calls'][params['secret']], voice: 'woman')}
         memory['pending_calls'].delete params['secret']
-        [response.text, 200]
+        [response.to_s, 200]
       end
     end
 

--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -66,13 +66,13 @@ module Agents
     end
 
     def send_message(message)
-      client.account.messages.create :from => interpolated['sender_cell'],
+      client.messages.create :from => interpolated['sender_cell'],
                                          :to => interpolated['receiver_cell'],
                                          :body => message
     end
 
     def make_call(secret)
-      client.account.calls.create :from => interpolated['sender_cell'],
+      client.calls.create :from => interpolated['sender_cell'],
                                   :to => interpolated['receiver_cell'],
                                   :url => post_url(interpolated['server_url'], secret)
     end

--- a/app/models/agents/twilio_receive_text_agent.rb
+++ b/app/models/agents/twilio_receive_text_agent.rb
@@ -71,7 +71,7 @@ module Agents
       signature = headers['HTTP_X_TWILIO_SIGNATURE']
 
       # validate from twilio
-      @validator ||= Twilio::Util::RequestValidator.new interpolated['auth_token']
+      @validator ||= Twilio::Security::RequestValidator.new interpolated['auth_token']
       if !@validator.validate(post_url, params, signature)
         error("Twilio Signature Failed to Validate\n\n"+
           "URL: #{post_url}\n\n"+
@@ -82,12 +82,12 @@ module Agents
       end
 
       if create_event(payload: params)
-        response = Twilio::TwiML::Response.new do |r|
+        response = Twilio::TwiML::MessagingResponse.new do |r|
           if interpolated['reply_text'].present?
-            r.Message interpolated['reply_text']
+            r.message(body: interpolated['reply_text'])
           end
         end
-        return [response.text, 201, "text/xml"]
+        return [response.to_s, 200, "text/xml"]
       else
         return ["Bad request", 400]
       end


### PR DESCRIPTION
This pull request updates the twilio-ruby gem from version 3.X to 5.48.0.  The new API allows for the use of Twilio's conversation API, which is being used for some SMS and group MMS messages.  See https://github.com/paul-sx/huginn_twilio_conversation_agent for an example of using the new API.  

The existing Twilio agents were modified to use the new paths for the equivalent calls.