### PR TITLE
Handle file permissions in a cleaner way while building Docker images

### DIFF
--- a/bin/docker_wrapper
+++ b/bin/docker_wrapper
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-chmod -R g=u . && docker "$@"

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -5,7 +5,7 @@ set -e
 : ${DOCKER_IMAGE_TAG:=${GITHUB_SHA:-$(git rev-parse HEAD)}}
 : ${DOCKERFILE:=docker/multi-process/Dockerfile}
 
-bin/docker_wrapper build $BUILD_ARGS -t "$DOCKER_IMAGE" -f "$DOCKERFILE" .
+docker build $BUILD_ARGS -t "$DOCKER_IMAGE" -f "$DOCKERFILE" .
 
 if [[ "$1" == --push ]]; then
   [[ -n "$DOCKER_USER" && -n "$DOCKER_IMAGE_TAG" ]]

--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -12,29 +12,32 @@ ENV HOME=/app
 
 ARG UID=1001
 RUN useradd -u "$UID" -g 0 -d /app -s /sbin/nologin -c "default user" default
+RUN chown -R "$UID:0" /app
+USER $UID
 
 ENV LC_ALL=en_US.UTF-8
 ENV RAILS_ENV=production
 
-COPY ["Gemfile", "Gemfile.lock", "/app/"]
-COPY lib/gemfile_helper.rb /app/lib/
-COPY vendor/gems/ /app/vendor/gems/
+COPY --chown="$UID:0" ["Gemfile", "Gemfile.lock", "/app/"]
+COPY --chown="$UID:0" lib/gemfile_helper.rb /app/lib/
+COPY --chown="$UID:0" vendor/gems/ /app/vendor/gems/
+
+ARG ADDITIONAL_GEMS=
+ENV ADDITIONAL_GEMS=$ADDITIONAL_GEMS
 
 # Get rid of annoying "fatal: Not a git repository (or any of the parent directories): .git" messages
-RUN umask 002 && git init && \
+RUN git init && \
     bundle config set --local path vendor/bundle && \
-    bundle config set --local without 'test development' && \
-    APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle install -j 4
+    bundle config set --local without 'test development'
 
-COPY ./ /app/
+RUN APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle install -j 4
+
+COPY --chown="$UID:0" ./ /app/
 
 ARG OUTDATED_DOCKER_REGISTRY=false
 ENV OUTDATED_DOCKER_REGISTRY=${OUTDATED_DOCKER_REGISTRY}
 
-RUN umask 002 && \
-    APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle exec rake assets:clean assets:precompile && \
-    chmod g=u /app/.env.example /app/Gemfile.lock /app/config/ /app/tmp/ && \
-    chown -R "$UID" /app
+RUN APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle exec rake assets:clean assets:precompile
 
 EXPOSE 3000
 
@@ -47,7 +50,5 @@ COPY ["docker/multi-process/scripts/bootstrap.sh", \
       "docker/multi-process/scripts/init", \
       "docker/scripts/setup_env", "/scripts/"]
 CMD ["/scripts/init"]
-
-USER $UID
 
 VOLUME /var/lib/mysql

--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -20,6 +20,7 @@ ENV RAILS_ENV=production
 
 COPY --chown="$UID:0" ["Gemfile", "Gemfile.lock", "/app/"]
 COPY --chown="$UID:0" lib/gemfile_helper.rb /app/lib/
+RUN mkdir /app/vendor
 COPY --chown="$UID:0" vendor/gems/ /app/vendor/gems/
 
 ARG ADDITIONAL_GEMS=

--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -116,7 +116,7 @@ In newer versions of Docker you are able to pass your own .env file in to the co
 
 You don't need to do this on your own, because there is an [automated build](https://hub.docker.com/r/huginn/huginn/) for this repository, but if you really want run this command in the Huginn root directory:
 
-    bin/docker_wrapper build --rm=true --tag={yourname}/huginn -f docker/multi-process/Dockerfile .
+    docker build --rm=true --tag={yourname}/huginn -f docker/multi-process/Dockerfile .
 
 ## Source
 

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -17,6 +17,7 @@ ENV RAILS_ENV=production
 
 COPY --chown="$UID:0" ["Gemfile", "Gemfile.lock", "/app/"]
 COPY --chown="$UID:0" lib/gemfile_helper.rb /app/lib/
+RUN mkdir /app/vendor
 COPY --chown="$UID:0" vendor/gems/ /app/vendor/gems/
 
 ARG ADDITIONAL_GEMS=

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -9,33 +9,34 @@ ENV HOME=/app
 
 ARG UID=1001
 RUN useradd -u "$UID" -g 0 -d /app -s /sbin/nologin -c "default user" default
+RUN chown -R "$UID:0" /app
+USER $UID
 
 ENV LC_ALL=en_US.UTF-8
 ENV RAILS_ENV=production
 
-COPY ["Gemfile", "Gemfile.lock", "/app/"]
-COPY lib/gemfile_helper.rb /app/lib/
-COPY vendor/gems/ /app/vendor/gems/
+COPY --chown="$UID:0" ["Gemfile", "Gemfile.lock", "/app/"]
+COPY --chown="$UID:0" lib/gemfile_helper.rb /app/lib/
+COPY --chown="$UID:0" vendor/gems/ /app/vendor/gems/
+
+ARG ADDITIONAL_GEMS=
+ENV ADDITIONAL_GEMS=$ADDITIONAL_GEMS
 
 # Get rid of annoying "fatal: Not a git repository (or any of the parent directories): .git" messages
-RUN umask 002 && git init && \
+RUN git init && \
     bundle config set --local path vendor/bundle && \
-    bundle config set --local without 'test development' && \
-    APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle install -j 4
+    bundle config set --local without 'test development'
 
-COPY ./ /app/
+RUN APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle install -j 4
+
+COPY --chown="$UID:0" ./ /app/
 
 ARG OUTDATED_DOCKER_REGISTRY=false
 ENV OUTDATED_DOCKER_REGISTRY=${OUTDATED_DOCKER_REGISTRY}
 
-RUN umask 002 && \
-    APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle exec rake assets:clean assets:precompile && \
-    chmod g=u /app/.env.example /app/Gemfile.lock /app/config/ /app/tmp/ && \
-    chown -R "$UID" /app
+RUN APP_SECRET_TOKEN=secret DATABASE_ADAPTER=mysql2 ON_HEROKU=true bundle exec rake assets:clean assets:precompile
 
 EXPOSE 3000
 
 COPY ["docker/scripts/setup_env", "docker/single-process/scripts/init", "/scripts/"]
 CMD ["/scripts/init"]
-
-USER $UID

--- a/docker/single-process/README.md
+++ b/docker/single-process/README.md
@@ -98,7 +98,7 @@ In newer versions of Docker you are able to pass your own .env file in to the co
 
 You don't need to do this on your own, but if you really want run this command in the Huginn root directory:
 
-    bin/docker_wrapper build --rm=true --tag={yourname}/huginn -f docker/single-process/Dockerfile .
+    docker build --rm=true --tag={yourname}/huginn -f docker/single-process/Dockerfile .
 
 ## Source
 


### PR DESCRIPTION
- Use COPY --chown wisely
- Switch USER earlier so that generated files are owned by the user