### PR TITLE
docs: add one-click-deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Our general intention is to encourage complex and specific Agents to be written 
 
 Please see [the Huginn Wiki](https://github.com/huginn/huginn/wiki#deploying-huginn) for detailed deployment strategies for different providers.
 
+### Dome
+
+Try the full version of Huginn with a free trial on Dome with [one-click](https://app.trydome.io/signup?package=huginn):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=huginn)
+
 ### Heroku
 
 Try Huginn on Heroku: [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy) (Takes a few minutes to setup. Read the [documentation](https://github.com/huginn/huginn/blob/master/doc/heroku/install.md) while you are waiting and be sure to click 'View it' after launch!)


### PR DESCRIPTION
Adds [one-click-deploy link](https://app.trydome.io/signup?package=huginn) with Dome to the readme

Hey!

We build this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:
https://6edadc20b3dead29d6187dc8348fa8615b6ffad0.dome.tools/

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.