### PR TITLE
Upgrade Twilio-ruby to 5.48.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 
 # Optional libraries.  To conserve RAM, comment out any that you don't need,
 # then run `bundle` and commit the updated Gemfile and Gemfile.lock.
-gem 'twilio-ruby', '~> 3.11.5'    # TwilioAgent
+gem 'twilio-ruby', '~> 5.48.0'    # TwilioAgent
 gem 'ruby-growl', '~> 4.1.0'      # GrowlAgent
 gem 'net-ftp-list', '~> 3.2.8'    # FtpsiteAgent
 gem 'forecast_io', '~> 2.0.0'     # WeatherAgent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,10 +643,10 @@ GEM
     to_regexp (0.2.1)
     treetop (1.6.10)
       polyglot (~> 0.3)
-    twilio-ruby (3.11.6)
-      builder (>= 2.1.2)
-      jwt (>= 0.1.2)
-      multi_json (>= 1.3.0)
+    twilio-ruby (5.48.0)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
@@ -783,7 +783,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.1)
   sprockets (~> 3.7.2)
   tumblr_client!
-  twilio-ruby (~> 3.11.5)
+  twilio-ruby (~> 5.48.0)
   twitter!
   twitter-stream!
   typhoeus (~> 1.3.1)

--- a/app/models/agents/twilio_agent.rb
+++ b/app/models/agents/twilio_agent.rb
@@ -66,13 +66,13 @@ module Agents
     end
 
     def send_message(message)
-      client.account.messages.create :from => interpolated['sender_cell'],
+      client.messages.create :from => interpolated['sender_cell'],
                                          :to => interpolated['receiver_cell'],
                                          :body => message
     end
 
     def make_call(secret)
-      client.account.calls.create :from => interpolated['sender_cell'],
+      client.calls.create :from => interpolated['sender_cell'],
                                   :to => interpolated['receiver_cell'],
                                   :url => post_url(interpolated['server_url'], secret)
     end
@@ -83,9 +83,9 @@ module Agents
 
     def receive_web_request(params, method, format)
       if memory['pending_calls'].has_key? params['secret']
-        response = Twilio::TwiML::Response.new {|r| r.Say memory['pending_calls'][params['secret']], :voice => 'woman'}
+        response = Twilio::TwiML::VoiceResponse.new {|r| r.say( message: memory['pending_calls'][params['secret']], voice: 'woman')}
         memory['pending_calls'].delete params['secret']
-        [response.text, 200]
+        [response.to_s, 200]
       end
     end
 

--- a/app/models/agents/twilio_receive_text_agent.rb
+++ b/app/models/agents/twilio_receive_text_agent.rb
@@ -71,7 +71,7 @@ module Agents
       signature = headers['HTTP_X_TWILIO_SIGNATURE']
 
       # validate from twilio
-      @validator ||= Twilio::Util::RequestValidator.new interpolated['auth_token']
+      @validator ||= Twilio::Security::RequestValidator.new interpolated['auth_token']
       if !@validator.validate(post_url, params, signature)
         error("Twilio Signature Failed to Validate\n\n"+
           "URL: #{post_url}\n\n"+
@@ -82,12 +82,12 @@ module Agents
       end
 
       if create_event(payload: params)
-        response = Twilio::TwiML::Response.new do |r|
+        response = Twilio::TwiML::MessagingResponse.new do |r|
           if interpolated['reply_text'].present?
-            r.Message interpolated['reply_text']
+            r.message(body: interpolated['reply_text'])
           end
         end
-        return [response.text, 201, "text/xml"]
+        return [response.to_s, 200, "text/xml"]
       else
         return ["Bad request", 400]
       end

--- a/spec/models/agents/twilio_agent_spec.rb
+++ b/spec/models/agents/twilio_agent_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
+class TwilioDummyCreator
+  attr_accessor :message_calls
+
+  def create(message)
+    @message_calls << message
+  end
+end
+
 describe Agents::TwilioAgent do
   before do
     @checker = Agents::TwilioAgent.new(:name => 'somename',
@@ -20,8 +28,24 @@ describe Agents::TwilioAgent do
     @event.save!
 
     @message_calls = []
-    stub.any_instance_of(Twilio::REST::Messages).create { |message| @message_calls << message }
-    stub.any_instance_of(Twilio::REST::Calls).create
+
+    mc = TwilioDummyCreator.new
+    mc.message_calls = @message_calls
+    stub.any_instance_of(Twilio::REST::Client).messages { mc }
+
+    cc = TwilioDummyCreator.new
+    cc.message_calls = []
+    stub.any_instance_of(Twilio::REST::Client).calls { cc }
+
+    #messages_create = double()
+    #allow(messages_create).to receive(:create) { |message| @message_calls << message }
+    #stub.any_instance_of(Twilio::REST::Client).messages { messages_create }
+    #stub.any_instance_of(Twilio::REST::Client).calls.create
+    # {
+    #  def create(message)
+    #  end
+    #} 
+    stub.any_instance_of(Twilio::TwiML::VoiceResponse)
   end
 
   describe '#receive' do

--- a/spec/models/agents/twilio_receive_text_agent_spec.rb
+++ b/spec/models/agents/twilio_receive_text_agent_spec.rb
@@ -8,7 +8,7 @@ require 'rails_helper'
 
 describe Agents::TwilioReceiveTextAgent do
   before do
-    stub.any_instance_of(Twilio::Util::RequestValidator).validate { true }
+    stub.any_instance_of(Twilio::Security::RequestValidator).validate { true }
   end
 
   let(:payload) { 
@@ -61,7 +61,7 @@ describe Agents::TwilioReceiveTextAgent do
       expect {
         out = @agent.receive_web_request(request)
       }.to change { Event.count }.by(1)
-      expect(out).to eq(["<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response></Response>", 201, "text/xml"])
+      expect(out).to eq(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response/>\n", 200, "text/xml"])
       expect(Event.last.payload).to eq(payload)
     end
   end
@@ -92,7 +92,7 @@ describe Agents::TwilioReceiveTextAgent do
       expect {
         out = @agent.receive_web_request(request)
       }.to change { Event.count }.by(1)
-      expect(out).to eq(["<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response><Message>thanks!</Message></Response>", 201, "text/xml"])
+      expect(out).to eq(["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n<Message>thanks!</Message>\n</Response>\n", 200, "text/xml"])
       expect(Event.last.payload).to eq(payload)
     end
   end


### PR DESCRIPTION
Upgrades twilio-ruby to 5.48.0 with changes in the associated agents to use the new name path.

This is necessary for the conversations API in Twilio.  This is a new API system for SMS and Group MMS messages in Twilio.  See https://github.com/paul-sx/huginn_twilio_conversation_agent for an example agent that sends conversations.