### PR TITLE
#3483 - Attempts to fix an issue with missing Rails timezone in the ActiveSupport TimeZone mapping.

### DIFF
--- a/lib/huginn_scheduler.rb
+++ b/lib/huginn_scheduler.rb
@@ -112,7 +112,8 @@ class HuginnScheduler < LongRunnable::Worker
   }
 
   def setup
-    tzinfo_friendly_timezone = ActiveSupport::TimeZone::MAPPING[ENV['TIMEZONE'].presence || "Pacific Time (US & Canada)"]
+    Time.zone = ENV['TIMEZONE'].presence || 'Pacific Time (US & Canada)'
+    tzinfo_friendly_timezone = Time.zone.tzinfo.identifier
 
     # Schedule event propagation.
     every '1m' do


### PR DESCRIPTION
The timezone is set and the tzinfo is derived from the current tzinfo-data, etc. and the rufus-sheduler friendly tzinfo identifier is used.