### PR TITLE
Interpolate credentials

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -129,9 +129,9 @@ class Agent < ActiveRecord::Base
   def credential(name)
     @credential_cache ||= {}
     if @credential_cache.has_key?(name)
-      @credential_cache[name]
+      interpolate_string(@credential_cache[name])
     else
-      @credential_cache[name] = user.user_credentials.where(:credential_name => name).first.try(:credential_value)
+      interpolate_string(@credential_cache[name] = user.user_credentials.where(:credential_name => name).first.try(:credential_value))
     end
   end
 


### PR DESCRIPTION
Interpolate credentials to allow the use and expansion of liquid tags in inside credentials

Typical use case is defining the `body` for an `EmailAgent` using credentials.  This ensures any liquid formatting inside the credential is correctly interpolated.

@dsander, you mentioned a different use case in this post https://github.com/huginn/huginn/issues/2121#issuecomment-328335356

I think this is worthwhile, although you may have a better implementation.