### PR TITLE
Enhance TwitterPublishAgent

### DIFF
--- a/app/models/agents/twitter_publish_agent.rb
+++ b/app/models/agents/twitter_publish_agent.rb
@@ -24,7 +24,7 @@ module Agents
           "success": true,
           "published_tweet": "...",
           "tweet_id": ...,
-          "tweet_id_str": "...",
+          "tweet_url": "...",
           "agent_id": ...,
           "event_id": ...
         }
@@ -83,6 +83,7 @@ module Agents
             'success' => true,
             'published_tweet' => tweet_text,
             'tweet_id' => tweet.id,
+            'tweet_url' => tweet.url,
             'agent_id' => event.agent_id,
             'event_id' => event.id
           )


### PR DESCRIPTION
A couple of enhancements to TwitterPublishAgent:

- Add `tweet_url` to the payload.
- Accept additional parameters for the API (https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update)