### PR TITLE
Fix huginn_agent gems for Rails 6 & 7 Zeitwerk loader

### DIFF
--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -91,7 +91,9 @@ module AgentHelper
 
   def agent_type_select_options
     Rails.cache.fetch('agent_type_select_options') do
-      [['Select an Agent Type', 'Agent', {title: ''}]] + Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name, User.new(id: 0), {}).html_description.lines.first.strip)}] }
+      types = Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name, User.new(id: 0), {}).html_description.lines.first.strip)}] }
+      types.sort_by! { |t| t[0] }
+      [['Select an Agent Type', 'Agent', {title: ''}]] + types
     end
   end
 

--- a/config/initializers/requires.rb
+++ b/config/initializers/requires.rb
@@ -1,2 +1,4 @@
 require 'pp'
-HuginnAgent.require!
+Rails.application.config.to_prepare do
+  HuginnAgent.require!
+end


### PR DESCRIPTION
huginn_agent was loaded in such a way that the Zeitwerk loader wouldn't find agent gems and the `Agent::TYPES` array wasn't being extended with custom agent gems when Zeitwerk reloaded the Agent model.

Call `HuginnAgent.require!` in a `Application.config.to_prepare` event so that it is run whenever Zeitwerk reloads code (specifically the Agent model).

Fixes #2845.
Closes huginn/huginn_agent#29 as unneeded.