### PR TITLE
.bz isn't supplied by ruby anymore

### DIFF
--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -72,7 +72,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.bz2 | tar xj
+    wget https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
+    tar -xvzf ruby-3.2.2.tar.gz
     cd ruby-3.2.2
     ./configure --disable-install-rdoc
     make -j`nproc`


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/