### PR TITLE
WebsiteAgent can output raw XPath values

### DIFF
--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -62,6 +62,8 @@ module Agents
 
       Beware that when parsing an XML document (i.e. `type` is `xml`) using `xpath` expressions, all namespaces are stripped from the document unless the top-level option `use_namespaces` is set to `true`.
 
+      For extraction with `raw` set to true, each value will be returned as is without any conversion instead of stringifying them.  This is useful when you want to extract a number, a boolean value, or an array of strings.
+
       For extraction with `single_array` set to true, all matches will be extracted into an array. This is useful when extracting list elements or multiple parts of a website that can only be matched with the same selector.
 
       # Scraping JSON
@@ -297,7 +299,7 @@ module Agents
             extract.each do |name, details|
               details.each do |name,|
                 case name
-                when 'css', 'xpath', 'value', 'repeat', 'hidden', 'single_array'
+                when 'css', 'xpath', 'value', 'repeat', 'hidden', 'raw', 'single_array'
                   # ok
                 else
                   errors.add(:base, "Unknown key #{name.inspect} in extraction details")
@@ -636,22 +638,63 @@ module Agents
         else
           raise '"css" or "xpath" is required for HTML or XML extraction'
         end
+
         log "Extracting #{extraction_type} at #{xpath || css}"
+
+        expr = extraction_details['value'] || '.'
+
+        handle_float = ->(value) {
+          case
+          when value.nan?
+            'NaN'
+          when value.infinite?
+            if value > 0
+              'Infinity'
+            else
+              '-Infinity'
+            end
+          when value.to_i == value
+            # Node#xpath() returns any numeric value as float;
+            # convert it to integer as appropriate.
+            value.to_i
+          else
+            value
+          end
+        }
+        jsonify =
+          if boolify(extraction_details['raw'])
+            ->(value) {
+              case value
+              when nil, true, false, String, Integer
+                value
+              when Float
+                handle_float.call(value)
+              when Nokogiri::XML::NodeSet
+                value.map(&jsonify)
+              else
+                value.to_s
+              end
+            }
+          else
+            ->(value) {
+              case value
+              when Float
+                handle_float.call(value).to_s
+              else
+                value.to_s
+              end
+            }
+          end
+
         case nodes
         when Nokogiri::XML::NodeSet
-          stringified_nodes = nodes.map do |node|
-            case value = node.xpath(extraction_details['value'] || '.')
-            when Float
-              # Node#xpath() returns any numeric value as float;
-              # convert it to integer as appropriate.
-              value = value.to_i if value.to_i == value
-            end
-            value.to_s
-          end
+          node_values = nodes.map { |node|
+            jsonify.call(node.xpath(expr))
+          }
           if boolify(extraction_details['single_array'])
-            values << stringified_nodes
+            values << node_values
           else
-            stringified_nodes.each { |n| values << n }
+            node_values.each { |value| values << value }
           end
         else
           raise "The result of HTML/XML extraction was not a NodeSet"

--- a/app/models/agents/website_agent.rb
+++ b/app/models/agents/website_agent.rb
@@ -62,7 +62,7 @@ module Agents
 
       Beware that when parsing an XML document (i.e. `type` is `xml`) using `xpath` expressions, all namespaces are stripped from the document unless the top-level option `use_namespaces` is set to `true`.
 
-      For extraction with `array` set to true, all matches will be extracted into an array. This is useful when extracting list elements or multiple parts of a website that can only be matched with the same selector.
+      For extraction with `single_array` set to true, all matches will be extracted into an array. This is useful when extracting list elements or multiple parts of a website that can only be matched with the same selector.
 
       # Scraping JSON
 
@@ -295,6 +295,15 @@ module Agents
           case extraction_type
           when 'html', 'xml'
             extract.each do |name, details|
+              details.each do |name,|
+                case name
+                when 'css', 'xpath', 'value', 'repeat', 'hidden', 'single_array'
+                  # ok
+                else
+                  errors.add(:base, "Unknown key #{name.inspect} in extraction details")
+                end
+              end
+
               case details['css']
               when String
                 # ok
@@ -639,7 +648,7 @@ module Agents
             end
             value.to_s
           end
-          if boolify(extraction_details['array'])
+          if boolify(extraction_details['single_array'])
             values << stringified_nodes
           else
             stringified_nodes.each { |n| values << n }

