### PR TITLE
Force setup_heroku to use heroku-18 stack

### DIFF
--- a/bin/setup_heroku
+++ b/bin/setup_heroku
@@ -39,7 +39,7 @@ elsif info =~ /No app specified/i
   puts "It looks like you don't have a Heroku app set up yet for this repo."
   puts "You can either exit now and run 'heroku create', or I can do it for you."
   if yes?("Would you like me to create a Heroku app for you now in this repo?")
-    puts `heroku create`
+    puts `heroku create --stack heroku-18`
     info = capture("heroku info")
   else
     puts "Okay, exiting so you can do it."


### PR DESCRIPTION
Heroku's default stack is now heroku-20, which does not allow installing Ruby 2.6.5. The `bin/setup_heroku` step needs to specify the heroku-18 stack, see [docs](https://devcenter.heroku.com/articles/heroku-18-stack#using-heroku-18).

Without this the `bin/setup_heroku` command fails with a critical error:

```
Should I push your current branch (master) to heroku? (Y/n) 
This may take a moment...
remote: Compressing source files... done.        
remote: Building source:        
remote: 
remote: -----> Building on the Heroku-20 stack        
remote: -----> Using buildpack: https://github.com/heroku/heroku-buildpack-multi.git        
remote: -----> Multipack app detected        
remote: =====> Downloading Buildpack: https://github.com/cantino/heroku-selectable-procfile.git        
remote: =====> Detected Framework: Selectable Procfile        
remote: -----> Using deployment/heroku/Procfile.heroku as Procfile        
remote: =====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-ruby.git        
remote: =====> Detected Framework: Ruby        
remote: -----> Installing bundler 2.3.10        
remote: -----> Removing BUNDLED WITH version in the Gemfile.lock        
remote: -----> Compiling Ruby/Rails        
remote:        Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.5.tgz -s -o - | tar zxf - ' failed on attempt 1 of 3.        
remote:        Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-20/ruby-2.6.5.tgz -s -o - | tar zxf - ' failed on attempt 2 of 3.        
remote:         
remote:  !        
remote:  !     The Ruby version you are trying to install does not exist on this stack.        
remote:  !             
remote:  !     You are trying to install ruby-2.6.5 on heroku-20.        
remote:  !             
remote:  !     Ruby ruby-2.6.5 is present on the following stacks:        
remote:  !             
remote:  !     - heroku-18        
remote:  !             
remote:  !     Heroku recommends you use the latest supported Ruby version listed here:        
remote:  !     https://devcenter.heroku.com/articles/ruby-support#supported-runtimes        
remote:  !             
remote:  !     For more information on syntax for declaring a Ruby version see:        
remote:  !     https://devcenter.heroku.com/articles/ruby-versions        
remote:  !        
remote:  !     Push rejected, failed to compile Multipack app.        
```