### PR TITLE
Add libre friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Really want a fix or feature? Want to solve some community issues and earn some 
 
 Have an awesome idea but not feeling quite up to contributing yet? Head over to our [Official 'suggest an agent' thread ](https://github.com/huginn/huginn/issues/353) and tell us!
 
+#### Huginn is part of **Libre-Friends**  
+Huginn is a proud member of [Libre-Friends](https://libre-friends.silexlabs.org/), an initiative where libre projects support each other. If you maintain a libre project, consider joining and collaborating with others to build a stronger ecosystem!
+
 ## Examples
 
 Please checkout the [Huginn Introductory Screencast](http://vimeo.com/61976251)!


### PR DESCRIPTION
Hello
I'm the maintainer of Silex free/libre website builder With Keila newsletter - free libre newsletter software, we've decided to create[ this list for cross-promotion of free/libre software](https://gitlab.com/silexlabs/libre-friends/). We display the list on our projects websites
i personally use huginn so I added it to the list. That would be great if we can add a link in huginn readme too Here is the list on silex website: https://www.silex.me/community/  I'll add that nothing and nobody monetizes this or our software and never will (backed with www.silexlabs.org non profit organisation and more than 15 years of existence, just like huginn :) https://en.m.wikipedia.org/wiki/Silex_website_builder