--- a/db/migrate/20241027081918_website_agent_rename_array_to_single_array.rb
+++ b/db/migrate/20241027081918_website_agent_rename_array_to_single_array.rb
@@ -1,0 +1,29 @@
+class WebsiteAgentRenameArrayToSingleArray < ActiveRecord::Migration[6.1]
+  def up
+    Agents::WebsiteAgent.find_each do |agent|
+      case extract = agent.options['extract']
+      when Hash
+        extract.each_value do |details|
+          if details.is_a?(Hash) && details.key?('array')
+            details['single_array'] = details.delete('array')
+          end
+        end
+        agent.save(validate: false)
+      end
+    end
+  end
+
+  def down
+    Agents::WebsiteAgent.find_each do |agent|
+      case extract = agent.options['extract']
+      when Hash
+        extract.each_value do |details|
+          if details.is_a?(Hash) && details.key?('single_array')
+            details['array'] = details.delete('single_array')
+          end
+        end
+        agent.save(validate: false)
+      end
+    end
+  end
+end

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -729,6 +729,25 @@ describe Agents::WebsiteAgent do
         expect(event.payload['slogan']).to eq("A webcomic of romance, sarcasm, math, &amp; language.")
       end
 
+      it "should return an array if XPath returns many nodes and the raw option is specified" do
+        rel_site = {
+          'name' => "XKCD",
+          'expected_update_period_in_days' => 2,
+          'type' => "html",
+          'url' => "http://xkcd.com",
+          'mode' => "on_change",
+          'extract' => {
+            'slogan' => {'css' => "#slogan", 'value' => ".//text()", 'raw' => true}
+          }
+        }
+        rel = Agents::WebsiteAgent.new(name: "xkcd", options: rel_site)
+        rel.user = users(:bob)
+        rel.save!
+        rel.check
+        event = Event.last
+        expect(event.payload['slogan']).to eq(["A webcomic of romance,", " sarcasm, math, &amp; language."])
+      end
+
       it "should return a string value returned by XPath" do
         rel_site = {
           'name' => "XKCD",

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -122,6 +122,27 @@ describe Agents::WebsiteAgent do
           expect(@checker).to be_valid
         end
       end
+
+      context "in 'html' type" do
+        it "should ensure that all extractions have either 'xpath' or 'css'" do
+          @checker.options['type'] = 'html'
+          @checker.options['extract'] = {
+            'url' => { 'array' => true },
+          }
+          expect(@checker).to_not be_valid
+          expect(@checker.errors_on(:base)).to include(/When type is html or xml, all extractions must have a css or xpath attribute/) & include(/Unknown key "array"/)
+
+          @checker.options['extract'] = {
+            'url' => { 'xpath' => '//bar', 'single_array' => true },
+          }
+          expect(@checker).to be_valid
+
+          @checker.options['extract'] = {
+            'url' => { 'css' => 'bar' },
+          }
+          expect(@checker).to be_valid
+        end
+      end
     end
 
     describe "#check" do
@@ -781,7 +802,7 @@ describe Agents::WebsiteAgent do
               'title' => { 'xpath' => '/feed/entry', 'value' => 'normalize-space(./title)' },
               'url' => { 'xpath' => '/feed/entry', 'value' => './link[1]/@href' },
               'thumbnail' => { 'xpath' => '/feed/entry', 'value' => './thumbnail/@url' },
-              'page_title': { 'xpath': '/feed/title', 'value': 'string(.)', 'repeat' => true }
+              'page_title' => { 'xpath' => '/feed/title', 'value' => 'string(.)', 'repeat' => true }
             }
           }, keep_events_for: 2.days)
           @checker.user = users(:bob)
@@ -1173,7 +1194,7 @@ fire: hot
         it 'returns an array of found nodes when the array extract_option is true' do
           stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
 
-          @checker.options['extract']['nav_links'] = {'css' => '#topLeft li', 'value' => 'normalize-space(.)', 'array' => 'true'}
+          @checker.options['extract']['nav_links'] = {'css' => '#topLeft li', 'value' => 'normalize-space(.)', 'single_array' => 'true'}
           expect {
             @checker.receive([@event])
           }.to change { Event.count }.by(1)

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -24,7 +24,7 @@ describe Agents::WebsiteAgent do
           'hovertext' => { 'css' => "#comic img", 'value' => "@title" }
         }
       }
