### PR TITLE
Track Ruby in CI and docs with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,56 @@
     enabled: true,
     schedule: ["after 9am and before 1pm on Friday"],
   },
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Update Ruby versions in CI and manual install docs",
+      managerFilePatterns: [
+        "/(^|/)\\.github/workflows/ci\\.yml$/",
+        "/(^|/)doc/manual/(installation|update)\\.md$/",
+      ],
+      matchStrings: [
+        "ruby:\\n\\s+- \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "Ruby (?<currentValue>\\d+\\.\\d+\\.\\d+) installed",
+        "cd ruby-(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+      ],
+      depNameTemplate: "ruby",
+      datasourceTemplate: "ruby-version",
+    },
+    {
+      customType: "regex",
+      description: "Update Ruby source archive URLs in manual install docs",
+      managerFilePatterns: ["/(^|/)doc/manual/(installation|update)\\.md$/"],
+      matchStrings: [
+        "https://cache\\.ruby-lang\\.org/pub/ruby/\\d+\\.\\d+/ruby-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.xz",
+      ],
+      depNameTemplate: "ruby",
+      datasourceTemplate: "ruby-version",
+      autoReplaceStringTemplate: "https://cache.ruby-lang.org/pub/ruby/{{{newMajor}}}.{{{newMinor}}}/ruby-{{{newValue}}}.tar.xz",
+    },
+    {
+      customType: "regex",
+      description: "Update Ruby versions in Docker base images",
+      managerFilePatterns: ["/(^|/)docker/(multi|single)-process/Dockerfile$/"],
+      matchStrings: [
+        "FROM rubylang/ruby:(?<currentValue>\\d+\\.\\d+\\.\\d+)-(?<compatibility>\\S+)",
+      ],
+      depNameTemplate: "ruby",
+      datasourceTemplate: "ruby-version",
+      autoReplaceStringTemplate: "FROM rubylang/ruby:{{{newValue}}}-{{{compatibility}}}",
+    },
+  ],
   packageRules: [
+    {
+      groupName: "Ruby",
+      matchDatasources: ["ruby-version"],
+      matchPackageNames: ["ruby"],
+    },
+    {
+      matchDatasources: ["docker"],
+      matchPackageNames: ["rubylang/ruby"],
+      enabled: false,
+    },
     {
       groupName: "patch updated gems",
       matchDatasources: ["rubygems"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - enabled
           - disabled
         ruby:
-          - "3.4"
+          - "3.4.9"
     env:
       DATABASE_ADAPTER: ${{ matrix.database_adapter }}
       DATABASE_HOST: "127.0.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -901,7 +901,7 @@ DEPENDENCIES
   xmpp4r
 
 RUBY VERSION
-  ruby 3.4.8
+  ruby 3.4.9
 
 BUNDLED WITH
   4.0.8

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -72,8 +72,8 @@ Remove the old Ruby versions if present:
 Download Ruby and compile it:
 
     mkdir /tmp/ruby && cd /tmp/ruby
-    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.8.tar.xz | tar xJ
-    cd ruby-3.4.8
+    curl -L --progress-bar https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.9.tar.xz | tar xJ
+    cd ruby-3.4.9
     ./configure --disable-install-rdoc
     make -j`nproc`
     sudo make install

--- a/doc/manual/update.md
+++ b/doc/manual/update.md
@@ -52,7 +52,7 @@ sudo -u huginn -H cp Procfile.bak Procfile
 
 ### 4. Update ruby version
 
-Ensure you have Ruby 3.4 installed:
+Ensure you have Ruby 3.4.9 installed:
 
 ```
 ruby -v
@@ -62,8 +62,8 @@ Upgrade when required:
 
 ```
 mkdir /tmp/ruby && cd /tmp/ruby
-curl -L --progress https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.8.tar.xz | tar xJ
-cd ruby-3.4.8
+curl -L --progress https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.9.tar.xz | tar xJ
+cd ruby-3.4.9
 ./configure --disable-install-rdoc
 make -j`nproc`
 sudo make install

--- a/docker/multi-process/Dockerfile
+++ b/docker/multi-process/Dockerfile
@@ -1,4 +1,4 @@
-FROM rubylang/ruby:3.4-jammy
+FROM rubylang/ruby:3.4.9-jammy
 
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare

--- a/docker/single-process/Dockerfile
+++ b/docker/single-process/Dockerfile
@@ -1,4 +1,4 @@
-FROM rubylang/ruby:3.4-jammy
+FROM rubylang/ruby:3.4.9-jammy
 
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare


### PR DESCRIPTION
- Add regex managers for Ruby versions in CI and manual install docs
- Keep Ruby source archive URLs aligned across minor and major updates