### PR TITLE
Fix an issue in google_calendar.rb after upgrading to Ruby 3.2.0

### DIFF
--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -49,7 +49,7 @@ class GoogleCalendar
     @logger.info("Attempting to create event for " + who)
     @logger.debug details.to_yaml
 
-    event = Google::Apis::CalendarV3::Event.new(details.deep_symbolize_keys)
+    event = Google::Apis::CalendarV3::Event.new(**details.deep_symbolize_keys)
     ret = @calendar.insert_event(
         who,
         event,


### PR DESCRIPTION
Close: https://github.com/huginn/huginn/issues/3274