-      @checker = Agents::WebsiteAgent.new(:name => "xkcd", :options => @valid_options, :keep_events_for => 2.days)
+      @checker = Agents::WebsiteAgent.new(name: "xkcd", options: @valid_options, keep_events_for: 2.days)
       @checker.user = users(:bob)
       @checker.save!
     end
@@ -151,7 +151,7 @@ describe Agents::WebsiteAgent do
           expect { @checker.check }.to change { Event.count }.by(1)
         end
         event = Event.last
-        expect { @checker.check }.not_to change { Event.count }
+        expect { @checker.check }.not_to(change { Event.count })
         update_event = Event.last
         expect(update_event.expires_at).not_to eq(event.expires_at)
       end
@@ -179,7 +179,7 @@ describe Agents::WebsiteAgent do
           @valid_options['uniqueness_look_back'] = 2
           @checker.options = @valid_options
           @checker.check
-        }.not_to change { Event.count }
+        }.not_to(change { Event.count })
 
         expect {
           @valid_options['mode'] = 'on_change'
@@ -199,8 +199,8 @@ describe Agents::WebsiteAgent do
       it "should accept an array for url" do
         @valid_options['url'] = ["http://xkcd.com/1/", "http://xkcd.com/2/"]
         @checker.options = @valid_options
-        expect { @checker.save! }.not_to raise_error;
-        expect { @checker.check }.not_to raise_error;
+        expect { @checker.save! }.not_to raise_error
+        expect { @checker.check }.not_to raise_error
       end
 
       it "should parse events from all urls in array" do
@@ -243,7 +243,7 @@ describe Agents::WebsiteAgent do
           },
           # no unzip option
         }
-        checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+        checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
         checker.user = users(:bob)
         checker.save!
 
@@ -274,7 +274,7 @@ describe Agents::WebsiteAgent do
           },
           # no unzip option
         }
-        checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+        checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
         checker.user = users(:bob)
         checker.save!
 
@@ -303,7 +303,7 @@ describe Agents::WebsiteAgent do
           },
           'unzip' => 'gzip',
         }
-        checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+        checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
         checker.user = users(:bob)
         checker.save!
 
@@ -313,13 +313,13 @@ describe Agents::WebsiteAgent do
       end
 
       it 'should either avoid or support a raw deflate stream (#1018)' do
-        stub_request(:any, /deflate/).with(headers: { 'Accept-Encoding' => /\A(?!.*deflate)/ }).
-          to_return(body: 'hello',
-                    status: 200)
-        stub_request(:any, /deflate/).with(headers: { 'Accept-Encoding' => /deflate/ }).
-          to_return(body: "\xcb\x48\xcd\xc9\xc9\x07\x00\x06\x2c".b,
-                    headers: { 'Content-Encoding' => 'deflate' },
-                    status: 200)
+        stub_request(:any, /deflate/).with(headers: { 'Accept-Encoding' => /\A(?!.*deflate)/ })
+          .to_return(body: 'hello',
+                     status: 200)
+        stub_request(:any, /deflate/).with(headers: { 'Accept-Encoding' => /deflate/ })
+          .to_return(body: "\xcb\x48\xcd\xc9\xc9\x07\x00\x06\x2c".b,
+                     headers: { 'Content-Encoding' => 'deflate' },
+                     status: 200)
 
         site = {
           'name' => 'Some Response',
@@ -370,7 +370,8 @@ describe Agents::WebsiteAgent do
             'Content-Type' => content_type,
           },
           body: body.b,
-          status: 200)
+          status: 200
+        )
       end
 
       let :options do
@@ -383,7 +384,7 @@ describe Agents::WebsiteAgent do
       end
 
       let :checker do
