### PR TITLE
Add a .irbrc

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,7 @@
+require "irb/completion"
+
+IRB.conf[:AUTO_INDENT] = true
+IRB.conf[:EVAL_HISTORY] = 100
+IRB.conf[:PROMPT_MODE] = :SIMPLE
+IRB.conf[:USE_AUTOCOMPLETE] = false
+IRB.conf[:ECHO_ON_ASSIGNMENT] = true


### PR DESCRIPTION
Add .irbrc as a reasonable default configuration for Rails console.

Ruby 3 will introduce a menu-based auto-complete UI that is too fancy and slow for remote environments, so disabling it will come in handy.