### PR TITLE
add mention of MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you just want to play around, you can simply fork this repository, then perfo
 
 * Run `git remote add upstream https://github.com/huginn/huginn.git` to add the main repository as a remote for your fork.
 * Copy `.env.example` to `.env` (`cp .env.example .env`) and edit `.env`, at least updating the `APP_SECRET_TOKEN` variable.
-* Make sure that you have MySQL or PostgreSQL installed. (On a Mac, the easiest way is with [Homebrew](http://brew.sh/). If you're going to use PostgreSQL, you'll need to prepend all commands below with `DATABASE_ADAPTER=postgresql`.)
+* Make sure that you have MariaDB, MySQL or PostgreSQL installed. (On a Mac, the easiest way is with [Homebrew](http://brew.sh/). If you're going to use PostgreSQL, you'll need to prepend all commands below with `DATABASE_ADAPTER=postgresql`.)
 * Run `bundle` to install dependencies
 * Run `bundle exec rake db:create`, `bundle exec rake db:migrate`, and then `bundle exec rake db:seed` to create a development database with some example Agents.
 * Run `bundle exec foreman start`, visit [http://localhost:3000/][localhost], and login with the username of `admin` and the password of `password`.

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -96,7 +96,9 @@ Create a user for Huginn:
 
 ## 5. Database
 
-### MySQL / MariaDB
+### MariaDB / MySQL
+
+Huginn’s `mysql2` gem works with MariaDB as well as MySQL. On Debian/Ubuntu, if you use MariaDB instead of MySQL, install `mariadb-server`, `mariadb-client`, and `libmariadb-dev` (or `default-libmysqlclient-dev`, which satisfies the same build dependency in many releases). The `mysql` CLI, `mysql_secure_installation`, and SQL examples below are the same.
 
 Install the database packages
 


### PR DESCRIPTION
## What

Small docs update to make MariaDB support visible. No code changes.

## Why

The installation manual already has a heading `### MySQL / MariaDB` at
`doc/manual/installation.md:99`, but the instructions underneath are
MySQL-only, and the README's prerequisites mention only MySQL. The
`mysql2` gem used by Huginn works with MariaDB in practice.

This PR closes the gap by:

1. Mentioning MariaDB in the README's prerequisites line
2. Adding a short note under the existing MariaDB/MySQL heading with the
   equivalent MariaDB package names for Debian/Ubuntu

The remaining MySQL commands (`mysql_secure_installation`, the `mysql`
CLI, etc.) work identically on MariaDB, so they're left unchanged.

## Changes

- `README.md`: "MySQL or PostgreSQL" → "MariaDB, MySQL or PostgreSQL"
- `doc/manual/installation.md`: short MariaDB package note added under
  the existing heading