-        Agents::WebsiteAgent.create!(name: 'Encoding Checker', options: options) { |agent|
+        Agents::WebsiteAgent.create!(name: 'Encoding Checker', options:) { |agent|
           agent.user = users(:bob)
         }
       end
@@ -436,10 +437,10 @@ describe Agents::WebsiteAgent do
             end
 
             let :body do
-              <<-HTML.encode(Encoding::ISO_8859_1)
-<!DOCTYPE html>
-<title>#{odin}</title>
-<p>Hello, world.
+              <<~HTML.encode(Encoding::ISO_8859_1)
+                <!DOCTYPE html>
+                <title>#{odin}</title>
+                <p>Hello, world.
               HTML
             end
 
@@ -452,11 +453,11 @@ describe Agents::WebsiteAgent do
 
           context 'with no charset in the header' do
             let :body do
-              <<-HTML.encode(Encoding::ISO_8859_1)
-<!DOCTYPE html>
-<meta charset="iso-8859-1">
-<title>#{odin}</title>
-<p>Hello, world.
+              <<~HTML.encode(Encoding::ISO_8859_1)
+                <!DOCTYPE html>
+                <meta charset="iso-8859-1">
+                <title>#{odin}</title>
+                <p>Hello, world.
               HTML
             end
 
@@ -473,11 +474,11 @@ describe Agents::WebsiteAgent do
             end
 
             let :body do
-              <<-HTML.encode(Encoding::ISO_8859_1)
-<!DOCTYPE html>
-<meta charset="UTF-8">
-<title>#{odin}</title>
-<p>Hello, world.
+              <<~HTML.encode(Encoding::ISO_8859_1)
+                <!DOCTYPE html>
+                <meta charset="UTF-8">
+                <title>#{odin}</title>
+                <p>Hello, world.
               HTML
             end
 
@@ -509,11 +510,11 @@ describe Agents::WebsiteAgent do
             end
 
             let :body do
-              <<-XML.encode(Encoding::EUC_JP)
-<?xml version="1.0"?>
-<root>
-  <message>#{huginn}</message>
-</root>
+              <<~XML.encode(Encoding::EUC_JP)
+                <?xml version="1.0"?>
+                <root>
+                  <message>#{huginn}</message>
+                </root>
               XML
             end
 
@@ -527,11 +528,11 @@ describe Agents::WebsiteAgent do
           context 'with no charset in the header' do
             context 'but in XML declaration' do
               let :body do
-                <<-XML.encode(Encoding::EUC_JP)
-<?xml version="1.0" encoding="euc-jp"?>
-<root>
-  <message>#{huginn}</message>
-</root>
+                <<~XML.encode(Encoding::EUC_JP)
+                  <?xml version="1.0" encoding="euc-jp"?>
+                  <root>
+                    <message>#{huginn}</message>
+                  </root>
                 XML
               end
 
@@ -544,11 +545,11 @@ describe Agents::WebsiteAgent do
 
             context 'but having a BOM' do
               let :body do
-                <<-XML.encode(Encoding::UTF_16LE)
-\u{feff}<?xml version="1.0"?>
-<root>
-  <message>#{huginn}</message>
-</root>
+                <<~XML.encode(Encoding::UTF_16LE)
+                  \u{feff}<?xml version="1.0"?>
+                  <root>
+                    <message>#{huginn}</message>
+                  </root>
                 XML
               end
 
@@ -607,11 +608,11 @@ describe Agents::WebsiteAgent do
             end
 
             let :body do
-              <<-HTML.encode(Encoding::EUC_JP)
-<!DOCTYPE html>
-<meta charset="UTF-8"/>
-<title>#{huginn}</title>
-<p>Hello, world.
+              <<~HTML.encode(Encoding::EUC_JP)
+                <!DOCTYPE html>
+                <meta charset="UTF-8"/>
+                <title>#{huginn}</title>
+                <p>Hello, world.
               HTML
             end
 
@@ -699,10 +700,10 @@ describe Agents::WebsiteAgent do
           'url' => "http://xkcd.com",
           'mode' => "on_change",
           'extract' => {
-            'num_links' => {'css' => "#comicLinks", 'value' => "count(./a)"}
+            'num_links' => { 'css' => "#comicLinks", 'value' => "count(./a)" }
           }
         }
-        rel = Agents::WebsiteAgent.new(:name => "xkcd", :options => rel_site)
+        rel = Agents::WebsiteAgent.new(name: "xkcd", options: rel_site)
         rel.user = users(:bob)
         rel.save!
         rel.check
@@ -718,10 +719,10 @@ describe Agents::WebsiteAgent do
           'url' => "http://xkcd.com",
           'mode' => "on_change",
           'extract' => {
-            'slogan' => {'css' => "#slogan", 'value' => ".//text()"}
+            'slogan' => { 'css' => "#slogan", 'value' => ".//text()" }
           }
         }
