### PR TITLE
DelayAgent can sort events

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js
+++ b/app/assets/javascripts/pages/agent-edit-page.js
@@ -16,9 +16,9 @@
 
       // Validate agents_options Json on form submit
       $("form.agent-form").submit(function (e) {
-        if ($("textarea#agent_options").length) {
+        for (const textarea of $("textarea.live-json-editor").toArray()) {
           try {
-            JSON.parse($("#agent_options").val());
+            JSON.parse($(textarea).val());
           } catch (err) {
             e.preventDefault();
             alert(

--- a/app/concerns/form_configurable.rb
+++ b/app/concerns/form_configurable.rb
@@ -31,8 +31,8 @@ module FormConfigurable
     def form_configurable(name, *args)
       options = args.extract_options!.reverse_merge(roles: [], type: :string)
 
-      if args.all? { |arg| arg.is_a?(Symbol) }
-        options.assert_valid_keys([:type, :roles, :values, :ace, :cache_response])
+      if args.all?(Symbol)
+        options.assert_valid_keys([:type, :roles, :values, :ace, :cache_response, :html_options])
       end
 
       if options[:type] == :array && (options[:values].blank? || !options[:values].is_a?(Array))

--- a/app/concerns/form_configurable.rb
+++ b/app/concerns/form_configurable.rb
@@ -3,7 +3,7 @@ module FormConfigurable
 
   included do
     class_attribute :_form_configurable_fields
-    self._form_configurable_fields = HashWithIndifferentAccess.new { |h,k| h[k] = [] }
+    self._form_configurable_fields = HashWithIndifferentAccess.new { |h, k| h[k] = [] }
   end
 
   delegate :form_configurable_attributes, to: :class
@@ -43,11 +43,28 @@ module FormConfigurable
         options[:roles] = [options[:roles]]
       end
 
-      if options[:type] == :array
+      case options[:type]
+      when :array
         options[:roles] << :completable
-        class_eval <<-EOF
+        class_eval <<-EOF, __FILE__, __LINE__ + 1
           def complete_#{name}
             #{options[:values]}.map { |v| {text: v, id: v} }
+          end
+        EOF
+      when :json
+        class_eval <<-EOF, __FILE__, __LINE__ + 1
+          before_validation :decode_#{name}_json
+
+          private def decode_#{name}_json
+            case value = options[:#{name}]
+            when String
+              options[:#{name}] =
+                begin
+                  JSON.parse(value)
+                rescue StandardError
+                  value
+                end
+            end
           end
         EOF
       end

--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -31,10 +31,10 @@ module Agents
       }
     end
 
-    form_configurable :expected_receive_period_in_days, type: :string
-    form_configurable :max_events, type: :string
+    form_configurable :expected_receive_period_in_days, type: :number, html_options: { min: 1 }
+    form_configurable :max_events, type: :number, html_options: { min: 1 }
     form_configurable :keep, type: :array, values: %w[newest oldest]
-    form_configurable :max_emitted_events, type: :string
+    form_configurable :max_emitted_events, type: :number, html_options: { min: 0 }
     form_configurable :events_order, type: :json
 
     def validate_options

--- a/app/presenters/form_configurable_agent_presenter.rb
+++ b/app/presenters/form_configurable_agent_presenter.rb
@@ -16,7 +16,10 @@ class FormConfigurableAgentPresenter < Decorator
   def option_field_for(attribute)
     data = @agent.form_configurable_fields[attribute]
     value = @agent.options[attribute.to_s] || @agent.default_options[attribute.to_s]
-    html_options = { role: (data[:roles] + ['form-configurable']).join(' '), data: { attribute: } }
+    html_options = data.fetch(:html_options, {}).deep_merge({
+      role: (data[:roles] + ['form-configurable']).join(' '),
+      data: { attribute: },
+    })
 
     case data[:type]
     when :text
@@ -56,6 +59,9 @@ class FormConfigurableAgentPresenter < Decorator
     when :string
       @view.text_field_tag "agent[options][#{attribute}]", value,
                            html_options.deep_merge(class: 'form-control', data: { cache_response: data[:cache_response] != false })
+    when :number
+      @view.number_field_tag "agent[options][#{attribute}]", value,
+                             html_options.deep_merge(class: 'form-control', data: { cache_response: data[:cache_response] != false })
     when :json
       @view.text_area_tag "agent[options][#{attribute}]", value,
                           html_options.deep_merge(class: 'form-control live-json-editor', rows: 10)

--- a/app/presenters/form_configurable_agent_presenter.rb
+++ b/app/presenters/form_configurable_agent_presenter.rb
@@ -56,6 +56,9 @@ class FormConfigurableAgentPresenter < Decorator
     when :string
       @view.text_field_tag "agent[options][#{attribute}]", value,
                            html_options.deep_merge(class: 'form-control', data: { cache_response: data[:cache_response] != false })
+    when :json
+      @view.text_area_tag "agent[options][#{attribute}]", value,
+                          html_options.deep_merge(class: 'form-control live-json-editor', rows: 10)
     end
   end
 end

--- a/spec/presenters/form_configurable_agent_presenter_spec.rb
+++ b/spec/presenters/form_configurable_agent_presenter_spec.rb
@@ -9,6 +9,7 @@ describe FormConfigurableAgentPresenter do
     form_configurable :text, type: :text, roles: :completable
     form_configurable :boolean, type: :boolean
     form_configurable :array, type: :array, values: [1, 2, 3]
+    form_configurable :json, type: :json
   end
 
   before(:all) do
@@ -65,6 +66,20 @@ describe FormConfigurableAgentPresenter do
           'data-attribute': 'array',
           role: 'completable form-configurable',
           name: 'agent[options][array]'
+        }
+      )
+    )
+  end
+
+  it "works for the type :json" do
+    expect(@presenter.option_field_for(:json)).to(
+      have_tag(
+        'textarea',
+        with: {
+          'data-attribute': 'json',
+          role: 'form-configurable',
+          name: 'agent[options][json]',
+          class: 'live-json-editor',
         }
       )
     )

--- a/spec/presenters/form_configurable_agent_presenter_spec.rb
+++ b/spec/presenters/form_configurable_agent_presenter_spec.rb
@@ -6,6 +6,7 @@ describe FormConfigurableAgentPresenter do
     include FormConfigurable
 
     form_configurable :string, roles: :validatable
+    form_configurable :number, type: :number, html_options: { min: 0 }
     form_configurable :text, type: :text, roles: :completable
     form_configurable :boolean, type: :boolean
     form_configurable :array, type: :array, values: [1, 2, 3]
@@ -26,6 +27,21 @@ describe FormConfigurableAgentPresenter do
           role: 'validatable form-configurable',
           type: 'text',
           name: 'agent[options][string]'
+        }
+      )
+    )
+  end
+
+  it "works for the type :number" do
+    expect(@presenter.option_field_for(:number)).to(
+      have_tag(
+        'input',
+        with: {
+          'data-attribute': 'number',
+          role: 'form-configurable',
+          type: 'number',
+          name: 'agent[options][number]',
+          min: '0',
         }
       )
     )


### PR DESCRIPTION
I have plans to add more features to DelayAgent, and this is the first one.

It would be more useful if you could buffer a sequence of unordered events for a while and then emit them in a well-organized order.

I'll add the `emit_interval` option later so your workflow won't get flooded by randomly called webhooks.