### PR TITLE
Add Agent.fetch/fetchAll and WHATWG URL to JavascriptAgent

### DIFF
--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -1,11 +1,29 @@
 require 'date'
 require 'cgi'
+require 'faraday'
+require 'faraday/follow_redirects'
+require 'faraday/gzip'
+require 'faraday/typhoeus'
 
 module Agents
   class JavaScriptAgent < Agent
     include FormConfigurable
 
     can_dry_run!
+
+    FETCH_USER_AGENT = "Huginn - https://github.com/huginn/huginn".freeze
+    ALLOWED_FETCH_METHODS = %i[get head post put delete patch options].freeze
+
+    class ConditionalFollowRedirects < Faraday::FollowRedirects::Middleware
+      def call(env)
+        case env[:request]&.context
+        in { skip_follow_redirects: true }
+          @app.call(env)
+        else
+          super
+        end
+      end
+    end
 
     default_schedule "never"
 
@@ -36,6 +54,17 @@ module Agents
       * `this.kvs` (whose properties are variables provided by KeyValueStoreAgents)
       * `this.escapeHtml(htmlToEscape)`
       * `this.unescapeHtml(htmlToUnescape)`
+
+      A synchronous subset of the Web `fetch` API is also available as `Agent.fetch(url, options)`.  It blocks until the response is received and returns a Response-like object with the following members:
+
+      * `ok`, `status`, `statusText`, `url`, `redirected`
+      * `headers`: an object whose own properties are the response headers (with lower-cased names), plus `get(name)` and `has(name)` methods for case-insensitive lookup
+      * `text()` returning the response body as a string
+      * `json()` returning the parsed JSON body
+
+      Supported request options are `method` (default `"GET"`), `headers` (a plain object), `body` (a string), `timeout` (in seconds), and `redirect` (`"follow"` or `"manual"`, default `"follow"`).  Network errors throw a `TypeError`; HTTP error statuses do not — check `response.ok` as per the standard.  A default `User-Agent` header is sent when not overridden by the `headers` option.
+
+      To issue multiple requests in parallel, use `Agent.fetchAll(requests, options)`.  Each request may be a URL string or a `[url, options]` pair mirroring the arguments of `Agent.fetch`.  The return value is an array of Response-like objects in the same order as the input.  As with `Agent.fetch`, any network error throws a `TypeError` for the whole batch, while individual HTTP error statuses are reported via each `response.ok`.  The optional second argument accepts `{ concurrency: 8 }` to cap the number of concurrent requests.
     MD
 
     form_configurable :code, type: :text, ace: { mode: 'javascript' }
@@ -127,6 +156,11 @@ module Agents
       context.attach("unescapeHtml", ->(x) { CGI.unescapeHTML(x) })
       context.attach('getCredential', ->(k) { credential(k); })
       context.attach('setCredential', ->(k, v) { set_credential(k, v) })