-        rel = Agents::WebsiteAgent.new(:name => "xkcd", :options => rel_site)
+        rel = Agents::WebsiteAgent.new(name: "xkcd", options: rel_site)
         rel.user = users(:bob)
         rel.save!
         rel.check
@@ -737,7 +738,7 @@ describe Agents::WebsiteAgent do
           'url' => "http://xkcd.com",
           'mode' => "on_change",
           'extract' => {
-            'slogan' => {'css' => "#slogan", 'value' => ".//text()", 'raw' => true}
+            'slogan' => { 'css' => "#slogan", 'value' => ".//text()", 'raw' => true }
           }
         }
         rel = Agents::WebsiteAgent.new(name: "xkcd", options: rel_site)
@@ -756,10 +757,10 @@ describe Agents::WebsiteAgent do
           'url' => "http://xkcd.com",
           'mode' => "on_change",
           'extract' => {
-            'slogan' => {'css' => "#slogan", 'value' => "string(.)"}
+            'slogan' => { 'css' => "#slogan", 'value' => "string(.)" }
           }
         }
-        rel = Agents::WebsiteAgent.new(:name => "xkcd", :options => rel_site)
+        rel = Agents::WebsiteAgent.new(name: "xkcd", options: rel_site)
         rel.user = users(:bob)
         rel.save!
         rel.check
@@ -794,14 +795,15 @@ describe Agents::WebsiteAgent do
         @checker.check
 
         expect(@checker.event_keys).to contain_exactly('url', 'title', 'summary')
-        expect(@checker.event_description.scan(/"(\w+)": "\.\.\."/).flatten).to contain_exactly('url', 'title', 'summary')
+        expect(@checker.event_description.scan(/"(\w+)": "\.\.\."/).flatten).to contain_exactly('url', 'title',
+                                                                                                'summary')
 
         event = Event.last
         expect(event.payload).to eq({
-                                      'title' => 'EVOLVING',
-                                      'url' => 'http://imgs.xkcd.com/comics/evolving.png',
-                                      'summary' => 'Evolving: Biologists play r...',
-                                    })
+          'title' => 'EVOLVING',
+          'url' => 'http://imgs.xkcd.com/comics/evolving.png',
+          'summary' => 'Evolving: Biologists play r...',
+        })
       end
 
       describe "XML" do
@@ -924,7 +926,7 @@ describe Agents::WebsiteAgent do
             'url' => 'http://example.com/cdata_rss.atom',
             'mode' => 'on_change',
             'extract' => {
-              'author' => { 'xpath' => '/feed/entry/author/name', 'value' => 'string(.)'},
+              'author' => { 'xpath' => '/feed/entry/author/name', 'value' => 'string(.)' },
               'title' => { 'xpath' => '/feed/entry/title', 'value' => 'string(.)' },
               'content' => { 'xpath' => '/feed/entry/content', 'value' => 'string(.)' },
             }
@@ -942,7 +944,6 @@ describe Agents::WebsiteAgent do
           expect(event.payload['title']).to eq('Help: Rainmeter Skins • Test if Today is Between 2 Dates')
           expect(event.payload['content']).to start_with('Can I ')
         end
-
       end
 
       describe "JSON" do
@@ -953,7 +954,7 @@ describe Agents::WebsiteAgent do
               'title' => "hello!"
             }
           }
-          stub_request(:any, /json-site/).to_return(:body => json.to_json, :status => 200)
+          stub_request(:any, /json-site/).to_return(body: json.to_json, status: 200)
           site = {
             'name' => "Some JSON Response",
             'expected_update_period_in_days' => "2",
@@ -961,11 +962,11 @@ describe Agents::WebsiteAgent do
             'url' => "http://json-site.com",
             'mode' => 'on_change',
             'extract' => {
-              'version' => {'path' => "response.version"},
-              'title' => {'path' => "response.title"}
+              'version' => { 'path' => "response.version" },
+              'title' => { 'path' => "response.title" }
             }
           }
-          checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+          checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
           checker.user = users(:bob)
           checker.save!
 
