### PR TITLE
Fix a regression in a validation rule of TriggerAgent

### DIFF
--- a/app/models/agents/trigger_agent.rb
+++ b/app/models/agents/trigger_agent.rb
@@ -55,7 +55,7 @@ module Agents
       when Hash
         VALID_COMPARISON_TYPES.include?(rule['type']) &&
           /\S/.match?(rule['path']) &&
-          rule['value'].is_a?(String)
+          rule.key?('value')
       else
         false
       end

--- a/spec/models/agents/trigger_agent_spec.rb
+++ b/spec/models/agents/trigger_agent_spec.rb
@@ -88,6 +88,12 @@ describe Agents::TriggerAgent do
       expect(@checker).not_to be_valid
       @checker.options['rules'].last['value'] = ''
       expect(@checker).to be_valid
+      @checker.options['rules'].last['value'] = nil
+      expect(@checker).to be_valid
+      @checker.options['rules'].last.delete('value')
+      expect(@checker).not_to be_valid
+      @checker.options['rules'].last['value'] = ['a']
+      expect(@checker).to be_valid
       @checker.options['rules'].last['path'] = ''
       expect(@checker).not_to be_valid
     end


### PR DESCRIPTION
The value of a rule should be allowed to be anything, including an array of strings for example.

Fixes #3292.