### PR TITLE
avoid web request encode  error

### DIFF
--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -53,7 +53,7 @@ module WebRequestConcern
           # Return body as binary if default_encoding is nil
           next if encoding.nil?
         end
-        body.encode!(Encoding::UTF_8, encoding)
+        body.encode!(Encoding::UTF_8, encoding, invalid: :replace, undef: :replace, replace: " " )
       end
     end
   end

--- a/app/concerns/web_request_concern.rb
+++ b/app/concerns/web_request_concern.rb
@@ -53,7 +53,7 @@ module WebRequestConcern
           # Return body as binary if default_encoding is nil
           next if encoding.nil?
         end
-        body.encode!(Encoding::UTF_8, encoding, invalid: :replace, undef: :replace, replace: " " )
+        body.encode!(Encoding::UTF_8, encoding, invalid: :replace, undef: :replace)
       end
     end
   end


### PR DESCRIPTION
when access some malform encoded website .    
website agent stop working by throwing exception

fix by  replacing unknow ,invalid char sequence to space.

```
Error when fetching url: "\xFA\xD4" from EUC-JP to UTF-8
/app/app/concerns/web_request_concern.rb:56:in `encode!'
```

[Encoding+Options](https://ruby-doc.org/3.2.2/encodings_rdoc.html#label-Encoding+Options)