@@ -983,12 +984,12 @@ describe Agents::WebsiteAgent do
             'response' => {
               'status' => 'ok',
               'data' => [
-                {'title' => "first", 'version' => 2},
-                {'title' => "second", 'version' => 2.5}
+                { 'title' => "first", 'version' => 2 },
+                { 'title' => "second", 'version' => 2.5 }
               ]
             }
           }
-          stub_request(:any, /json-site/).to_return(:body => json.to_json, :status => 200)
+          stub_request(:any, /json-site/).to_return(body: json.to_json, status: 200)
           site = {
             'name' => "Some JSON Response",
             'expected_update_period_in_days' => "2",
@@ -1001,7 +1002,7 @@ describe Agents::WebsiteAgent do
               'status' => { 'path' => "response.status", 'repeat' => true },
             }
           }
-          checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+          checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
           checker.user = users(:bob)
           checker.save!
 
@@ -1026,7 +1027,7 @@ describe Agents::WebsiteAgent do
               'title' => "hello!"
             }
           }
-          stub_request(:any, /json-site/).to_return(:body => json.to_json, :status => 200)
+          stub_request(:any, /json-site/).to_return(body: json.to_json, status: 200)
           site = {
             'name' => "Some JSON Response",
             'expected_update_period_in_days' => "2",
@@ -1034,7 +1035,7 @@ describe Agents::WebsiteAgent do
             'url' => "http://json-site.com",
             'mode' => 'on_change'
           }
-          checker = Agents::WebsiteAgent.new(:name => "Weather Site", :options => site)
+          checker = Agents::WebsiteAgent.new(name: "Weather Site", options: site)
           checker.user = users(:bob)
           checker.save!
 
@@ -1049,10 +1050,10 @@ describe Agents::WebsiteAgent do
 
       describe "text parsing" do
         before do
-          stub_request(:any, /text-site/).to_return(body: <<-EOF, status: 200)
-VERSION 1
-water: wet
-fire: hot
+          stub_request(:any, /text-site/).to_return(body: <<~EOF, status: 200)
+            VERSION 1
+            water: wet
+            fire: hot
           EOF
           site = {
             'name' => 'Some Text Response',
@@ -1141,7 +1142,8 @@ fire: hot
           stub2 = stub_request(:any, 'http://google.org/?url=http%3A%2F%2Ffoo.com')
 
           @checker.options = @valid_options.merge(
-            'url_from_event' => ['http://example.org/?url={{url | uri_escape}}', 'http://google.org/?url={{url | uri_escape}}']
+            'url_from_event' => ['http://example.org/?url={{url | uri_escape}}',
+                                 'http://google.org/?url={{url | uri_escape}}']
           )
           @checker.receive([@event])
 
@@ -1150,7 +1152,8 @@ fire: hot
         end
 
         it "should interpolate values from incoming event payload" do
-          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")),
+                                              status: 200)
 
           expect {
             @valid_options['url_from_event'] = '{{ url }}'
@@ -1211,9 +1214,11 @@ fire: hot
         end
 
         it 'returns an array of found nodes when the array extract_option is true' do
-          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")),
+                                              status: 200)
 
-          @checker.options['extract']['nav_links'] = {'css' => '#topLeft li', 'value' => 'normalize-space(.)', 'single_array' => 'true'}
+          @checker.options['extract']['nav_links'] =
+            { 'css' => '#topLeft li', 'value' => 'normalize-space(.)', 'single_array' => 'true' }
           expect {
             @checker.receive([@event])
           }.to change { Event.count }.by(1)
@@ -1221,8 +1226,9 @@ fire: hot
         end
 
         it "should set the inbound_event when logging errors" do
-          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
-           @valid_options['extract'] = {
+          stub_request(:any, /foo/).to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")),
+                                              status: 200)
+          @valid_options['extract'] = {
             'url' => { 'css' => "div", 'value' => "@src" },
             'title' => { 'css' => "#comic img", 'value' => "@alt" },
           }
@@ -1272,7 +1278,8 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => 200 })
+            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world',
+                                                         'type' => 'application/json', 'status' => 200 })
           end
 
           it "should support merge mode" do