+      context.attach("doFetch", ->(url, opts) { do_fetch(url, **opts&.deep_symbolize_keys) })
+      context.attach("doFetchAll", ->(pairs, opts) {
+        pairs = pairs&.map { |(url, o)| [url, o.is_a?(Hash) ? o.deep_symbolize_keys : {}] }
+        do_fetch_all(pairs, **opts&.deep_symbolize_keys)
+      })
 
       kvs = Agents::KeyValueStoreAgent.merge(controllers).find_each.to_h { |kvs|
         [kvs.options[:variable], kvs.memory.as_json]
@@ -221,6 +255,57 @@ module Agents
 
         Agent.check = function(){};
         Agent.receive = function(){};
+
+        function buildResponse(result) {
+          var headers = result.headers;
+          return {
+            ok: result.ok,
+            status: result.status,
+            statusText: result.statusText,
+            url: result.url,
+            redirected: result.redirected,
+            headers: Object.assign({}, headers, {
+              get: function(name) {
+                var key = String(name).toLowerCase();
+                return Object.prototype.hasOwnProperty.call(headers, key) ? headers[key] : null;
+              },
+              has: function(name) {
+                return Object.prototype.hasOwnProperty.call(headers, String(name).toLowerCase());
+              }
+            }),
+            text: function() { return result.body; },
+            json: function() { return JSON.parse(result.body); }
+          };
+        }
+
+        Agent.fetch = function(url, options) {
+          var result = doFetch(String(url), options || {});
+          if (result.error) {
+            throw new TypeError(result.error);
+          }
+          return buildResponse(result);
+        }
+
+        Agent.fetchAll = function(requests, options) {
+          if (!Array.isArray(requests)) {
+            throw new TypeError("fetchAll requires an array of requests");
+          }
+          var pairs = requests.map(function(r, i) {
+            if (typeof r === "string") return [r, {}];
+            if (Array.isArray(r)) {
+              if (typeof r[0] !== "string") {
+                throw new TypeError("Request at index " + i + ": first element must be a URL string");
+              }
+              return [r[0], r[1] || {}];
+            }
+            throw new TypeError("Request at index " + i + " must be a URL string or [url, options] array");
+          });
+          var results = doFetchAll(pairs, options || {});
+          if (results.error) {
+            throw new TypeError(results.error);
+          }
+          return results.map(buildResponse);
+        }
       JS
     end
 
@@ -228,6 +313,110 @@ module Agents
       yield
     rescue MiniRacer::Error => e
       error "JavaScript error: #{e.message}"
+    end
+
+    def fetch_client
+      @fetch_client ||= Faraday.new(headers: { "User-Agent" => FETCH_USER_AGENT }) { |b|
+        b.use ConditionalFollowRedirects
+        b.request :gzip
+        b.adapter :typhoeus
+      }
+    end
+
+    def do_fetch(url, **opts)
+      case normalize_fetch_request(url, **opts)
+      in { error: } => result
+        result
+      in req
+        build_fetch_result(req, run_fetch_request(**req))
+      end
+    rescue Faraday::Error => e
+      { error: fetch_error_message(e) }
+    end
+
+    def do_fetch_all(pairs, concurrency: 8, **_rest)
+      return { error: "fetchAll requires an array of requests" } unless pairs.is_a?(Array)
+
+      requests = pairs.map { |(url, opts)| normalize_fetch_request(url, **opts) }
+      if (bad = requests.find { it in { error: } })
+        return bad.slice(:error)
+      end
+
+      concurrency = 8 if concurrency.to_i <= 0
+      manager = Faraday::Adapter::Typhoeus.setup_parallel_manager(max_concurrency: concurrency)
+
+      responses = nil
+      fetch_client.in_parallel(manager) do
+        responses = requests.map { run_fetch_request(**it) }
+      end
+
+      results = requests.zip(responses).map { |req, response| build_fetch_result(req, response) }
+      if (failed = results.find { it in { error: } })
+        return failed.slice(:error)
+      end
+
+      results
+    rescue Faraday::Error => e
+      { error: fetch_error_message(e) }
+    end
+
+    def run_fetch_request(url:, method:, headers:, body:, follow:, timeout:)
+      fetch_client.run_request(method, url, body, headers) { |r|
+        r.options.timeout = timeout if timeout > 0
+        r.options.context = { skip_follow_redirects: true } unless follow
+      }
+    end
+
+    def normalize_fetch_request(url, method: "GET", headers: nil, body: nil, redirect: "follow", timeout: 0, **_rest)
+      url = url.to_s
+      return { error: "fetch requires a URL" } if url.empty?
+
+      begin
+        parsed = URI.parse(url)
+      rescue URI::InvalidURIError => e
+        return { error: "Invalid URL: #{e.message}" }
+      end
+      return { error: "Only http and https URLs are supported" } unless parsed.is_a?(URI::HTTP)
+
+      method = method.to_s.downcase.to_sym
+      return { error: "Unsupported method: #{method}" } unless ALLOWED_FETCH_METHODS.include?(method)
+      return { error: "headers must be an object" } if headers && !headers.is_a?(Hash)
+      return { error: "body must be a string" } if body && !body.is_a?(String)
+
+      {
+        url:, method:, headers:, body:,
+        follow: redirect.to_s != "manual",
+        timeout: timeout.to_i,
+      }
+    end
+
+    def fetch_error_message(e)
+      case e
+      when Faraday::TimeoutError then "Request timed out: #{e.message}"
+      when Faraday::ConnectionFailed then "Connection failed: #{e.message}"
+      when Faraday::SSLError then "SSL error: #{e.message}"
+      else "Request failed: #{e.message}"
+      end
+    end
+
+    def build_fetch_result(req, response)
+      case response.env
+      in { typhoeus_timed_out: true, typhoeus_return_message: msg }
+        { error: "Request timed out: #{msg}" }
+      in { typhoeus_connection_failed: true, typhoeus_return_message: msg }
+        { error: "Connection failed: #{msg}" }
+      in env
+        final_url = env.url.to_s
+        {
+          ok: response.status.between?(200, 299),
+          status: response.status,
+          statusText: Rack::Utils::HTTP_STATUS_CODES[response.status] || "",
+          url: final_url,
+          redirected: final_url != req[:url],
+          headers: response.headers.to_h { |k, v| [k.to_s.downcase, Array(v).join(", ")] },
+          body: response.body.to_s,
+        }
+      end
     end
 
     def clean_nans(input)

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -73,7 +73,7 @@ module Agents
 
       To issue multiple requests in parallel, use `Agent.fetchAll(requests, options)`.  Each request may be a URL string or a `[url, options]` pair mirroring the arguments of `Agent.fetch`.  The return value is an array of Response-like objects in the same order as the input.  As with `Agent.fetch`, any network error throws a `TypeError` for the whole batch, while individual HTTP error statuses are reported via each `response.ok`.  The optional second argument accepts `{ concurrency: 8 }` to cap the number of concurrent requests.
 
-      The WHATWG `URL` and `URLSearchParams` classes are also available as globals.
+      The WHATWG `URL` and `URLSearchParams` classes are also available as globals.  A `URL` instance may be passed wherever a URL string is accepted, including the first argument of `Agent.fetch` and each element of `Agent.fetchAll`.
     MD
 
     form_configurable :code, type: :text, ace: { mode: 'javascript' }
@@ -288,8 +288,13 @@ module Agents
           };
         }
 
