### PR TITLE
Show controllers on the Agent show page

### DIFF
--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -83,6 +83,13 @@
               </p>
             <% end %>
 
+            <% if (agents = @agent.controllers).length > 0 %>
+              <p>
+                <b>Controllers:</b>
+                <%= agents.map { |agent| link_to(agent.name, agent_path(agent)) }.to_sentence.html_safe %>
+              </p>
+            <% end %>
+
             <% if @agent.can_create_events? %>
               <p>
                 <b>Keep events:</b>


### PR DESCRIPTION
`/agents/:id` shows control targets but it does not currently show controllers, which should be there too.