### PR TITLE
Local File Agent: Output event with file pointer when writing to file

### DIFF
--- a/app/models/agents/local_file_agent.rb
+++ b/app/models/agents/local_file_agent.rb
@@ -111,9 +111,11 @@ module Agents
       return if interpolated['mode'] != 'write' || !should_run?
       incoming_events.each do |event|
         mo = interpolated(event)
-        File.open(File.expand_path(mo['path']), boolify(mo['append']) ? 'a' : 'w') do |file|
+        expanded_path = File.expand_path(mo['path'])
+        File.open(expanded_path, boolify(mo['append']) ? 'a' : 'w') do |file|
           file.write(mo['data'])
         end
+        create_event payload: get_file_pointer(expanded_path)
       end
     end
 

--- a/spec/models/agents/local_file_agent_spec.rb
+++ b/spec/models/agents/local_file_agent_spec.rb
@@ -187,6 +187,15 @@ describe Agents::LocalFileAgent do
       expect { @checker.receive([]) }.to change(AgentLog, :count).by(1)
       ENV['ENABLE_INSECURE_AGENTS'] = 'true'
     end
+
+    it "emits an event containing the file pointer" do
+      expect(@file_mock).to receive(:write).with('hello world')
+      event = Event.new(payload: {'data' => 'hello world'})
+      expect(File).to receive(:open).with(File.join(Rails.root, 'tmp', 'spec'), 'w').and_yield(@file_mock)
+
+      expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+      expect(Event.last.payload.has_key?('file_pointer')).to be_truthy
+    end
   end
 
   describe describe Agents::LocalFileAgent::Worker do


### PR DESCRIPTION
Change Local File Agent to also emit events when in write mode. The event emitted contains a file pointer to the local file that was just written or appended to. This makes it more convenient to create workflows that involve writing content to a file and then performing an action on that file.