@@ -1281,7 +1288,8 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq(@event.payload.merge('value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => 200))
+            expect(@checker.events.last.payload).to eq(@event.payload.merge('value' => 'world',
+                                                                            'url' => 'http://example.com/world', 'type' => 'application/json', 'status' => 200))
           end
 
           it "should convert headers and status in the event data properly" do
@@ -1290,7 +1298,8 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world', 'type' => 'application/rss+xml', 'status' => 201 })
+            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world',
+                                                         'type' => 'application/rss+xml', 'status' => 201 })
           end
 
           it "should ignore inconvertible headers and status in the event data" do
@@ -1299,7 +1308,8 @@ fire: hot
             expect {
               @checker.receive([@event])
             }.to change { Event.count }.by(1)
-            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world', 'type' => '', 'status' => nil })
+            expect(@checker.events.last.payload).to eq({ 'value' => 'world', 'url' => 'http://example.com/world',
+                                                         'type' => '', 'status' => nil })
           end
 
           it "should output an error when nothing can be found at the path" do
@@ -1309,7 +1319,7 @@ fire: hot
 
             expect {
               @checker.receive([@event])
-            }.to_not change { Event.count }
+            }.to_not(change { Event.count })
 
             expect(@checker.logs.last.message).to match(/No data was found in the Event payload using the template {{ some_object\.mistake }}/)
           end
@@ -1319,7 +1329,7 @@ fire: hot
 
             expect {
               @checker.receive([@event])
-            }.to_not change { Event.count }
+            }.to_not(change { Event.count })
 
             expect(@checker.logs.last.message).to match(/Error when handling event data:/)
           end
@@ -1373,28 +1383,28 @@ fire: hot
         },
         'basic_auth' => "user:pass"
       }
-      @checker = Agents::WebsiteAgent.new(:name => "auth", :options => @valid_options)
+      @checker = Agents::WebsiteAgent.new(name: "auth", options: @valid_options)
       @checker.user = users(:bob)
       @checker.save!
 
-      stub_request(:any, "www.example.com").
-        with(basic_auth: ['user', 'pass']).
-        to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
+      stub_request(:any, "www.example.com")
+        .with(basic_auth: ['user', 'pass'])
+        .to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
     end
 
     describe "#check" do
       it "should check for changes" do
         expect { @checker.check }.to change { Event.count }.by(1)
-        expect { @checker.check }.not_to change { Event.count }
+        expect { @checker.check }.not_to(change { Event.count })
       end
     end
   end
 
   describe "checking with headers" do
     before do
-      stub_request(:any, /example/).
-        with(headers: { 'foo' => 'bar' }).
-        to_return(:body => File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), :status => 200)
+      stub_request(:any, /example/)
+        .with(headers: { 'foo' => 'bar' })
+        .to_return(body: File.read(Rails.root.join("spec/data_fixtures/xkcd.html")), status: 200)
       @valid_options = {
         'name' => "XKCD",
         'expected_update_period_in_days' => "2",
@@ -1406,7 +1416,7 @@ fire: hot
           'url' => { 'css' => "#comic img", 'value' => "@src" },
         }
       }
-      @checker = Agents::WebsiteAgent.new(:name => "ua", :options => @valid_options)
+      @checker = Agents::WebsiteAgent.new(name: "ua", options: @valid_options)
       @checker.user = users(:bob)
       @checker.save!
     end
@@ -1420,8 +1430,8 @@ fire: hot
 
   describe "checking urls" do
     before do
-      stub_request(:any, /example/).
-        to_return(:body => File.read(Rails.root.join("spec/data_fixtures/urlTest.html")), :status => 200)
+      stub_request(:any, /example/)
+        .to_return(body: File.read(Rails.root.join("spec/data_fixtures/urlTest.html")), status: 200)
       @valid_options = {
         'name' => "Url Test",
         'expected_update_period_in_days' => "2",
@@ -1435,7 +1445,7 @@ fire: hot
           'url' => '{{ url | to_uri }}',
         }
       }
-      @checker = Agents::WebsiteAgent.new(:name => "ua", :options => @valid_options)
+      @checker = Agents::WebsiteAgent.new(name: "ua", options: @valid_options)
       @checker.user = users(:bob)
       @checker.save!
     end


### PR DESCRIPTION
This allows for obtaining raw XPath values, including booleans, numbers, and arrays of strings.

The `array` option may now sound confusing, so it is renamed `single_array`.  The new `raw` option should hopefully make the feature obsolete.

While at it, NaN and Infinity are now converted to a string instead of causing runtime error.