### PR TITLE
Allow setting action mailer read and open timeouts via environment

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -10,6 +10,6 @@ ActionMailer::Base.smtp_settings = {
   openssl_verify_mode: ENV['SMTP_OPENSSL_VERIFY_MODE'].presence,
   ca_path: ENV['SMTP_OPENSSL_CA_PATH'].presence,
   ca_file: ENV['SMTP_OPENSSL_CA_FILE'].presence,
-  read_timeout: ENV['SMTP_READ_TIMEOUT'] || nil,
-  open_timeout: ENV['SMTP_OPEN_TIMEOUT'] || nil
+  read_timeout: ENV['SMTP_READ_TIMEOUT']&.to_i,
+  open_timeout: ENV['SMTP_OPEN_TIMEOUT']&.to_i,
  }

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -9,5 +9,7 @@ ActionMailer::Base.smtp_settings = {
   password: ENV['SMTP_USER_NAME'] == 'none' ? nil : ENV['SMTP_PASSWORD'].presence,
   openssl_verify_mode: ENV['SMTP_OPENSSL_VERIFY_MODE'].presence,
   ca_path: ENV['SMTP_OPENSSL_CA_PATH'].presence,
-  ca_file: ENV['SMTP_OPENSSL_CA_FILE'].presence
-}
+  ca_file: ENV['SMTP_OPENSSL_CA_FILE'].presence,
+  read_timeout: ENV['SMTP_READ_TIMEOUT'] || nil,
+  open_timeout: ENV['SMTP_OPEN_TIMEOUT'] || nil
+ }


### PR DESCRIPTION
This allows fixing `Net::ReadTimeout with #<Socket:(closed)>` errors when sending email