### PR TITLE
Add a new option "line_break_is_lf" to LiquidOutputAgent

### DIFF
--- a/app/models/agents/liquid_output_agent.rb
+++ b/app/models/agents/liquid_output_agent.rb
@@ -22,6 +22,7 @@ module Agents
         * `secret` - A token that the requestor must provide for light-weight authentication.
         * `expected_receive_period_in_days` - How often you expect data to be received by this Agent from other Agents.
         * `content` - The content to display when someone requests this page.
+        * `line_break_is_lf` - Use LF as line breaks instead of CRLF.
         * `mime_type` - The mime type to use when someone requests this page.
         * `response_headers` - An object with any custom response headers. (example: `{"Access-Control-Allow-Origin": "*"}`)
         * `mode` - The behavior that determines what data is passed to the Liquid template.
@@ -98,6 +99,7 @@ module Agents
     form_configurable :secret
     form_configurable :expected_receive_period_in_days
     form_configurable :content, type: :text
+    form_configurable :line_break_is_lf, type: :boolean
     form_configurable :mime_type
     form_configurable :mode, type: :array, values: ['Last event in', 'Merge events', 'Last X events']
     form_configurable :event_limit
@@ -195,7 +197,9 @@ module Agents
     end
 
     def liquified_content
-      interpolated(data_for_liquid_template)['content']
+      content = interpolated(data_for_liquid_template)['content']
+      content.gsub!(/\r(?=\n)/, '') if boolify(options['line_break_is_lf'])
+      content
     end
 
     def data_for_liquid_template

--- a/spec/models/agents/liquid_output_agent_spec.rb
+++ b/spec/models/agents/liquid_output_agent_spec.rb
@@ -203,7 +203,7 @@ describe Agents::LiquidOutputAgent do
     end
   end
 
-  describe "#receive_web_request?" do
+  describe "#receive_web_request" do
     let(:secret) { SecureRandom.uuid }
 
     let(:headers) { {} }
@@ -231,6 +231,21 @@ describe Agents::LiquidOutputAgent do
       agent.memory['last_event'] = { key => value }
       agent.save!
       agents(:bob_website_agent).events.destroy_all
+    end
+
+    it "should output LF-terminated lines if line_break_is_lf is true" do
+      agent.options["content"] = "hello\r\nworld\r\n"
+
+      result = agent.receive_web_request request
+      expect(result[0]).to eq "hello\r\nworld\r\n"
+
+      agent.options["line_break_is_lf"] = "true"
+      result = agent.receive_web_request request
+      expect(result[0]).to eq "hello\nworld\n"
+
+      agent.options["line_break_is_lf"] = "false"
+      result = agent.receive_web_request request
+      expect(result[0]).to eq "hello\r\nworld\r\n"
     end
 
     it 'should respond with custom response header if configured with `response_headers` option' do


### PR DESCRIPTION
Because this agent uses form_configurable every line break entered in the "content" field will be encoded and saved as CRLF, which will be directly reflected in the final output.

This option allows the agent to output lines terminated with LF instead of CRLF.