### PR TITLE
Add signup, recover password environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ SKIP_INVITATION_CODE=false
 # If you'd like to require new users to confirm their email address after sign up, set this to true.
 REQUIRE_CONFIRMED_EMAIL=false
 
+ALLOW_SIGN_UP=true
+ALLOW_PASSWORD_RESET=true
+
 # If REQUIRE_CONFIRMED_EMAIL is true, set this to the duration in which a user needs to confirm their email address.
 ALLOW_UNCONFIRMED_ACCESS_FOR=2.days
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,4 +119,8 @@ module ApplicationHelper
   def user_omniauth_authorize_path(provider)
     send "user_#{provider}_omniauth_authorize_path"
   end
+
+  def global_devise_mapping
+    Devise.mappings[:user]
+  end
 end

--- a/app/views/home/_signed_out_index.html.erb
+++ b/app/views/home/_signed_out_index.html.erb
@@ -7,7 +7,10 @@
       <p>Huginn monitors the world and acts on your behalf.</p>
 
       <%= link_to "Login", new_user_session_path, :class => "btn btn-large" %>
-      <%= link_to "Signup", new_user_registration_path, :class => "btn btn-primary btn-large" %>
+
+      <%- if global_devise_mapping.registerable? && controller_name != 'registrations' %>
+        <%= link_to "Signup", new_user_registration_path, :class => "btn btn-primary btn-large" %>
+      <% end -%>
     </div>
     
     <div class="col-md-3 col-md-offset-1">

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -75,7 +75,9 @@
           <% if user_signed_in? %>
             <%= link_to 'Account', edit_user_registration_path, :tabindex => "-1" %>
           <% else %>
-            <%= link_to 'Sign up', new_user_registration_path, :tabindex => "-1" %>
+            <%- if global_devise_mapping.registerable? && controller_name != 'registrations' %>
+              <%= link_to 'Sign up', new_user_registration_path, :tabindex => "-1" %>
+             <% end -%> 
           <% end %>
         </li>
         <% if user_signed_in? && current_user.admin %>


### PR DESCRIPTION
This issue: https://github.com/huginn/huginn/issues/2824

## ALLOW_SIGN_UP
### if you not set, or ALLOW_SIGN_UP=false
hide signup button
### ALLOW_SIGN_UP=true
show signup button

## ALLOW_PASSWORD_RESET
same with ALLOW_SIGN_UP

----------
changes

```properties
# .env.sample
ALLOW_SIGN_UP=true
ALLOW_PASSWORD_RESET=true
```

```ruby
# user.rb
class User < ActiveRecord::Base
  devise :database_authenticatable, :rememberable, :trackable,
         :validatable, :lockable, :omniauthable,
         *(:registerable if ENV['ALLOW_SIGN_UP'] == 'true'),
         *(:recoverable if ENV['ALLOW_PASSWORD_RESET'] == 'true'),
         *(:confirmable if ENV['REQUIRE_CONFIRMED_EMAIL'] == 'true')
```

and some veiws, helpers