### PR TITLE
Skip sanity_check if APP_SECRET_TOKEN is defined

### DIFF
--- a/lib/gemfile_helper.rb
+++ b/lib/gemfile_helper.rb
@@ -57,7 +57,7 @@ class GemfileHelper
     end
 
     def sanity_check(env)
-      return if ENV['CI'] == 'true' || !env.empty?
+      return if ENV['CI'] == 'true' || ENV['APP_SECRET_TOKEN'] || !env.empty?
       puts warning
       raise "Could not load huginn settings from .env file."
     end


### PR DESCRIPTION
Heroku is not the only running platform where environment variables are set outside of `.env` files, and APP_SECRET_TOKEN should be a good choice to determine if the environment is properly configured because [bin/pre_runner_boot.rb](https://github.com/huginn/huginn/blob/c342f320d807dc6ba10ce71878568d5878b90cbd/bin/pre_runner_boot.rb#L11) already uses this variable to decide whether to call `Dotenv.load`.