### PR TITLE
Fix undefined method `payload' for nil:NilClass in delay_agent.rb

### DIFF
--- a/app/models/agents/delay_agent.rb
+++ b/app/models/agents/delay_agent.rb
@@ -93,7 +93,7 @@ module Agents
         events = sort_events(events)
       end
 
-      if interpolated['max_emitted_events'].present?
+      if interpolated['max_emitted_events'].present? and interpolated['max_emitted_events'].to_i < events.length
         events[interpolated['max_emitted_events'].to_i..] = []
       end
 


### PR DESCRIPTION
When the number of events is less than `max_emitted_events` configured delay_agent is trying to emit empty events.

close: https://github.com/huginn/huginn/issues/3315