### PR TITLE
Use unicorn (instead of webrick) in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -177,6 +177,7 @@ end
 
 group :production do
   gem 'unicorn'
+  gem 'unicorn-rails'
 end
 
 # Platform requirements.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,6 +813,9 @@ GEM
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    unicorn-rails (2.2.1)
+      rack
+      unicorn
     vcr (6.1.0)
     version_gem (1.1.2)
     warden (1.2.9)
@@ -951,6 +954,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (~> 2.7.2)
   unicorn
+  unicorn-rails
   vcr
   web-console (>= 4.2.1)
   webmock


### PR DESCRIPTION
Starting from Ruby 3.0, webrick is only loadable when it is required as a gem.  Our Gemfile did not require it as a gem, but [google-apis-core](https://rubygems.org/gems/google-apis-core) <=0.11.2 happened to have had it as a dependency, so Rails server could successfully load webrick.
#3381 upgraded [google-apis-core](https://rubygems.org/gems/google-apis-core) to 0.11.3, in which version the dependency on webrick was dropped, and that made Rails server fail in trying to load webrick.

However, running webrick in production is not recommended in the first place as it is only for development and testing purposes.
By requiring unicorn-rails, unicorn becomes the default Rails server which is suitable for running in production.