### PR TITLE
fix: ignore subdirs in the dropbox watch agent

### DIFF
--- a/app/models/agents/dropbox_watch_agent.rb
+++ b/app/models/agents/dropbox_watch_agent.rb
@@ -52,7 +52,9 @@ module Agents
     private
 
     def ls(dir_to_watch)
-      dropbox.ls(dir_to_watch).map { |file| { 'path' => file.path, 'rev' => file.rev, 'modified' => file.server_modified } }
+      dropbox.ls(dir_to_watch)
+             .select { |entry| entry.respond_to?(:rev) }
+             .map { |file| { 'path' => file.path, 'rev' => file.rev, 'modified' => file.server_modified } }
     end
 
     def previous_contents

--- a/spec/models/agents/dropbox_watch_agent_spec.rb
+++ b/spec/models/agents/dropbox_watch_agent_spec.rb
@@ -50,7 +50,15 @@ describe Agents::DropboxWatchAgent do
 
   describe '#check' do
 
-    let(:first_result) { Dropbox::API::Object.convert([{ 'path_display' => '1.json', 'rev' => '1', 'server_modified' => '01-01-01' }], nil) }
+    let(:first_result) do
+      Dropbox::API::Object.convert(
+        [
+          { 'path_display' => '1.json', 'rev' => '1', 'server_modified' => '01-01-01' },
+          { 'path_display' => 'sub_dir_1', '.tag' => 'folder' }
+        ],
+        nil
+      )
+    end
 
     before(:each) do
       allow(Dropbox::API::Client).to receive(:new) do
@@ -77,7 +85,15 @@ describe Agents::DropboxWatchAgent do
 
     context 'subsequent calls' do
 
-      let(:second_result) { Dropbox::API::Object.convert([{ 'path_display' => '2.json', 'rev' => '1', 'server_modified' => '02-02-02' }], nil) }
+      let(:second_result) do
+        Dropbox::API::Object.convert(
+          [
+            { 'path_display' => '2.json', 'rev' => '1', 'server_modified' => '02-02-02' },
+            { 'path_display' => 'sub_dir_2', '.tag' => 'folder' }
+          ],
+          nil
+        )
+      end
 
       before(:each) do
         @agent.memory = { 'contents' => 'not_empty' }


### PR DESCRIPTION
Dropbox watch agent fails when subdirectory exists in the directory to watch. This is happens because directory object does not have `rev` field.

Filter out subdirs to make agent work as expected.

Fixes https://github.com/huginn/huginn/issues/2888