### PR TITLE
Push docker images to docker hub and ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,33 @@ jobs:
       - name: Run tests
         run: bundle exec rake
 
+  ghcr-build-docker-images:
+    name: ghcr-docker-build-${{ matrix.docker_image }}
+    needs: run-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker_image:
+          - huginn/huginn
+          - huginn/huginn-single-process
+    env:
+      DOCKER_IMAGE: ghcr.io/${{ matrix.docker_image }}
+      DOCKERFILE: docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
+      DOCKER_USER: ${{ github.actor }}
+      DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
+      REGISTRY: ghcr.io
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build a docker image
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = push -a "$GITHUB_REF_NAME" = master ]; then
+            ./build_docker_image.sh --push
+          else
+            ./build_docker_image.sh
+          fi
+
   build-docker-images:
     name: docker-build-${{ matrix.docker_image }}
     needs: run-tests
@@ -90,6 +117,4 @@ jobs:
         run: |
           if [ "$GITHUB_EVENT_NAME" = push -a "$GITHUB_REF_NAME" = master ]; then
             ./build_docker_image.sh --push
-          else
-            ./build_docker_image.sh
           fi

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -4,17 +4,18 @@ set -e
 : ${DOCKER_IMAGE:=huginn/huginn}
 : ${DOCKER_IMAGE_TAG:=${GITHUB_SHA:-$(git rev-parse HEAD)}}
 : ${DOCKERFILE:=docker/multi-process/Dockerfile}
+: ${REGISTRY:=docker.com}
 
 bin/docker_wrapper build -t "$DOCKER_IMAGE" -f "$DOCKERFILE" .
 
 if [[ "$1" == --push ]]; then
   [[ -n "$DOCKER_USER" && -n "$DOCKER_IMAGE_TAG" ]]
-  docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+  docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" "$REGISTRY"
   docker tag "$DOCKER_IMAGE" "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
   docker push "$DOCKER_IMAGE"
   docker push "$DOCKER_IMAGE:$DOCKER_IMAGE_TAG"
 fi
 
-if [[ "$DOCKER_IMAGE" == "huginn/huginn-single-process" ]]; then
+if [[ "$DOCKER_IMAGE" == *huginn/huginn-single-process ]]; then
   DOCKER_IMAGE=huginn/huginn-test DOCKERFILE=docker/test/Dockerfile ./build_docker_image.sh
 fi


### PR DESCRIPTION
As discussed in #3234 we want to make the transition from hosting the docker images on docker hub to GitHub container registry. This change will push the images to both registries, after we have verified everything works as expected we can embed a warning in images pushed to docker hub which tells the users to switch.

[This is the github action run][1] on my fork that successfully created the [images][2].

I didn't bother with integrating the two registries into a build matrix because it is probably easier to just remove the docker hub jobs once we are done with the transition.

[1]: https://github.com/dsander/huginn/actions/runs/4451875730
[2]: https://github.com/dsander?tab=packages&repo_name=huginn