### PR TITLE
suppress logrotate error

### DIFF
--- a/deployment/logrotate/huginn
+++ b/deployment/logrotate/huginn
@@ -15,6 +15,6 @@
   # as our "lastaction" action:
   lastaction
     pid=/home/huginn/huginn/tmp/pids/unicorn.pid
-    test -s $pid && kill -USR1 "$(cat $pid)"
+    if test -s $pid; then kill -USR1 "$(cat $pid)"; fi
   endscript
 }


### PR DESCRIPTION
If logrotate is performed when Huginn is not running, the following error is output:

> error: error running last action script for /path/to/huginn/log/*.log

as the ``test`` command returns non-zero value.
This PR avoids the error by using ``if`` statement.