+        function toUrlString(input) {
+          if (input == null) throw new TypeError("URL is required");
+          return String(input);
+        }
+
         Agent.fetch = function(url, options) {
-          var result = doFetch(String(url), options || {});
+          var result = doFetch(toUrlString(url), options || {});
           if (result.error) {
             throw new TypeError(result.error);
           }
@@ -312,14 +317,12 @@ module Agents
             throw new TypeError("fetchAll requires an array of requests");
           }
           var pairs = requests.map(function(r, i) {
-            if (typeof r === "string") return [r, {}];
-            if (Array.isArray(r)) {
-              if (typeof r[0] !== "string") {
-                throw new TypeError("Request at index " + i + ": first element must be a URL string");
-              }
-              return [r[0], r[1] || {}];
+            try {
+              if (Array.isArray(r)) return [toUrlString(r[0]), r[1] || {}];
+              return [toUrlString(r), {}];
+            } catch (e) {
+              throw new TypeError("Request at index " + i + ": " + e.message);
             }
-            throw new TypeError("Request at index " + i + " must be a URL string or [url, options] array");
           });
           var results = doFetchAll(pairs, options || {});
           if (results.error) {

--- a/app/models/agents/java_script_agent.rb
+++ b/app/models/agents/java_script_agent.rb
@@ -13,6 +13,13 @@ module Agents
 
     FETCH_USER_AGENT = "Huginn - https://github.com/huginn/huginn".freeze
     ALLOWED_FETCH_METHODS = %i[get head post put delete patch options].freeze
+    URL_POLYFILL_PATH = Rails.root.join("tmp/build/url-polyfill.js").freeze
+
+    def self.url_polyfill_source
+      @url_polyfill_source ||= File.read(URL_POLYFILL_PATH)
+    rescue Errno::ENOENT
+      raise "URL polyfill not found at #{URL_POLYFILL_PATH}. Run `npm install && npm run build`."
+    end
 
     class ConditionalFollowRedirects < Faraday::FollowRedirects::Middleware
       def call(env)
@@ -65,6 +72,8 @@ module Agents
       Supported request options are `method` (default `"GET"`), `headers` (a plain object), `body` (a string), `timeout` (in seconds), and `redirect` (`"follow"` or `"manual"`, default `"follow"`).  Network errors throw a `TypeError`; HTTP error statuses do not — check `response.ok` as per the standard.  A default `User-Agent` header is sent when not overridden by the `headers` option.
 
       To issue multiple requests in parallel, use `Agent.fetchAll(requests, options)`.  Each request may be a URL string or a `[url, options]` pair mirroring the arguments of `Agent.fetch`.  The return value is an array of Response-like objects in the same order as the input.  As with `Agent.fetch`, any network error throws a `TypeError` for the whole batch, while individual HTTP error statuses are reported via each `response.ok`.  The optional second argument accepts `{ concurrency: 8 }` to cap the number of concurrent requests.
+
+      The WHATWG `URL` and `URLSearchParams` classes are also available as globals.
     MD
 
     form_configurable :code, type: :text, ace: { mode: 'javascript' }
@@ -161,6 +170,7 @@ module Agents
         pairs = pairs&.map { |(url, o)| [url, o.is_a?(Hash) ? o.deep_symbolize_keys : {}] }
         do_fetch_all(pairs, **opts&.deep_symbolize_keys)
       })
