### PR TITLE
default_scenario.json - working alternative to iTunes Trailer Source

### DIFF
--- a/data/default_scenario.json
+++ b/data/default_scenario.json
@@ -93,21 +93,21 @@
     },
     {
       "type": "Agents::WebsiteAgent",
-      "name": "iTunes Trailer Source",
+      "name": "FilmJabber Trailer Source",
       "disabled": false,
-      "guid": "e9afa65457d0a736b9ec20a8dd452fc8",
+      "guid": "e88caf57d7f1c565d8d4bf5fc04572ec",
       "options": {
-        "url": "https://trailers.apple.com/trailers/home/rss/newtrailers.rss",
+        "url": "https://www.filmjabber.com/rss/rss-trailers.php",
         "mode": "on_change",
         "type": "xml",
         "expected_update_period_in_days": 5,
         "extract": {
           "title": {
-            "css": "item title",
+            "xpath": "/rss/channel/item/title",
             "value": "string(.)"
           },
           "url": {
-            "css": "item link",
+            "xpath": "/rss/channel/item/link",
             "value": "string(.)"
           }
         }


### PR DESCRIPTION
Hi,

I just installed huginn and wanted to test the default scenario. There is a iTunes Trailer source which isn't working. Seems the URL isn't available anymore. 

May I suggest an drop in replacement from filmjabber.com?

I am not related anyhow to that site.
The RSS feed is public available, anyhow I did inform them that I started that pull request, and I will wait some days if they reach out to me before removing the draft status here.

