### PR TITLE
Implement Templates

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js
+++ b/app/assets/javascripts/pages/agent-edit-page.js
@@ -209,10 +209,9 @@
       $("#agent-spinner").fadeIn();
       if (!firstTime) {
         $(".model-errors").hide();
+        // Only clear template_id when user manually changes type (not on first load)
+        $("#agent_template_id").val('');
       }
-
-      // Clear template_id when selecting a regular type
-      $("#agent_template_id").val('');
 
       return $.getJSON("/agents/type_details", { type }, (json) => {
           if (json.can_be_scheduled) {

--- a/app/assets/javascripts/pages/agent-edit-page.js
+++ b/app/assets/javascripts/pages/agent-edit-page.js
@@ -101,13 +101,120 @@
       if (type === "Agent") {
         $(".agent-settings").hide();
         return $(".description").hide();
-      } else {
+      }
+
+      // Check if this is a template selection (value like "template_123")
+      const templateMatch = type && type.match(/^template_(\d+)$/);
+      if (templateMatch) {
+        const templateId = templateMatch[1];
         $(".agent-settings").show();
         $("#agent-spinner").fadeIn();
         if (!firstTime) {
           $(".model-errors").hide();
         }
-        return $.getJSON("/agents/type_details", { type }, (json) => {
+        return $.getJSON("/agents/template_details", { id: templateId }, (json) => {
+          // Set the hidden template_id
+          $("#agent_template_id").val(json.template_id);
+
+          // Set the actual agent type back to the real type so the form submits correctly
+          if (json.type) {
+            // Temporarily unbind change handler to avoid re-triggering
+            $("#agent_type").off("change");
+            $("#agent_type").val(json.type).trigger('change.select2');
+            $("#agent_type").on("change", () => this.handleTypeChange(false));
+          }
+
+          // Pre-fill form fields
+          if (json.template_name) {
+            $("#agent_name").val(json.template_name);
+          }
+
+          if (json.can_be_scheduled) {
+            this.showSchedule(json.schedule || json.default_schedule);
+          } else {
+            this.hideSchedule();
+          }
+
+          if (json.can_receive_events) {
+            this.showLinks();
+          } else {
+            this.hideLinks();
+          }
+
+          if (json.can_control_other_agents) {
+            this.showControlLinks();
+          } else {
+            this.hideControlLinks();
+          }
+
+          if (json.can_create_events) {
+            this.showEventCreation();
+          } else {
+            this.hideEventCreation();
+          }
+
+          if (json.keep_events_for != null) {
+            $("#agent_keep_events_for").val(json.keep_events_for);
+          }
+
+          if (json.propagate_immediately != null) {
+            $("#agent_propagate_immediately").prop('checked', json.propagate_immediately);
+          }
+
+          // Pre-fill scenario_ids
+          if (json.scenario_ids && json.scenario_ids.length > 0) {
+            $("#agent_scenario_ids").val(json.scenario_ids).trigger('change');
+          }
+
+          // Pre-fill controller_ids
+          if (json.controller_ids && json.controller_ids.length > 0) {
+            $("#agent_controller_ids").val(json.controller_ids).trigger('change');
+          }
+
+          // Pre-fill control_target_ids
+          if (json.control_target_ids && json.control_target_ids.length > 0) {
+            $("#agent_control_target_ids").val(json.control_target_ids).trigger('change');
+          }
+
+          if (json.description_html != null) {
+            $(".description").show().html(json.description_html);
+          }
+
+          if (json.oauthable != null) {
+            $(".oauthable-form").html(json.oauthable);
+          }
+          if (json.form_options != null) {
+            $(".agent-options").html(json.form_options);
+          }
+
+          // Set options in the JSON editor
+          if (json.options != null) {
+            const optionsJson = JSON.stringify(json.options, null, 2);
+            $("textarea.live-json-editor").val(optionsJson);
+          }
+
+          window.jsonEditor = setupJsonEditor()[0];
+
+          this.enableDryRunButton();
+          this.buildAce();
+
+          window.initializeFormCompletable();
+
+          return $("#agent-spinner").stop(true, true).fadeOut();
+        });
+      }
+
+      // Normal agent type selection
+      $(".agent-settings").show();
+      $("#agent-spinner").fadeIn();
+      if (!firstTime) {
+        $(".model-errors").hide();
+      }
+
+      // Clear template_id when selecting a regular type
+      $("#agent_template_id").val('');
+
+      return $.getJSON("/agents/type_details", { type }, (json) => {
           if (json.can_be_scheduled) {
             if (firstTime) {
               this.showSchedule();
@@ -157,7 +264,6 @@
 
           return $("#agent-spinner").stop(true, true).fadeOut();
         });
-      }
     }
 
     hideSchedule() {

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -258,7 +258,7 @@ class AgentsController < ApplicationController
       can_dry_run: @agent.can_dry_run?,
       options: template.options || @agent.default_options,
       description_html: @agent.html_description,
-      template_description: template.description,
+      template_description: template.template_description,
       template_name: template.name,
       template_id: template.id,
       keep_events_for: template.keep_events_for,

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -249,6 +249,7 @@ class AgentsController < ApplicationController
     initialize_presenter
 
     render json: {
+      type: template.type,
       can_be_scheduled: @agent.can_be_scheduled?,
       default_schedule: template.schedule || @agent.default_schedule,
       can_receive_events: @agent.can_receive_events?,

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -280,7 +280,7 @@ class AgentsController < ApplicationController
       return
     end
 
-    @agent.update!(template: true)
+    @agent.update!(template: true, source_ids: [], receiver_ids: [])
     @agent.events.delete_all
     @agent.logs.delete_all
     @agent.update!(memory: {})

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
   def agent_params
     return {} unless params[:agent]
     @agent_params ||= begin
-      params[:agent].permit([:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events, :service_id, :template_id, :template, :description,
+      params[:agent].permit([:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events, :service_id, :template_id, :template, :template_description,
                               source_ids: [], receiver_ids: [], scenario_ids: [], controller_ids: [], control_target_ids: []] + agent_params_options)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
   def agent_params
     return {} unless params[:agent]
     @agent_params ||= begin
-      params[:agent].permit([:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events, :service_id,
+      params[:agent].permit([:memory, :name, :type, :schedule, :disabled, :keep_events_for, :propagate_immediately, :drop_pending_events, :service_id, :template_id, :template, :description,
                               source_ids: [], receiver_ids: [], scenario_ids: [], controller_ids: [], control_target_ids: []] + agent_params_options)
     end
   end

--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -90,10 +90,25 @@ module AgentHelper
   end
 
   def agent_type_select_options
-    Rails.cache.fetch('agent_type_select_options') do
+    options = Rails.cache.fetch('agent_type_select_options') do
       types = Agent.types.map {|type| [agent_type_to_human(type.name), type, {title: h(Agent.build_for_type(type.name, User.new(id: 0), {}).html_description.lines.first.strip)}] }
       types.sort_by! { |t| t[0] }
       [['Select an Agent Type', 'Agent', {title: ''}]] + types
+    end
+
+    if current_user
+      templates = current_user.agents.templates
+      if templates.any?
+        template_options = templates.map do |t|
+          ["[Template] #{t.name}", "template_#{t.id}", {title: h(t.description.presence || "Template based on #{t.short_type.titleize}")}]
+        end
+        template_options.sort_by! { |t| t[0] }
+        options + template_options
+      else
+        options
+      end
+    else
+      options
     end
   end
 

--- a/app/helpers/agent_helper.rb
+++ b/app/helpers/agent_helper.rb
@@ -100,7 +100,7 @@ module AgentHelper
       templates = current_user.agents.templates
       if templates.any?
         template_options = templates.map do |t|
-          ["[Template] #{t.name}", "template_#{t.id}", {title: h(t.description.presence || "Template based on #{t.short_type.titleize}")}]
+          ["[Template] #{t.name}", "template_#{t.id}", {title: h(t.template_description.presence || "Template based on #{t.short_type.titleize}")}]
         end
         template_options.sort_by! { |t| t[0] }
         options + template_options

--- a/app/helpers/dot_helper.rb
+++ b/app/helpers/dot_helper.rb
@@ -144,10 +144,11 @@ module DotHelper
     draw(agents:,
          agent_id: ->(agent) { 'a%d' % agent.id },
          agent_label: ->(agent) {
-           agent.name.gsub(/(.{20}\S*)\s+/) {
+           name = agent.name.gsub(/(.{20}\S*)\s+/) {
              # Fold after every 20+ characters
              $1 + "\n"
            }
+           agent.template? ? "[T] #{name}" : name
          },
          agent_url: ->(agent) { agent_path(agent.id) },
          rich:) {

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -199,7 +199,7 @@ class Agent < ActiveRecord::Base
   end
 
   def unavailable?
-    disabled? || dependencies_missing?
+    disabled? || template? || dependencies_missing?
   end
 
   def dependencies_missing?

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -281,6 +281,7 @@ class Agent < ActiveRecord::Base
     if template?
       self.disabled = true
       self.schedule = 'never' if can_be_scheduled?
+      self.template_id = nil # Templates cannot be derived from other templates
     end
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -51,12 +51,15 @@ class Agent < ActiveRecord::Base
   after_initialize :set_default_schedule
   before_validation :set_default_schedule
   before_validation :unschedule_if_cannot_schedule
+  before_validation :enforce_template_constraints
   before_save :unschedule_if_cannot_schedule
   before_create :set_last_checked_event_id
   after_save :possibly_update_event_expirations
 
   belongs_to :user, inverse_of: :agents
   belongs_to :service, inverse_of: :agents, optional: true
+  belongs_to :source_template, class_name: 'Agent', foreign_key: 'template_id', optional: true
+  has_many :derived_agents, class_name: 'Agent', foreign_key: 'template_id', dependent: :nullify
   has_many :events, -> { order("events.id desc") }, dependent: :delete_all, inverse_of: :agent
   has_one  :most_recent_event, -> { order("events.id desc") }, inverse_of: :agent, class_name: "Event"
   has_many :logs, -> { order("agent_logs.id desc") }, dependent: :delete_all, inverse_of: :agent, class_name: "AgentLog"
@@ -78,6 +81,8 @@ class Agent < ActiveRecord::Base
 
   scope :active,   -> { where(disabled: false, deactivated: false) }
   scope :inactive, -> { where(disabled: true).or(where(deactivated: true)) }
+  scope :templates, -> { where(template: true) }
+  scope :non_templates, -> { where(template: false) }
 
   scope :of_type, ->(type) {
     case type
@@ -90,6 +95,10 @@ class Agent < ActiveRecord::Base
 
   def short_type
     type.demodulize
+  end
+
+  def template?
+    !!template
   end
 
   def check
@@ -268,6 +277,13 @@ class Agent < ActiveRecord::Base
     self.schedule = nil if cannot_be_scheduled?
   end
 
+  def enforce_template_constraints
+    if template?
+      self.disabled = true
+      self.schedule = 'never' if can_be_scheduled?
+    end
+  end
+
   def set_last_checked_event_id
     if can_receive_events? && newest_event_id = Event.maximum(:id)
       self.last_checked_event_id = newest_event_id
@@ -326,6 +342,24 @@ class Agent < ActiveRecord::Base
           name = '%s (%d)' % [original.name, i]
           unless exists?(name:)
             clone.name = name
+            break
+          end
+        end
+      }
+    end
+
+    # Build a new agent from a template, copying all configuration except
+    # source_ids and receiver_ids. The new agent records its lineage via template_id.
+    def build_from_template(template)
+      new(template.slice(
+        :type, :options, :service_id, :schedule, :controller_ids, :control_target_ids,
+        :keep_events_for, :propagate_immediately, :scenario_ids
+      ).merge(template_id: template.id, disabled: false)) { |agent|
+        # Give it a unique name based on the template name
+        2.step do |i|
+          name = '%s (%d)' % [template.name, i]
+          unless exists?(name:)
+            agent.name = name
             break
           end
         end
@@ -404,7 +438,7 @@ class Agent < ActiveRecord::Base
           .joins("JOIN links ON (links.receiver_id = agents.id)")
           .joins("JOIN agents AS sources ON (links.source_id = sources.id)")
           .joins("JOIN events ON (events.agent_id = sources.id AND events.id > links.event_id_at_creation)")
-          .where("NOT agents.disabled AND NOT agents.deactivated AND (agents.last_checked_event_id IS NULL OR events.id > agents.last_checked_event_id)")
+          .where("NOT agents.disabled AND NOT agents.deactivated AND NOT agents.template AND (agents.last_checked_event_id IS NULL OR events.id > agents.last_checked_event_id)")
         if options[:only_receivers].present?
           scope = scope.where("agents.id in (?)", options[:only_receivers])
         end
@@ -466,7 +500,7 @@ class Agent < ActiveRecord::Base
     def bulk_check(schedule)
       raise "Call #bulk_check on the appropriate subclass of Agent" if self == Agent
 
-      where("NOT disabled AND NOT deactivated AND schedule = ?", schedule).pluck("agents.id").each do |agent_id|
+      where("NOT disabled AND NOT deactivated AND NOT template AND schedule = ?", schedule).pluck("agents.id").each do |agent_id|
         async_check(agent_id)
       end
     end

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -48,7 +48,7 @@
   <% else %>
     <li>
       <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-convert-template#{agent.id}" do %>
-        <%= icon_tag('glyphicon-duplicate') %> Convert to Template
+        <%= icon_tag('fa-t', class: 'fa-bold') %> Convert to Template
       <% end %>
     </li>
   <% end %>

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -72,11 +72,7 @@
           <%= icon_tag('glyphicon-refresh') %> Re-emit all events
         <% end %>
       </li>
-    <% end %>
 
-    <li class="divider"></li>
-
-    <% if agent.can_create_events? && agent.events_count > 0 %>
       <li>
         <%= link_to icon_tag('glyphicon-trash', class: 'color-danger') + ' Delete all events', remove_events_agent_path(agent, return: return_to), method: :delete, data: {confirm: 'Are you sure you want to delete ALL emitted events for this Agent?'}, tabindex: "-1" %>
       </li>

--- a/app/views/agents/_action_menu.html.erb
+++ b/app/views/agents/_action_menu.html.erb
@@ -1,14 +1,16 @@
 <ul class="dropdown-menu" role="menu">
-  <% if agent.can_be_scheduled? %>
-    <li>
-      <%= link_to icon_tag('glyphicon-refresh', class: 'color-success') + ' Run', run_agent_path(agent, return: return_to), method: :post, tabindex: "-1" %>
-    </li>
-  <% end %>
+  <% unless agent.template? %>
+    <% if agent.can_be_scheduled? %>
+      <li>
+        <%= link_to icon_tag('glyphicon-refresh', class: 'color-success') + ' Run', run_agent_path(agent, return: return_to), method: :post, tabindex: "-1" %>
+      </li>
+    <% end %>
 
-  <% if agent.can_dry_run? %>
-    <li>
-      <%= link_to icon_tag('glyphicon-refresh') + ' Dry Run', '#', 'data-action-url' => agent_dry_runs_path(agent), 'data-with-event-mode' => agent_dry_run_with_event_mode(agent), tabindex: "-1", onclick: "Utils.handleDryRunButton(this)" %>
-    </li>
+    <% if agent.can_dry_run? %>
+      <li>
+        <%= link_to icon_tag('glyphicon-refresh') + ' Dry Run', '#', 'data-action-url' => agent_dry_runs_path(agent), 'data-with-event-mode' => agent_dry_run_with_event_mode(agent), tabindex: "-1", onclick: "Utils.handleDryRunButton(this)" %>
+      </li>
+    <% end %>
   <% end %>
 
   <li>
@@ -21,19 +23,35 @@
     <%= link_to icon_tag('glyphicon-pencil') + ' Edit agent'.html_safe, edit_agent_path(agent, return: return_to) %>
   </li>
 
-  <li>
-    <%= link_to icon_tag('fa-copy') + ' Clone agent'.html_safe, new_agent_path(id: agent), tabindex: "-1" %>
-  </li>
+  <% unless agent.template? %>
+    <li>
+      <%= link_to icon_tag('fa-copy') + ' Clone agent'.html_safe, new_agent_path(id: agent), tabindex: "-1" %>
+    </li>
 
-  <li>
-    <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-enable-disable#{agent.id}" do %>
-      <% if agent.disabled? %>
-        <%= icon_tag('glyphicon-play') %> Enable agent
-      <% else %>
-        <%= icon_tag('glyphicon-pause') %> Disable agent
+    <li>
+      <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-enable-disable#{agent.id}" do %>
+        <% if agent.disabled? %>
+          <%= icon_tag('glyphicon-play') %> Enable agent
+        <% else %>
+          <%= icon_tag('glyphicon-pause') %> Disable agent
+        <% end %>
       <% end %>
-    <% end %>
-  </li>
+    </li>
+  <% end %>
+
+  <% if agent.template? %>
+    <li class="divider"></li>
+
+    <li>
+      <%= link_to icon_tag('glyphicon-plus') + ' Create Agent from Template', new_agent_path(template_id: agent), tabindex: "-1" %>
+    </li>
+  <% else %>
+    <li>
+      <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-convert-template#{agent.id}" do %>
+        <%= icon_tag('glyphicon-duplicate') %> Convert to Template
+      <% end %>
+    </li>
+  <% end %>
 
   <% if agent.scenarios.length > 0 %>
     <li class="divider"></li>
@@ -45,80 +63,109 @@
     <% end %>
   <% end %>
 
-  <% if agent.can_create_events? && agent.events_count > 0 %>
+  <% unless agent.template? %>
+    <% if agent.can_create_events? && agent.events_count > 0 %>
+      <li class="divider"></li>
+
+      <li>
+        <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-reemit-events#{agent.id}" do %>
+          <%= icon_tag('glyphicon-refresh') %> Re-emit all events
+        <% end %>
+      </li>
+    <% end %>
+
     <li class="divider"></li>
 
-    <li>
-      <%= link_to '#', 'data-toggle' => 'modal', 'data-target' => "#confirm-agent-reemit-events#{agent.id}" do %>
-        <%= icon_tag('glyphicon-refresh') %> Re-emit all events
-      <% end %>
-    </li>
+    <% if agent.can_create_events? && agent.events_count > 0 %>
+      <li>
+        <%= link_to icon_tag('glyphicon-trash', class: 'color-danger') + ' Delete all events', remove_events_agent_path(agent, return: return_to), method: :delete, data: {confirm: 'Are you sure you want to delete ALL emitted events for this Agent?'}, tabindex: "-1" %>
+      </li>
+    <% end %>
   <% end %>
 
   <li class="divider"></li>
 
-  <% if agent.can_create_events? && agent.events_count > 0 %>
-    <li>
-      <%= link_to icon_tag('glyphicon-trash', class: 'color-danger') + ' Delete all events', remove_events_agent_path(agent, return: return_to), method: :delete, data: {confirm: 'Are you sure you want to delete ALL emitted events for this Agent?'}, tabindex: "-1" %>
-    </li>
-  <% end %>
-
   <li>
-    <%= link_to icon_tag('glyphicon-remove', class: 'color-danger') + ' Delete agent', agent_path(agent, return: return_to), method: :delete, data: { confirm: 'Are you sure that you want to permanently delete this Agent?' }, tabindex: "-1" %>
+    <%= link_to icon_tag('glyphicon-remove', class: 'color-danger') + " Delete #{agent.template? ? 'template' : 'agent'}", agent_path(agent, return: return_to), method: :delete, data: { confirm: "Are you sure that you want to permanently delete this #{agent.template? ? 'Template' : 'Agent'}?" }, tabindex: "-1" %>
   </li>
 </ul>
 
-<div id="confirm-agent-enable-disable<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
-  <div class="modal-dialog modal-sm">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h4 class="modal-title">Confirm</h4>
-      </div>
-      <div class="modal-body">
-        <p><% if agent.disabled? %>Enable<% else %>Disable<% end %> &quot;<%= agent.name %>&quot;?</p>
-      </div>
-      <div class="modal-footer">
-        <%= form_for(agent, as: :agent, url: agent_path(agent, return: return_to), method: 'PUT') do |f| %>
-          <% if agent.disabled && agent.can_receive_events? %>
-            <div class="form-group">
-              <%= f.check_box :drop_pending_events %>
-              <%= f.label :drop_pending_events, 'Drop pending events' %>
-              <span class="glyphicon glyphicon-question-sign hover-help" data-content="As soon as you enable this agent, it starts to receive pending events that have not been processed while it was disabled.  To prevent that from happening, you can check this option."></span>
-            </div>
+<% unless agent.template? %>
+  <div id="confirm-agent-enable-disable<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+          <h4 class="modal-title">Confirm</h4>
+        </div>
+        <div class="modal-body">
+          <p><% if agent.disabled? %>Enable<% else %>Disable<% end %> &quot;<%= agent.name %>&quot;?</p>
+        </div>
+        <div class="modal-footer">
+          <%= form_for(agent, as: :agent, url: agent_path(agent, return: return_to), method: 'PUT') do |f| %>
+            <% if agent.disabled && agent.can_receive_events? %>
+              <div class="form-group">
+                <%= f.check_box :drop_pending_events %>
+                <%= f.label :drop_pending_events, 'Drop pending events' %>
+                <span class="glyphicon glyphicon-question-sign hover-help" data-content="As soon as you enable this agent, it starts to receive pending events that have not been processed while it was disabled.  To prevent that from happening, you can check this option."></span>
+              </div>
+            <% end %>
+            <%= f.hidden_field :disabled, value: (!agent.disabled).to_s %>
+            <%= f.button 'No', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
+            <%= f.submit 'Yes', class: 'btn btn-primary' %>
           <% end %>
-          <%= f.hidden_field :disabled, value: (!agent.disabled).to_s %>
-          <%= f.button 'No', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
-          <%= f.submit 'Yes', class: 'btn btn-primary' %>
-        <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<div id="confirm-agent-reemit-events<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
-  <div class="modal-dialog modal-sm">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h4 class="modal-title">Confirm</h4>
-      </div>
-      <div class="modal-body">
-        <p>Re-emit all events for &quot;<%= agent.name %>&quot;?</p>
-      </div>
-      <div class="modal-footer">
-        <%= form_for(agent, as: :agent, url: reemit_events_agent_path(agent, return: return_to), method: 'POST') do |f| %>
-          <% if agent.can_create_events? && agent.events_count > 0 %>
-            <div class="form-group">
-              <%= check_box_tag :delete_old_events %>
-              <%= label_tag :delete_old_events, 'Delete old events' %>
-              <span class="glyphicon glyphicon-question-sign hover-help" data-content="If this is checked, the original copies of the events will be deleted once they are re-emitted."></span>
-            </div>
+  <div id="confirm-agent-reemit-events<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+          <h4 class="modal-title">Confirm</h4>
+        </div>
+        <div class="modal-body">
+          <p>Re-emit all events for &quot;<%= agent.name %>&quot;?</p>
+        </div>
+        <div class="modal-footer">
+          <%= form_for(agent, as: :agent, url: reemit_events_agent_path(agent, return: return_to), method: 'POST') do |f| %>
+            <% if agent.can_create_events? && agent.events_count > 0 %>
+              <div class="form-group">
+                <%= check_box_tag :delete_old_events %>
+                <%= label_tag :delete_old_events, 'Delete old events' %>
+                <span class="glyphicon glyphicon-question-sign hover-help" data-content="If this is checked, the original copies of the events will be deleted once they are re-emitted."></span>
+              </div>
+            <% end %>
+            <%= f.button 'Cancel', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
+            <%= f.submit 'Re-emit all events', class: 'btn btn-primary' %>
           <% end %>
-          <%= f.button 'Cancel', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
-          <%= f.submit 'Re-emit all events', class: 'btn btn-primary' %>
-        <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>
+
+<% unless agent.template? %>
+  <div id="confirm-agent-convert-template<%= agent.id %>" class="confirm-agent modal fade" tabindex="-1" role="dialog" aria-labelledby="confirmAgentLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+          <h4 class="modal-title">Convert to Template</h4>
+        </div>
+        <div class="modal-body">
+          <p>Convert &quot;<%= agent.name %>&quot; to a template?</p>
+          <p class="text-warning"><small>This will disable the agent, clear its events, logs, and memory. This action cannot be undone.</small></p>
+        </div>
+        <div class="modal-footer">
+          <%= form_for(agent, as: :agent, url: convert_to_template_agent_path(agent), method: 'POST') do |f| %>
+            <%= f.button 'Cancel', class: 'btn btn-default', 'data-dismiss' => 'modal' %>
+            <%= f.submit 'Convert', class: 'btn btn-primary' %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -16,6 +16,7 @@
              html: { class: 'agent-form' }) do |f| %>
 
   <%= hidden_field_tag :return, params[:return] %>
+  <%= f.hidden_field :template_id, id: 'agent_template_id' %>
 
   <div class="row">
     <div class="col-md-6">

--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -83,36 +83,38 @@
               </div>
             </div>
 
-            <div class="form-group">
-              <%= f.label :sources %>
-              <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
-              <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
-                <% eventSources = (current_user.agents - [@agent]).find_all { |a| a.can_create_events? } %>
-                <%= f.select(:source_ids,
-                             options_for_select(eventSources.map {|s| [s.name, s.id] },
-                                                @agent.source_ids),
-                             {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
-                <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>
-                <%= f.label :propagate_immediately, :class => 'propagate-immediately' do %>Propagate immediately
-                  <%= f.check_box :propagate_immediately %>
-                  &nbsp;
-                  <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, Huginn moves Events from source Agents to receiving Agents once per minute. Checking this option will cause Events created by this Agent's sources to be received immediately. This can use more CPU resources, but will decrease the time between Event creation and being received by this Agent."></span>
-                <% end %>
+            <% unless @agent.template? %>
+              <div class="form-group">
+                <%= f.label :sources %>
+                <span class="glyphicon glyphicon-question-sign hover-help" data-content="This Agent will receive events from the selected Agents."></span>
+                <div class="link-region" data-can-receive-events="<%= @agent.can_receive_events? %>">
+                  <% eventSources = (current_user.agents - [@agent]).find_all { |a| a.can_create_events? } %>
+                  <%= f.select(:source_ids,
+                               options_for_select(eventSources.map {|s| [s.name, s.id] },
+                                                  @agent.source_ids),
+                               {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+                  <span class='cannot-receive-events text-info'>This type of Agent cannot receive events.</span>
+                  <%= f.label :propagate_immediately, :class => 'propagate-immediately' do %>Propagate immediately
+                    <%= f.check_box :propagate_immediately %>
+                    &nbsp;
+                    <span class="glyphicon glyphicon-question-sign hover-help" data-content="Normally, Huginn moves Events from source Agents to receiving Agents once per minute. Checking this option will cause Events created by this Agent's sources to be received immediately. This can use more CPU resources, but will decrease the time between Event creation and being received by this Agent."></span>
+                  <% end %>
+                </div>
               </div>
-            </div>
 
-            <div class="form-group">
-              <%= f.label :receivers %>
-              <span class="glyphicon glyphicon-question-sign hover-help" data-content="Events created by this Agent will be sent to the selected Agents."></span>
-              <div class="event-related-region">
-                <% eventTargets = (current_user.agents - [@agent]).find_all { |a| a.can_receive_events? } %>
-                <%= f.select(:receiver_ids,
-                             options_for_select(eventTargets.pluck(:name, :id),
-                                                @agent.receiver_ids),
-                             {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
-                <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
+              <div class="form-group">
+                <%= f.label :receivers %>
+                <span class="glyphicon glyphicon-question-sign hover-help" data-content="Events created by this Agent will be sent to the selected Agents."></span>
+                <div class="event-related-region">
+                  <% eventTargets = (current_user.agents - [@agent]).find_all { |a| a.can_receive_events? } %>
+                  <%= f.select(:receiver_ids,
+                               options_for_select(eventTargets.pluck(:name, :id),
+                                                  @agent.receiver_ids),
+                               {}, { :multiple => true, :size => 5, :class => 'select2-linked-tags form-control', data: {url_prefix: '/agents'} }) %>
+                  <span class='cannot-create-events text-info'>This type of Agent cannot create events.</span>
+                </div>
               </div>
-            </div>
+            <% end %>
 
             <% if current_user.scenario_count > 0 %>
               <div class="form-group">

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -4,7 +4,7 @@
   <div class='row'>
     <div class='col-md-2'>
         <ul class="nav nav-pills nav-stacked" id="show-tabs">
-          <li><%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, filtered_agent_return_link || agents_path %></li>
+          <li><%= link_to icon_tag('glyphicon-chevron-left') + ' Back'.html_safe, filtered_agent_return_link || (@agent.template? ? templates_agents_path : agents_path) %></li>
 
           <% if agent_show_view(@agent).present? %>
             <li class='active'><a href="#summary" data-toggle="tab"><span class='glyphicon glyphicon-picture'></span> Summary</a></li>
@@ -14,12 +14,14 @@
             <li class='active'><a href="#details" data-toggle="tab"><span class='glyphicon glyphicon-indent-left'></span> Details</a></li>
           <% end %>
 
-          <li><a href="#logs" data-toggle="tab" data-agent-id="<%= @agent.id %>" class='<%= @agent.recent_error_logs? ? 'recent-errors' : '' %>'><span class='glyphicon glyphicon-list-alt'></span> Logs</a></li>
+          <% unless @agent.template? %>
+            <li><a href="#logs" data-toggle="tab" data-agent-id="<%= @agent.id %>" class='<%= @agent.recent_error_logs? ? 'recent-errors' : '' %>'><span class='glyphicon glyphicon-list-alt'></span> Logs</a></li>
 
-          <% if @agent.can_create_events? && @agent.events_count > 0 %>
-            <li><%= link_to icon_tag('glyphicon-random') + ' Events'.html_safe, agent_events_path(@agent, return: request.fullpath) %></li>
-          <% else %>
-            <li class='disabled'><a><span class='glyphicon glyphicon-random'></span> Events</a></li>
+            <% if @agent.can_create_events? && @agent.events_count > 0 %>
+              <li><%= link_to icon_tag('glyphicon-random') + ' Events'.html_safe, agent_events_path(@agent, return: request.fullpath) %></li>
+            <% else %>
+              <li class='disabled'><a><span class='glyphicon glyphicon-random'></span> Events</a></li>
+            <% end %>
           <% end %>
 
           <li class="dropdown">
@@ -41,35 +43,50 @@
             <% end %>
           </div>
 
-          <div class="tab-pane" id="logs" data-agent-id="<%= @agent.id %>">
-            <div class='row'>
-              <div class='col-md-12'>
-                <h2>
-                  <%= @agent.name %> Logs
-                  <small>
-                    <%= image_tag "spinner-arrows.gif", class: "spinner" %>
-                    <span class="glyphicon glyphicon-refresh action-icon refresh"></span>
-                    <span class="glyphicon glyphicon-trash action-icon clear"></span>
-                  </small>
-                </h2>
+          <% unless @agent.template? %>
+            <div class="tab-pane" id="logs" data-agent-id="<%= @agent.id %>">
+              <div class='row'>
+                <div class='col-md-12'>
+                  <h2>
+                    <%= @agent.name %> Logs
+                    <small>
+                      <%= image_tag "spinner-arrows.gif", class: "spinner" %>
+                      <span class="glyphicon glyphicon-refresh action-icon refresh"></span>
+                      <span class="glyphicon glyphicon-trash action-icon clear"></span>
+                    </small>
+                  </h2>
+                </div>
               </div>
-            </div>
-            <div class='row'>
-              <div class='col-md-12'>
-                <div class='logs'>
-                  Just a moment...
+              <div class='row'>
+                <div class='col-md-12'>
+                  <div class='logs'>
+                    Just a moment...
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          <% end %>
 
           <div class="tab-pane <%= agent_show_view(@agent).present? ? "" : "active" %>" id="details">
             <h2><%= @agent.name %> Details</h2>
+
+            <% if @agent.template? %>
+              <p>
+                <span class="label label-info">Template</span>
+              </p>
+            <% end %>
 
             <p>
               <b>Type:</b>
               <%= @agent.short_type.titleize %>
             </p>
+
+            <% if @agent.template? && @agent.description.present? %>
+              <p>
+                <b>Description:</b>
+                <%= @agent.description %>
+              </p>
+            <% end %>
 
             <% if @agent.can_be_scheduled? %>
               <p>
@@ -77,10 +94,12 @@
                 <%= agent_schedule(@agent) %>
               </p>
 
-              <p>
-                <b>Last checked:</b>
-                <%= @agent.last_check_at ? time_ago_in_words(@agent.last_check_at) + " ago" : "never" %>
-              </p>
+              <% unless @agent.template? %>
+                <p>
+                  <b>Last checked:</b>
+                  <%= @agent.last_check_at ? time_ago_in_words(@agent.last_check_at) + " ago" : "never" %>
+                </p>
+              <% end %>
             <% end %>
 
             <% if (agents = @agent.controllers).length > 0 %>
@@ -90,30 +109,32 @@
               </p>
             <% end %>
 
-            <% if @agent.can_create_events? %>
-              <p>
-                <b>Keep events:</b>
-                <%= (Agent::EVENT_RETENTION_SCHEDULES.detect {|s| s.last == @agent.keep_events_for } || [@agent.keep_events_for]).first %>
-              </p>
+            <% unless @agent.template? %>
+              <% if @agent.can_create_events? %>
+                <p>
+                  <b>Keep events:</b>
+                  <%= (Agent::EVENT_RETENTION_SCHEDULES.detect {|s| s.last == @agent.keep_events_for } || [@agent.keep_events_for]).first %>
+                </p>
 
-              <p>
-                <b>Last event created:</b>
-                <%= @agent.last_event_at ? time_ago_in_words(@agent.last_event_at) + " ago" : "never" %>
-              </p>
-            <% end %>
+                <p>
+                  <b>Last event created:</b>
+                  <%= @agent.last_event_at ? time_ago_in_words(@agent.last_event_at) + " ago" : "never" %>
+                </p>
+              <% end %>
 
-            <% if @agent.can_receive_events? %>
-              <p>
-                <b>Last received event:</b>
-                <%= @agent.last_receive_at ? time_ago_in_words(@agent.last_receive_at) + " ago" : "never" %>
-              </p>
-            <% end %>
+              <% if @agent.can_receive_events? %>
+                <p>
+                  <b>Last received event:</b>
+                  <%= @agent.last_receive_at ? time_ago_in_words(@agent.last_receive_at) + " ago" : "never" %>
+                </p>
+              <% end %>
 
-            <% if @agent.can_create_events? %>
-              <p>
-                <b>Events created:</b>
-                <%= link_to @agent.events_count, agent_events_path(@agent) %>
-              </p>
+              <% if @agent.can_create_events? %>
+                <p>
+                  <b>Events created:</b>
+                  <%= link_to @agent.events_count, agent_events_path(@agent) %>
+                </p>
+              <% end %>
             <% end %>
 
             <% if @agent.try(:oauthable?) %>
@@ -161,27 +182,47 @@
               </p>
             <% end %>
 
-            <p>
-              <b>Working:</b>
-              <%= working @agent %>
-            </p>
+            <% unless @agent.template? %>
+              <p>
+                <b>Working:</b>
+                <%= working @agent %>
+              </p>
+            <% end %>
 
             <p>
               <b>Options:</b>
               <pre><%= Utils.pretty_jsonify @agent.options || {} %></pre>
             </p>
-            <% if @agent.memory.present? %>
-              <p id="memory" data-agent-id="<%= @agent.id %>">
-                <b>Memory:</b>
-                <i class="fa-solid fa-spinner fa-spin-pulse spinner"></i>
-                <i class="fa-solid fa-trash action-icon clear"></i>
-                <a id="toggle-memory" href="#">Show</a>
-                <pre class="memory hidden"><%= Utils.pretty_jsonify @agent.memory || {} %></pre>
+
+            <% if @agent.template? %>
+              <% derived = @agent.derived_agents %>
+              <p>
+                <b>Derived Agents (<%= derived.count %>):</b>
               </p>
+              <% if derived.any? %>
+                <ul>
+                  <% derived.each do |derived_agent| %>
+                    <li><%= link_to derived_agent.name, agent_path(derived_agent) %> <span class='text-muted'>(<%= derived_agent.short_type.titleize %>)</span></li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class='text-muted'>No agents have been created from this template yet.</p>
+              <% end %>
+            <% end %>
+
+            <% unless @agent.template? %>
+              <% if @agent.memory.present? %>
+                <p id="memory" data-agent-id="<%= @agent.id %>">
+                  <b>Memory:</b>
+                  <i class="fa-solid fa-spinner fa-spin-pulse spinner"></i>
+                  <i class="fa-solid fa-trash action-icon clear"></i>
+                  <a id="toggle-memory" href="#">Show</a>
+                  <pre class="memory hidden"><%= Utils.pretty_jsonify @agent.memory || {} %></pre>
+                </p>
+              <% end %>
             <% end %>
           </div>
         </div>
       </div>
   </div>
 </div>
-

--- a/app/views/agents/show.html.erb
+++ b/app/views/agents/show.html.erb
@@ -81,10 +81,10 @@
               <%= @agent.short_type.titleize %>
             </p>
 
-            <% if @agent.template? && @agent.description.present? %>
+            <% if @agent.template? && @agent.template_description.present? %>
               <p>
                 <b>Description:</b>
-                <%= @agent.description %>
+                <%= @agent.template_description %>
               </p>
             <% end %>
 

--- a/app/views/agents/templates.html.erb
+++ b/app/views/agents/templates.html.erb
@@ -28,7 +28,7 @@
                   <span class='text-muted'><%= template.short_type.titleize %></span>
                 </td>
                 <td>
-                  <%= truncate(template.description || '', length: 80) %>
+                  <%= truncate(template.template_description || '', length: 80) %>
                 </td>
                 <td>
                   <%= template.derived_agents.count %>

--- a/app/views/agents/templates.html.erb
+++ b/app/views/agents/templates.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Templates" -%>
+
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class="page-header">
+        <h2>Your Templates</h2>
+      </div>
+
+      <% if @templates.any? %>
+        <div class='table-responsive'>
+          <table class='table table-striped'>
+            <tr>
+              <th><%= sortable_column 'name', 'asc' %></th>
+              <th>Type</th>
+              <th>Description</th>
+              <th>Derived Agents</th>
+              <th><%= sortable_column 'created_at', 'desc', name: 'Created' %></th>
+              <th></th>
+            </tr>
+
+            <% @templates.each do |template| %>
+              <tr>
+                <td>
+                  <%= link_to template.name, agent_path(template, return: request.path) %>
+                </td>
+                <td>
+                  <span class='text-muted'><%= template.short_type.titleize %></span>
+                </td>
+                <td>
+                  <%= truncate(template.description || '', length: 80) %>
+                </td>
+                <td>
+                  <%= template.derived_agents.count %>
+                </td>
+                <td>
+                  <%= time_ago_in_words template.created_at %> ago
+                </td>
+                <td>
+                  <div class="btn-group">
+                    <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                      <span class="glyphicon glyphicon-th-list"></span> Actions <span class="caret"></span>
+                    </button>
+                    <%= render 'agents/action_menu', agent: template, return_to: request.path %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+
+        <%= paginate @templates, :theme => 'twitter-bootstrap-3' %>
+      <% else %>
+        <p class='text-muted'>You don't have any templates yet. You can convert an existing agent to a template from its action menu.</p>
+      <% end %>
+
+      <br/>
+
+      <div class="btn-group">
+        <%= link_to icon_tag('glyphicon-chevron-left') + ' Back to Agents', agents_path, class: "btn btn-default" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -17,7 +17,7 @@
           <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path %>
           <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path, method: 'post' %>
           <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path %>
-          <%= nav_link icon_tag('glyphicon-duplicate') + " View Templates", templates_agents_path %>
+          <%= nav_link icon_tag('fa-t', class: 'fa-bold') + " View Templates", templates_agents_path %>
         </ul>
       <% end %>
       <%= nav_link "Scenarios", scenarios_path %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -17,6 +17,7 @@
           <%= nav_link icon_tag('glyphicon-plus') + " New Agent", new_agent_path %>
           <%= nav_link icon_tag('glyphicon-refresh') + " Run event propagation", propagate_agents_path, method: 'post' %>
           <%= nav_link icon_tag('glyphicon-random') + " View Diagram", diagram_path %>
+          <%= nav_link icon_tag('glyphicon-duplicate') + " View Templates", templates_agents_path %>
         </ul>
       <% end %>
       <%= nav_link "Scenarios", scenarios_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       post :reemit_events
       delete :remove_events
       delete :memory, action: :destroy_memory
+      post :convert_to_template
     end
 
     collection do
@@ -14,6 +15,8 @@ Rails.application.routes.draw do
       post :propagate
       get :type_details
       get :event_descriptions
+      get :templates
+      get :template_details
       post :validate
       post :complete
       delete :undefined, action: :destroy_undefined

--- a/db/migrate/20260211010350_add_template_support_to_agents.rb
+++ b/db/migrate/20260211010350_add_template_support_to_agents.rb
@@ -1,7 +1,7 @@
 class AddTemplateSupportToAgents < ActiveRecord::Migration[7.0]
   def change
     add_column :agents, :template, :boolean, default: false, null: false
-    add_column :agents, :description, :text
+    add_column :agents, :template_description, :text
     add_column :agents, :template_id, :integer
 
     add_index :agents, :template

--- a/db/migrate/20260211010350_add_template_support_to_agents.rb
+++ b/db/migrate/20260211010350_add_template_support_to_agents.rb
@@ -1,0 +1,10 @@
+class AddTemplateSupportToAgents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :agents, :template, :boolean, default: false, null: false
+    add_column :agents, :description, :text
+    add_column :agents, :template_id, :integer
+
+    add_index :agents, :template
+    add_index :agents, :template_id
+  end
+end

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -4,7 +4,23 @@ require 'capybara-select-2'
 
 CAPYBARA_TIMEOUT = ENV['CI'] == 'true' ? 60 : 5
 
-Capybara.javascript_driver = ENV['USE_HEADED_CHROME'] ? :selenium_chrome : :selenium_chrome_headless
+# Register a headless Chrome driver with Docker-compatible options
+Capybara.register_driver :selenium_chrome_headless_docker do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless=new')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--disable-gpu')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+if ENV['USE_HEADED_CHROME']
+  Capybara.javascript_driver = :selenium_chrome
+elsif ENV['DOCKER'] == 'true'
+  Capybara.javascript_driver = :selenium_chrome_headless_docker
+else
+  Capybara.javascript_driver = :selenium_chrome_headless
+end
 Capybara.default_max_wait_time = CAPYBARA_TIMEOUT
 
 RSpec.configure do |config|

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -10,7 +10,7 @@ describe 'Template feature' do
           name: 'My Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -50,7 +50,7 @@ describe 'Template feature' do
           template: true,
           disabled: false,
           schedule: 'midnight',
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         expect(agent.disabled).to be true
         expect(agent.schedule).to eq('never')
@@ -69,16 +69,16 @@ describe 'Template feature' do
           name: 'Weather Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'abc123', 'location' => '94103' },
+          options: { 'api_key' => 'abc123', 'location' => '37.7749,-122.4194' },
           keep_events_for: 86400,
-          description: 'A weather template'
+          template_description: 'A weather template'
         )
       end
 
       it 'creates a new agent based on the template' do
         agent = user.agents.build_from_template(@template)
         expect(agent.type).to eq('Agents::WeatherAgent')
-        expect(agent.options).to eq({ 'api_key' => 'abc123', 'location' => '94103' })
+        expect(agent.options).to eq({ 'api_key' => 'abc123', 'location' => '37.7749,-122.4194' })
         expect(agent.template_id).to eq(@template.id)
         expect(agent.disabled).to be false
         expect(agent.template).not_to be true
@@ -107,13 +107,13 @@ describe 'Template feature' do
           name: 'Source Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         @derived = user.agents.create!(
           name: 'Derived Agent',
           type: 'Agents::WeatherAgent',
           template_id: @template.id,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -138,7 +138,7 @@ describe 'Template feature' do
           type: 'Agents::WeatherAgent',
           template: true,
           schedule: 'midnight',
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -149,7 +149,7 @@ describe 'Template feature' do
     end
   end
 
-  describe AgentsController, 'template actions' do
+  describe AgentsController, 'template actions', type: :controller do
     let(:user) { users(:bob) }
 
     before do
@@ -162,7 +162,7 @@ describe 'Template feature' do
           name: 'Index Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -178,7 +178,7 @@ describe 'Template feature' do
           name: 'Templates Index',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -195,13 +195,15 @@ describe 'Template feature' do
     end
 
     describe 'GET template_details' do
+      render_views
+
       before do
         @template = user.agents.create!(
           name: 'Details Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          description: 'My template description',
-          options: { 'api_key' => 'test123', 'location' => '94103' }
+          template_description: 'My template description',
+          options: { 'api_key' => 'test123', 'location' => '37.7749,-122.4194' }
         )
       end
 
@@ -212,7 +214,7 @@ describe 'Template feature' do
         expect(json['template_name']).to eq('Details Template')
         expect(json['template_description']).to eq('My template description')
         expect(json['template_id']).to eq(@template.id)
-        expect(json['options']).to eq({ 'api_key' => 'test123', 'location' => '94103' })
+        expect(json['options']).to eq({ 'api_key' => 'test123', 'location' => '37.7749,-122.4194' })
       end
 
       it "cannot access another user's templates" do
@@ -220,7 +222,7 @@ describe 'Template feature' do
           name: 'Jane Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         expect {
           get :template_details, params: { id: jane_template.id }
@@ -252,7 +254,7 @@ describe 'Template feature' do
           name: 'Already Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         post :convert_to_template, params: { id: template.to_param }
         expect(flash[:notice]).to include('already a template')
@@ -271,7 +273,7 @@ describe 'Template feature' do
           name: 'No Run Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         post :run, params: { id: template.to_param }
         expect(flash[:notice]).to include('cannot be run')
@@ -284,7 +286,7 @@ describe 'Template feature' do
           name: 'New From Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'from_template', 'location' => '12345' }
+          options: { 'api_key' => 'from_template', 'location' => '37.7771,-122.4196' }
         )
       end
 
@@ -293,7 +295,7 @@ describe 'Template feature' do
         agent = assigns(:agent)
         expect(agent.type).to eq('Agents::WeatherAgent')
         expect(agent.template_id).to eq(@template.id)
-        expect(agent.options).to eq({ 'api_key' => 'from_template', 'location' => '12345' })
+        expect(agent.options).to eq({ 'api_key' => 'from_template', 'location' => '37.7771,-122.4196' })
         expect(agent.template).not_to be true
       end
 
@@ -302,7 +304,7 @@ describe 'Template feature' do
           name: 'Jane Template',
           type: 'Agents::WeatherAgent',
           template: true,
-          options: { 'api_key' => 'test', 'location' => '12345' }
+          options: { 'api_key' => 'test', 'location' => '37.7771,-122.4196' }
         )
         expect {
           get :new, params: { template_id: jane_template.id }

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -1,0 +1,313 @@
+require 'rails_helper'
+
+describe 'Template feature' do
+  describe Agent, 'template support' do
+    let(:user) { users(:bob) }
+
+    describe '.templates / .non_templates scopes' do
+      before do
+        @template = user.agents.create!(
+          name: 'My Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+      end
+
+      it 'returns only templates with .templates scope' do
+        expect(Agent.templates).to include(@template)
+        expect(Agent.templates).not_to include(agents(:bob_website_agent))
+      end
+
+      it 'returns only non-templates with .non_templates scope' do
+        expect(Agent.non_templates).not_to include(@template)
+        expect(Agent.non_templates).to include(agents(:bob_website_agent))
+      end
+    end
+
+    describe '#template?' do
+      it 'returns true when template is set' do
+        agent = Agent.new(template: true)
+        expect(agent.template?).to be true
+      end
+
+      it 'returns false when template is not set' do
+        agent = Agent.new(template: false)
+        expect(agent.template?).to be false
+      end
+
+      it 'returns false by default' do
+        agent = Agent.new
+        expect(agent.template?).to be false
+      end
+    end
+
+    describe '#enforce_template_constraints' do
+      it 'forces disabled=true and schedule=never on save' do
+        agent = user.agents.create!(
+          name: 'Constraint Test',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          disabled: false,
+          schedule: 'midnight',
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        expect(agent.disabled).to be true
+        expect(agent.schedule).to eq('never')
+      end
+
+      it 'does not affect non-template agents' do
+        agent = agents(:bob_weather_agent)
+        expect(agent.disabled).to be false
+        expect(agent.schedule).not_to eq('never')
+      end
+    end
+
+    describe '.build_from_template' do
+      before do
+        @template = user.agents.create!(
+          name: 'Weather Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'abc123', 'location' => '94103' },
+          keep_events_for: 86400,
+          description: 'A weather template'
+        )
+      end
+
+      it 'creates a new agent based on the template' do
+        agent = user.agents.build_from_template(@template)
+        expect(agent.type).to eq('Agents::WeatherAgent')
+        expect(agent.options).to eq({ 'api_key' => 'abc123', 'location' => '94103' })
+        expect(agent.template_id).to eq(@template.id)
+        expect(agent.disabled).to be false
+        expect(agent.template).not_to be true
+      end
+
+      it 'copies configuration but not source_ids or receiver_ids' do
+        agent = user.agents.build_from_template(@template)
+        expect(agent.source_ids).to be_empty
+        expect(agent.receiver_ids).to be_empty
+      end
+
+      it 'generates a unique name' do
+        agent = user.agents.build_from_template(@template)
+        expect(agent.name).to match(/Weather Template \(\d+\)/)
+      end
+
+      it 'copies keep_events_for' do
+        agent = user.agents.build_from_template(@template)
+        expect(agent.keep_events_for).to eq(86400)
+      end
+    end
+
+    describe 'associations' do
+      before do
+        @template = user.agents.create!(
+          name: 'Source Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        @derived = user.agents.create!(
+          name: 'Derived Agent',
+          type: 'Agents::WeatherAgent',
+          template_id: @template.id,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+      end
+
+      it 'tracks derived agents' do
+        expect(@template.derived_agents).to include(@derived)
+      end
+
+      it 'tracks the source template' do
+        expect(@derived.source_template).to eq(@template)
+      end
+
+      it 'nullifies template_id when template is destroyed' do
+        @template.destroy
+        expect(@derived.reload.template_id).to be_nil
+      end
+    end
+
+    describe 'execution guards' do
+      before do
+        @template = user.agents.create!(
+          name: 'Template Guard Test',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          schedule: 'midnight',
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+      end
+
+      it 'excludes templates from bulk_check' do
+        # Template schedule is forced to 'never', so it won't match 'midnight'
+        expect(@template.schedule).to eq('never')
+      end
+    end
+  end
+
+  describe AgentsController, 'template actions' do
+    let(:user) { users(:bob) }
+
+    before do
+      sign_in user
+    end
+
+    describe 'GET index' do
+      before do
+        @template = user.agents.create!(
+          name: 'Index Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+      end
+
+      it 'excludes templates from the agents listing' do
+        get :index
+        expect(assigns(:agents)).not_to include(@template)
+      end
+    end
+
+    describe 'GET templates' do
+      before do
+        @template = user.agents.create!(
+          name: 'Templates Index',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+      end
+
+      it 'lists only templates' do
+        get :templates
+        expect(assigns(:templates)).to include(@template)
+        expect(assigns(:templates).all?(&:template?)).to be true
+      end
+
+      it 'does not include non-template agents' do
+        get :templates
+        expect(assigns(:templates)).not_to include(agents(:bob_website_agent))
+      end
+    end
+
+    describe 'GET template_details' do
+      before do
+        @template = user.agents.create!(
+          name: 'Details Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          description: 'My template description',
+          options: { 'api_key' => 'test123', 'location' => '94103' }
+        )
+      end
+
+      it 'returns template configuration as JSON' do
+        get :template_details, params: { id: @template.id }
+        json = JSON.parse(response.body)
+        expect(json['type']).to eq('Agents::WeatherAgent')
+        expect(json['template_name']).to eq('Details Template')
+        expect(json['template_description']).to eq('My template description')
+        expect(json['template_id']).to eq(@template.id)
+        expect(json['options']).to eq({ 'api_key' => 'test123', 'location' => '94103' })
+      end
+
+      it "cannot access another user's templates" do
+        jane_template = users(:jane).agents.create!(
+          name: 'Jane Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        expect {
+          get :template_details, params: { id: jane_template.id }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe 'POST convert_to_template' do
+      it 'converts an agent to a template' do
+        agent = agents(:bob_weather_agent)
+        post :convert_to_template, params: { id: agent.to_param }
+        agent.reload
+        expect(agent.template?).to be true
+        expect(agent.disabled).to be true
+        expect(agent.schedule).to eq('never')
+      end
+
+      it 'clears events, logs, and memory' do
+        agent = agents(:bob_website_agent)
+        agent.update!(memory: { 'test' => 42 })
+        post :convert_to_template, params: { id: agent.to_param }
+        agent.reload
+        expect(agent.events_count).to eq(0)
+        expect(agent.memory).to eq({})
+      end
+
+      it 'does not re-convert an already-template agent' do
+        template = user.agents.create!(
+          name: 'Already Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        post :convert_to_template, params: { id: template.to_param }
+        expect(flash[:notice]).to include('already a template')
+      end
+
+      it "cannot convert another user's agent" do
+        expect {
+          post :convert_to_template, params: { id: agents(:jane_website_agent).to_param }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe 'POST run' do
+      it 'blocks running a template' do
+        template = user.agents.create!(
+          name: 'No Run Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        post :run, params: { id: template.to_param }
+        expect(flash[:notice]).to include('cannot be run')
+      end
+    end
+
+    describe 'GET new with template_id' do
+      before do
+        @template = user.agents.create!(
+          name: 'New From Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'from_template', 'location' => '12345' }
+        )
+      end
+
+      it 'builds an agent from the template' do
+        get :new, params: { template_id: @template.id }
+        agent = assigns(:agent)
+        expect(agent.type).to eq('Agents::WeatherAgent')
+        expect(agent.template_id).to eq(@template.id)
+        expect(agent.options).to eq({ 'api_key' => 'from_template', 'location' => '12345' })
+        expect(agent.template).not_to be true
+      end
+
+      it "cannot build from another user's template" do
+        jane_template = users(:jane).agents.create!(
+          name: 'Jane Template',
+          type: 'Agents::WeatherAgent',
+          template: true,
+          options: { 'api_key' => 'test', 'location' => '12345' }
+        )
+        expect {
+          get :new, params: { template_id: jane_template.id }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Add template system for reusable agent configurations**

Introduces a template feature that allows users to convert agents into reusable templates and create new agents from them. Templates appear in agent type selection with a `[Template]` prefix and are marked with a bold "T" icon in diagrams.

Key changes:
- New database columns: `template`, `template_description`, `template_id`
- Templates are auto-disabled and excluded from scheduled runs
- New UI: `/agents/templates` page and "Convert to Template" action
- Agents created from templates inherit all configuration except sources/receivers
- Comprehensive test coverage included

Vibe-coded, but througly tested manually