### PR TITLE
Mismatched ruby versions - updated to 2.6.9

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -72,7 +72,7 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2 | tar xj
+    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2 | tar xj
     cd ruby-2.6.9
     ./configure --disable-install-rdoc
     make -j`nproc`


### PR DESCRIPTION
Mismatched ruby versions - updated to 2.6.9