### PR TITLE
Create a passwd entry for the default user during docker build

### DIFF
--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -41,6 +41,10 @@ COPY ["docker/multi-process/scripts/bootstrap.sh", \
       "docker/scripts/setup_env", "/scripts/"]
 CMD ["/scripts/init"]
 
-USER 1001
+ARG UID=1001
+RUN useradd -u "$UID" -g 0 -d /app -s /sbin/nologin -c "default user" default
+
+USER $UID
+ENV HOME /app
 
 VOLUME /var/lib/mysql

--- a/docker/scripts/setup_env
+++ b/docker/scripts/setup_env
@@ -3,17 +3,11 @@ set -e
 
 export LC_ALL=en_US.UTF-8
 
-cd /app
+export HOME=/app
+cd
 
 if [ -f /app/tmp/pids/delayed_job.pid ]; then
   rm /app/tmp/pids/delayed_job.pid
-fi
-
-export HOME=/app
-if ! whoami &> /dev/null; then
-    if [ -w /etc/passwd ]; then
-        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
-    fi
 fi
 
 # DATABASE_URL takes the highest precedence.

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -30,4 +30,8 @@ EXPOSE 3000
 COPY ["docker/scripts/setup_env", "docker/single-process/scripts/init", "/scripts/"]
 CMD ["/scripts/init"]
 
-USER 1001
+ARG UID=1001
+RUN useradd -u "$UID" -g 0 -d /app -s /sbin/nologin -c "default user" default
+
+USER $UID
+ENV HOME /app

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -28,4 +28,7 @@ COPY docker/test/scripts/test_env /scripts/
 ENTRYPOINT ["/scripts/test_env"]
 CMD ["rake spec"]
 
-USER 1001
+ARG UID=1001
+
+USER $UID
+ENV HOME /app


### PR DESCRIPTION
docker/scripts/setup_env includes a piece of code that tries to do this, but it is executed in run time as the default user who does not have permissions for that.

Running useradd(8) in Dockerfile as root instead ensures a passwd entry for the default user, which allows commands like ssh to work in a ShellCommandAgent.

I made UID tunable via the --build-arg option while I'm here.