### PR TITLE
Fix liquid interpolation cache on ruby 2.7

### DIFF
--- a/app/concerns/liquid_interpolatable.rb
+++ b/app/concerns/liquid_interpolatable.rb
@@ -96,7 +96,7 @@ module LiquidInterpolatable
 
   def interpolated(self_object = nil)
     interpolate_with(self_object) do
-      (@interpolated_cache ||= {})[[options, interpolation_context]] ||=
+      (@interpolated_cache ||= {})[[options, interpolation_context].hash] ||=
         interpolate_options(options)
     end
   end


### PR DESCRIPTION
I can not really explain why this broke. For some reason the array we
use as an index for the interpolation cache was not "hashed" properly
and created false hits inn the cache. Explicitly calling `hash` on the
array key also calls `hash` on elements and properly caches the data.