+      context.attach("doLoadUrlPolyfill", -> { context.eval(self.class.url_polyfill_source) })
 
       kvs = Agents::KeyValueStoreAgent.merge(controllers).find_each.to_h { |kvs|
         [kvs.options[:variable], kvs.memory.as_json]
@@ -284,7 +294,18 @@ module Agents
             throw new TypeError(result.error);
           }
           return buildResponse(result);
-        }
+        };
+
+        ['URL', 'URLSearchParams'].forEach(function(name) {
+          Object.defineProperty(globalThis, name, {
+            configurable: true,
+            get: function() {
+              ['URL', 'URLSearchParams'].forEach(function(n) { delete globalThis[n]; });
+              doLoadUrlPolyfill();
+              return globalThis[name];
+            }
+          });
+        });
 
         Agent.fetchAll = function(requests, options) {
           if (!Array.isArray(requests)) {

--- a/build/url-polyfill-entry.js
+++ b/build/url-polyfill-entry.js
@@ -1,0 +1,4 @@
+import { URL, URLSearchParams } from "whatwg-url-without-unicode";
+
+globalThis.URL = URL;
+globalThis.URLSearchParams = URLSearchParams;

--- a/lib/tasks/javascript_agent.rake
+++ b/lib/tasks/javascript_agent.rake
@@ -1,0 +1,10 @@
+namespace :javascript_agent do
+  desc "Bundle the whatwg-url polyfill used by JavaScriptAgent.fetch"
+  task :build_url_polyfill do
+    sh "npm run build"
+  end
+end
+
+%w[assets:precompile spec].each do |name|
+  Rake::Task[name].enhance(["javascript_agent:build_url_polyfill"]) if Rake::Task.task_defined?(name)
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "@fortawesome/fontawesome-free": "7.2.0",
-        "vanilla-jsoneditor": "^3.12.0"
+        "esbuild": "^0.25.0",
+        "vanilla-jsoneditor": "^3.12.0",
+        "whatwg-url-without-unicode": "^8.0.0-3"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -98,6 +100,422 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -345,6 +763,50 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -384,6 +846,47 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/esm-env": {
@@ -427,6 +930,26 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ],
       "license": "BSD-3-Clause"
@@ -536,6 +1059,15 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -626,6 +1158,29 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "7.2.0",
-    "vanilla-jsoneditor": "^3.12.0"
+    "esbuild": "^0.25.0",
+    "vanilla-jsoneditor": "^3.12.0",
+    "whatwg-url-without-unicode": "^8.0.0-3"
+  },
+  "scripts": {
+    "build": "esbuild --bundle --minify --format=iife --target=es2020 --outfile=tmp/build/url-polyfill.js build/url-polyfill-entry.js"
   }
 }

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -390,6 +390,61 @@ describe Agents::JavaScriptAgent do
     end
   end
 
