### PR TITLE
Agents can be archived

### DIFF
--- a/app/concerns/assignable_types.rb
+++ b/app/concerns/assignable_types.rb
@@ -10,7 +10,17 @@ module AssignableTypes
   end
 
   def validate_type
-    errors.add(:type, "cannot be changed once an instance has been created") if type_changed? && !new_record?
+    case type
+    when 'Agents::ArchivedAgent'
+      if new_record?
+        errors.add(:type, "cannot be #{type} for a new agent")
+      end
+    else
+      if !new_record? && type_changed?
+        errors.add(:type, "cannot be changed once an instance has been created")
+      end
+    end
+
     errors.add(:type, "is not a valid type") unless self.class.valid_type?(type)
   end
 
@@ -18,7 +28,9 @@ module AssignableTypes
     def load_types_in(module_name, my_name = module_name.singularize)
       const_set(:MODULE_NAME, module_name)
       const_set(:BASE_CLASS_NAME, my_name)
-      const_set(:TYPES, Dir[Rails.root.join("app", "models", module_name.underscore, "*.rb")].map { |path| module_name + "::" + File.basename(path, ".rb").camelize })
+      const_set(:TYPES, Dir[Rails.root.join("app", "models", module_name.underscore, "*.rb")].map { |path|
+                          module_name + "::" + File.basename(path, ".rb").camelize
+                        })
     end
 
     def types

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -233,6 +233,10 @@ class Agent < ActiveRecord::Base
     self.class.can_dry_run?
   end
 
+  def should_run?
+    self.class.should_run?
+  end
+
   def no_bulk_receive?
     self.class.no_bulk_receive?
   end
@@ -377,6 +381,10 @@ class Agent < ActiveRecord::Base
       !!@can_dry_run
     end
 
+    def should_run?
+      true
+    end
+
     def no_bulk_receive!
       @no_bulk_receive = true
     end
@@ -453,8 +461,7 @@ class Agent < ActiveRecord::Base
     def run_schedule(schedule)
       return if schedule == 'never'
 
-      types = where(schedule:).group(:type).pluck(:type)
-      types.each do |type|
+      where(schedule:).group(:type).pluck(:type).each do |type|
         next unless valid_type?(type)
 
         type.constantize.bulk_check(schedule)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -92,6 +92,64 @@ class Agent < ActiveRecord::Base
     type.demodulize
   end
 
+  def self.archive_all!
+    transaction do
+      id2type = connection.select_rows(
+        where.not(type: 'Agents::ArchivedAgent').select(:id, :type).to_sql
+      ).to_h
+
+      agents = unscoped.where(id: id2type.keys)
+
+      agents.update_all(type: 'Agents::ArchivedAgent')
+
+      agents.find_each do |agent|
+        id = agent.id
+        options = {
+          "type" => id2type.fetch(id),
+        }.update(
+          agent.slice(
+            :schedule,
+            :last_check_at,
+            :last_receive_at,
+            :last_checked_event_id,
+            :last_web_request_at,
+            :last_event_at,
+            :last_error_log_at,
+            :keep_events_for,
+            :propagate_immediately,
+            :deactivated,
+            :disabled,
+            :options,
+            :memory,
+          )
+        )
+
+        agent.update_columns(
+          disabled: true,
+          options:,
+          memory: {}
+        )
+
+        agent.update!(keep_events_for: 0)
+      end
+
+      agents.reset
+    end
+  end
+
+  def self.unarchive_all!
+    transaction do
+      ids = []
+
+      where(type: 'Agents::ArchivedAgent').find_each do |agent|
+        ids << agent.id
+        agent.update_columns(agent.options)
+      end
+
+      unscoped.where(id: ids)
+    end
+  end
+
   def check
     # Implement me in your subclass of Agent.
   end

--- a/app/models/agents/archived_agent.rb
+++ b/app/models/agents/archived_agent.rb
@@ -1,0 +1,41 @@
+module Agents
+  class ArchivedAgent < Agent
+    can_control_other_agents!
+
+    description <<~MD
+      The Archived Agent is a dormant and unresponsive agent that does nothing when it is run or when it receives an event.
+
+      It serves the sole purpose of keeping an agent that has been deleted or is no longer functional in an idle state, waiting for future fixes.
+    MD
+
+    def self.should_run?
+      false
+    end
+
+    def working?
+      false
+    end
+
+    def control_action
+      'control'
+    end
+
+    def validate_options
+      if options_changed?
+        errors.add(:base, "options cannot be edited")
+      end
+
+      if !disabled?
+        errors.add(:base, "cannot be enabled")
+      end
+    end
+
+    def check
+      # Do nada
+    end
+
+    def receive(incoming_events)
+      # Do nada
+    end
+  end
+end

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -5,6 +5,16 @@ describe "Creating a new agent", js: true do
     login_as(users(:bob))
   end
 
+  it "does not support ArchivedAgent" do
+    visit "/"
+    page.find("a", text: "Agents").hover
+    click_on("New Agent")
+
+    select2_open(from: 'Type')
+    expect(page).to have_select2_option('Website Agent', from: 'Type')
+    expect(page).not_to have_select2_option('Archived Agent', from: 'Type')
+  end
+
   it "creates an agent" do
     visit "/"
     page.find("a", text: "Agents").hover

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -31,6 +31,76 @@ describe Agent do
     end
   end
 
