### PR TITLE
#3324 - Installation and upgrade documentation updates.

### DIFF
--- a/doc/manual/update.md
+++ b/doc/manual/update.md
@@ -62,7 +62,7 @@ Upgrade when required:
 
 ```
 mkdir /tmp/ruby && cd /tmp/ruby
-curl -L --progress https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.bz2 | tar xj
+curl -L --progress https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.xz | tar xJ
 cd ruby-3.2.2
 ./configure --disable-install-rdoc
 make -j`nproc`
@@ -83,7 +83,8 @@ sudo gem update --system --no-document
 
 ```
 cd /home/huginn/huginn
-
+bundle config set --local deployment 'true'
+bundle config set --local without 'development test'
 sudo -u huginn -H bundle install --deployment --without development test
 
 # Run database migrations


### PR DESCRIPTION
Corrects bundle commands and the ruby 3.2.2 archive filename to the .xz (.bz variants do not exist). Also changes the tar command suggestion to use the `xJ` flag to extract the contents.

Finally, the bundle commands are changed to exclude the deprecated flags which generated warnings. Added two suggested bundler config commands to mimic these flags.