+  describe "URL and URLSearchParams" do
+    it "exposes the WHATWG URL class" do
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var u = new URL("http://example.com/path?a=1");
+          this.createEvent({
+            href: u.href,
+            host: u.host,
+            pathname: u.pathname,
+            search: u.search,
+            a: u.searchParams.get("a")
+          });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({
+        'href' => 'http://example.com/path?a=1',
+        'host' => 'example.com',
+        'pathname' => '/path',
+        'search' => '?a=1',
+        'a' => '1'
+      })
+    end
+
+    it "resolves relative URLs against a base" do
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          this.createEvent({ url: new URL("/foo", "http://example.com/bar/").toString() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({ 'url' => 'http://example.com/foo' })
+    end
+
+    it "builds query strings with URLSearchParams" do
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var params = new URLSearchParams();
+          params.append("q", "hello world");
+          params.append("tag", "a");
+          params.append("tag", "b");
+          this.createEvent({ query: params.toString() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({ 'query' => 'q=hello+world&tag=a&tag=b' })
+    end
+  end
+
   describe "fetch" do
     it "performs a GET request and exposes the standard response fields" do
       stub_request(:get, "http://example.com/").to_return(

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -661,6 +661,25 @@ describe Agents::JavaScriptAgent do
         expect(@agent.events.last.payload).to eq({ 'name' => 'TypeError' })
       end
 
+      it "accepts URL objects" do
+        stub_request(:get, "http://example.com/a").to_return(status: 200, body: "A")
+        stub_request(:post, "http://example.com/b").to_return(status: 200, body: "B")
+
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            var results = this.fetchAll([
+              new URL("http://example.com/a"),
+              [new URL("http://example.com/b"), { method: "POST" }]
+            ]);
+            this.createEvent({ bodies: results.map(function(r) { return r.text(); }) });
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        expect(@agent.events.last.payload).to eq({ 'bodies' => ['A', 'B'] })
+      end
+
       it "rejects invalid urls before performing any request" do
         @agent.options['code'] = <<~JS
           Agent.check = function() {
@@ -676,6 +695,21 @@ describe Agents::JavaScriptAgent do
 
         expect(@agent.events.last.payload['message']).to match(/http and https/)
       end
+    end
+
+    it "accepts a URL object" do
+      stub_request(:get, "http://example.com/path?a=1").to_return(status: 200, body: "ok")
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch(new URL("http://example.com/path?a=1"));
+          this.createEvent({ status: res.status, body: res.text() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({ 'status' => 200, 'body' => 'ok' })
     end
 
     it "rejects non-http urls" do

--- a/spec/models/agents/java_script_agent_spec.rb
+++ b/spec/models/agents/java_script_agent_spec.rb
@@ -390,6 +390,256 @@ describe Agents::JavaScriptAgent do
     end
   end
 
+  describe "fetch" do
+    it "performs a GET request and exposes the standard response fields" do
+      stub_request(:get, "http://example.com/").to_return(
+        status: 200,
+        body: '{"hello":"world"}',
+        headers: { "Content-Type" => "application/json; charset=utf-8" }
+      )
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch("http://example.com/");
+          this.createEvent({
+            ok: res.ok,
+            status: res.status,
+            statusText: res.statusText,
+            url: res.url,
+            redirected: res.redirected,
+            contentType: res.headers.get("Content-Type"),
+            unknownHeader: res.headers.get("X-Missing"),
+            json: res.json()
+          });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      payload = @agent.events.last.payload
+      expect(payload['ok']).to eq(true)
+      expect(payload['status']).to eq(200)
+      expect(payload['statusText']).to eq("OK")
+      expect(payload['url']).to eq("http://example.com/")
+      expect(payload['redirected']).to eq(false)
+      expect(payload['contentType']).to eq("application/json; charset=utf-8")
+      expect(payload['unknownHeader']).to be_nil
+      expect(payload['json']).to eq({ 'hello' => 'world' })
+    end
+
+    it "sets ok to false for HTTP error statuses without throwing" do
+      stub_request(:get, "http://example.com/404").to_return(status: 404, body: "not found")
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch("http://example.com/404");
+          this.createEvent({ ok: res.ok, status: res.status, body: res.text() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({ 'ok' => false, 'status' => 404, 'body' => 'not found' })
+    end
+
+    it "sends the method, headers, and body" do
+      stub_request(:post, "http://example.com/submit")
+        .with(body: '{"x":1}', headers: { 'Content-Type' => 'application/json', 'X-Custom' => 'yes' })
+        .to_return(status: 201, body: "created")
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch("http://example.com/submit", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-Custom": "yes" },
+            body: JSON.stringify({ x: 1 })
+          });
+          this.createEvent({ status: res.status, body: res.text() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({ 'status' => 201, 'body' => 'created' })
+    end
+
+    it "follows redirects by default and reports the final url" do
+      stub_request(:get, "http://example.com/start").to_return(
+        status: 302, headers: { "Location" => "http://example.com/end" }
+      )
+      stub_request(:get, "http://example.com/end").to_return(status: 200, body: "done")
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch("http://example.com/start");
+          this.createEvent({ url: res.url, redirected: res.redirected, body: res.text() });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({
+        'url' => 'http://example.com/end',
+        'redirected' => true,
+        'body' => 'done'
+      })
+    end
+
+    it "does not follow redirects when redirect is manual" do
+      stub_request(:get, "http://example.com/start").to_return(
+        status: 302, headers: { "Location" => "http://example.com/end" }
+      )
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          var res = this.fetch("http://example.com/start", { redirect: "manual" });
+          this.createEvent({ status: res.status, location: res.headers.get("Location") });
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload).to eq({
+        'status' => 302,
+        'location' => 'http://example.com/end'
+      })
+    end
+
+    it "throws a TypeError on connection failures" do
+      stub_request(:get, "http://example.com/").to_raise(Faraday::ConnectionFailed.new("boom"))
+
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          try {
+            this.fetch("http://example.com/");
+          } catch (e) {
+            this.createEvent({ name: e.name, message: e.message });
+          }
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      payload = @agent.events.last.payload
+      expect(payload['name']).to eq('TypeError')
+      expect(payload['message']).to match(/Connection failed/)
+    end
+
+    describe "fetchAll" do
+      it "performs multiple requests in parallel and preserves order" do
+        stub_request(:get, "http://example.com/a").to_return(status: 200, body: "A")
+        stub_request(:get, "http://example.com/b").to_return(status: 201, body: "B")
+        stub_request(:post, "http://example.com/c").with(body: "payload").to_return(status: 200, body: "C")
+
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            var results = this.fetchAll([
+              "http://example.com/a",
+              ["http://example.com/b"],
+              ["http://example.com/c", { method: "POST", body: "payload" }]
+            ]);
+            this.createEvent({
+              statuses: results.map(function(r) { return r.status; }),
+              bodies: results.map(function(r) { return r.text(); })
+            });
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        expect(@agent.events.last.payload).to eq({
+          'statuses' => [200, 201, 200],
+          'bodies' => ['A', 'B', 'C']
+        })
+      end
+
+      it "does not throw on HTTP error statuses" do
+        stub_request(:get, "http://example.com/ok").to_return(status: 200, body: "ok")
+        stub_request(:get, "http://example.com/missing").to_return(status: 404, body: "nope")
+
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            var results = this.fetchAll(["http://example.com/ok", "http://example.com/missing"]);
+            this.createEvent({ oks: results.map(function(r) { return r.ok; }) });
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        expect(@agent.events.last.payload).to eq({ 'oks' => [true, false] })
+      end
+
+      it "throws a TypeError when any request fails with a network error" do
+        stub_request(:get, "http://example.com/ok").to_return(status: 200, body: "ok")
+        stub_request(:get, "http://example.com/dead").to_raise(Faraday::ConnectionFailed.new("boom"))
+
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            try {
+              this.fetchAll(["http://example.com/ok", "http://example.com/dead"]);
+            } catch (e) {
+              this.createEvent({ name: e.name, message: e.message });
+            }
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        payload = @agent.events.last.payload
+        expect(payload['name']).to eq('TypeError')
+        expect(payload['message']).to match(/Connection failed/)
+      end
+
+      it "throws a TypeError when given a non-array" do
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            try {
+              this.fetchAll("not an array");
+            } catch (e) {
+              this.createEvent({ name: e.name });
+            }
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        expect(@agent.events.last.payload).to eq({ 'name' => 'TypeError' })
+      end
+
+      it "rejects invalid urls before performing any request" do
+        @agent.options['code'] = <<~JS
+          Agent.check = function() {
+            try {
+              this.fetchAll(["http://example.com/", "file:///etc/passwd"]);
+            } catch (e) {
+              this.createEvent({ message: e.message });
+            }
+          };
+        JS
+        @agent.save!
+        @agent.check
+
+        expect(@agent.events.last.payload['message']).to match(/http and https/)
+      end
+    end
+
+    it "rejects non-http urls" do
+      @agent.options['code'] = <<~JS
+        Agent.check = function() {
+          try {
+            this.fetch("file:///etc/passwd");
+          } catch (e) {
+            this.createEvent({ message: e.message });
+          }
+        };
+      JS
+      @agent.save!
+      @agent.check
+
+      expect(@agent.events.last.payload['message']).to match(/http and https/)
+    end
+  end
+
   describe "KVS" do
     before do
       Agents::KeyValueStoreAgent.create!(


### PR DESCRIPTION
- `Agent.fetch` is a synchronous subset of the Web fetch API, accompanied by `Agent.fetchAll` for making multiple requests in parallel.
- The WHATWG `URL` and `URLSearchParams` classes are provided via whatwg-url-without-unicode, loaded lazily on first reference.  Support for internationalized domain names is omitted; host names must be ASCII.