+  describe '.archive_all!/.unarchive_all!' do
+    let!(:agent_id) { agents(:bob_weather_agent).id }
+
+    it 'archives and unarchives Agents' do
+      expect {
+        Agent.where(id: [agent_id]).archive_all!
+      }.to change {
+        Agent.find(agent_id)
+      }.from(
+        be_a(Agents::WeatherAgent) & have_attributes(
+          disabled: false,
+          keep_events_for: be > 0,
+          options: hash_including(:location, :api_key)
+        )
+      ).to(
+        be_a(Agents::ArchivedAgent) & have_attributes(
+          disabled: true,
+          keep_events_for: 0,
+          options: hash_including(
+            :schedule,
+            :last_check_at,
+            :last_receive_at,
+            :last_checked_event_id,
+            :last_web_request_at,
+            :last_event_at,
+            :last_error_log_at,
+            :propagate_immediately,
+            type: 'Agents::WeatherAgent',
+            keep_events_for: be > 0,
+            deactivated: false,
+            disabled: false,
+            options: hash_including(:location, :api_key)
+          )
+        )
+      )
+
+      expect {
+        Agent.where(id: [agent_id]).unarchive_all!
+      }.to change {
+        Agent.find(agent_id)
+      }.from(
+        be_a(Agents::ArchivedAgent) & have_attributes(
+          disabled: true,
+          keep_events_for: 0,
+          options: hash_including(
+            :schedule,
+            :last_check_at,
+            :last_receive_at,
+            :last_checked_event_id,
+            :last_web_request_at,
+            :last_event_at,
+            :last_error_log_at,
+            :propagate_immediately,
+            type: 'Agents::WeatherAgent',
+            keep_events_for: be > 0,
+            deactivated: false,
+            disabled: false,
+            options: hash_including(:location, :api_key)
+          )
+        )
+      ).to(
+        be_a(Agents::WeatherAgent) & have_attributes(
+          disabled: false,
+          keep_events_for: be > 0,
+          options: hash_including(:location, :api_key)
+        )
+      )
+    end
+  end
+
   describe ".bulk_check" do
     before do
       @weather_agent_count = Agents::WeatherAgent.where(schedule: "midnight", disabled: false).count

--- a/spec/models/agents/archived_agent_spec.rb
+++ b/spec/models/agents/archived_agent_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+describe Agents::ArchivedAgent do
+  let(:agent_id) {
+    agent = agents(:jane_website_agent)
+    agent.sources << agents(:jane_weather_agent)
+    agent.id
+  }
+
+  let(:agent) {
+    Agent.where(id: agent_id).archive_all!
+    Agent.find(agent_id)
+  }
+
+  def create_event(payload)
+    agents(:jane_weather_agent).events.create!(payload:)
+  end
+
+  describe '.should_run?' do
+    it 'is false' do
+      expect(Agents::ArchivedAgent.should_run?).to eq false
+    end
+  end
+
+  describe '.can_control_other_agents?' do
+    it 'is true' do
+      expect(Agents::ArchivedAgent.can_control_other_agents?).to eq true
+    end
+  end
+
+  describe 'control_action' do
+    it 'is set' do
+      expect(agent.control_action).to eq 'control'
+    end
+  end
+
+  describe 'validation' do
+    before do
+      expect(agent).to be_valid
+    end
+
+    it 'cannot be enabled' do
+      agent.disabled = false
+      expect(agent).not_to be_valid
+    end
+
+    it 'cannot change its options' do
+      agent.options[:foo] = true
+      expect(agent).not_to be_valid
+    end
+  end
+
+  describe '#check' do
+    it 'does not cause error' do
+      expect {
+        agent.check
+      }.not_to raise_error
+    end
+  end
+
+  describe '#receive' do
+    let(:event) { create_event({ name: 'foo', numbers: [1, 2, 3, 4] }) }
+
+    it 'does not cause error' do
+      expect {
+        agent.receive([event])
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,4 +1,9 @@
+require 'capybara_select2'
+
 module FeatureHelpers
+  include CapybaraSelect2
+  include CapybaraSelect2::Helpers
+
   def select_agent_type(search)
     agent_name = search[/\A.*?Agent\b/] || search
     select2(agent_name, search:, from: "Type")


### PR DESCRIPTION
Some of the existing Agent types have already stopped working and need to be either deleted or updated, but currently, Huginn is very awkward at obsoleting an Agent type.  If a Huginn database had any existing instance of the type, deleting the Agent implementation could render the entire Huginn server dysfunctional because Huginn uses STI where retrieving an Agent record with a non-existent type will immediately cause an error.

This PR provides a way to "archive" agents by converting them to a new Agent type called "ArchivedAgent" with all states and configuration options saved.  Once an agent is archived, it is disabled and becomes dormant.  The archiving is intended to take place in database migrations so deleting an Agent type wouldn't cause trouble to users.

Archived agents could be unarchived someday when a successor Agent type got ready.