### PR TITLE
Upgrade twilio-ruby to 5.62.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ end
 
 # Optional libraries.  To conserve RAM, comment out any that you don't need,
 # then run `bundle` and commit the updated Gemfile and Gemfile.lock.
-gem 'twilio-ruby', '~> 5.48.0'    # TwilioAgent
+gem 'twilio-ruby', '~> 5.62.0'    # TwilioAgent
 gem 'ruby-growl', '~> 4.1.0'      # GrowlAgent
 gem 'net-ftp-list', '~> 3.2.8'    # FtpsiteAgent
 gem 'forecast_io', '~> 2.0.0'     # WeatherAgent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -642,7 +642,7 @@ GEM
     to_regexp (0.2.1)
     treetop (1.6.10)
       polyglot (~> 0.3)
-    twilio-ruby (5.48.0)
+    twilio-ruby (5.62.0)
       faraday (>= 0.9, < 2.0)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)
@@ -782,7 +782,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.1)
   sprockets (~> 3.7.2)
   tumblr_client!
-  twilio-ruby (~> 5.48.0)
+  twilio-ruby (~> 5.62.0)
   twitter!
   twitter-stream!
   typhoeus (~> 1.3.1)


### PR DESCRIPTION
This upgrades twilio-ruby gem from 5.48.0 to current 5.62.0.  The changes are non-breaking and test correctly.  