### PR TITLE
Refresh Threads tokens before expiry

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,8 @@
 class Service < ActiveRecord::Base
   include JsonSerializedField
 
+  THREADS_REFRESH_WINDOW = 7.days
+
   json_serialize :options
 
   belongs_to :user, inverse_of: :services
@@ -28,7 +30,7 @@ class Service < ActiveRecord::Base
   end
 
   def prepare_request
-    if expires_at && Time.now > expires_at
+    if token_refresh_due?
       refresh_token!
     end
   end
@@ -58,8 +60,29 @@ class Service < ActiveRecord::Base
         self.class.oauth_connection.post(endpoint.to_s, refresh_token_parameters)
       end
     data = response.body
-    update(expires_at: Time.current + data['expires_in'].to_i, token: data['access_token'],
-           refresh_token: data['refresh_token'].presence || refresh_token)
+    unless response.success? && data["access_token"].present?
+      raise refresh_token_error(response)
+    end
+
+    update!(expires_at: Time.current + data["expires_in"].to_i, token: data["access_token"],
+            refresh_token: data["refresh_token"].presence || refresh_token)
+  end
+
+  def token_refresh_due?
+    return false unless expires_at
+
+    if provider == "threads"
+      Time.current > expires_at - THREADS_REFRESH_WINDOW
+    else
+      Time.current > expires_at
+    end
+  end
+
+  def refresh_token_error(response)
+    message = response.body.dig("error", "message") if response.body.respond_to?(:dig)
+    message ||= response.body.to_s
+
+    "Unable to refresh #{provider} access token: #{message}"
   end
 
   def endpoint
@@ -203,6 +226,10 @@ class Service < ActiveRecord::Base
       if response.success? && data['access_token'].present?
         credentials[:token] = data['access_token']
         credentials[:expires_at] = Time.current + data['expires_in'].to_i
+      else
+        message = data.dig("error", "message") if data.respond_to?(:dig)
+        message ||= data.to_s
+        raise "Unable to exchange Threads access token: #{message}"
       end
     end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -57,6 +57,19 @@ describe Service do
       expect(@service.prepare_request).to eq(nil)
     end
 
+    it "should not update a Threads token outside the refresh window" do
+      @service.provider = "threads"
+      @service.expires_at = Time.current + Service::THREADS_REFRESH_WINDOW + 1.day
+      expect(@service.prepare_request).to eq(nil)
+    end
+
+    it "should update a Threads token inside the refresh window" do
+      allow(@service).to receive(:refresh_token!) { @service }
+      @service.provider = "threads"
+      @service.expires_at = Time.current + Service::THREADS_REFRESH_WINDOW - 1.day
+      expect(@service.prepare_request).to eq(@service)
+    end
+
     it "should call refresh_token! if the token expired" do
       allow(@service).to receive(:refresh_token!) { @service }
       @service.expires_at = Time.now - 1.hour
@@ -143,6 +156,31 @@ describe Service do
       expect(@service.refresh_token).to eq("new-raindrop-refresh-token")
       expect(@service.expires_at).to be > Time.current
     end
+
+    it "raises the provider error when refreshing a token fails" do
+      stub_request(:get, "https://graph.threads.net/refresh_access_token")
+        .with(query: {
+          "grant_type" => "th_refresh_token",
+          "access_token" => "expired-token"
+        })
+        .to_return(
+          status: 400,
+          body: {
+            error: {
+              message: "Session has expired",
+              type: "OAuthException"
+            }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      @service.provider = "threads"
+      @service.token = "expired-token"
+
+      expect {
+        @service.refresh_token!
+      }.to raise_error(RuntimeError, "Unable to refresh threads access token: Session has expired")
+    end
   end
 
   describe "creating services via omniauth" do
@@ -222,6 +260,31 @@ describe Service do
       expect(service.refresh_token).to eq("raindrop-refresh-token")
       expect(service.options[:user_id]).to eq(456)
       expect(service.options[:email]).to eq("raindrop@example.com")
+    end
+
+    it "raises the provider error when exchanging a Threads token fails" do
+      stub_request(:get, "https://graph.threads.net/access_token")
+        .with(query: {
+          "grant_type" => "th_exchange_token",
+          "client_secret" => "threadsappsecret",
+          "access_token" => "short-lived-threads-token"
+        })
+        .to_return(
+          status: 400,
+          body: {
+            error: {
+              message: "Invalid OAuth 2.0 Access Token",
+              type: "OAuthException"
+            }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      threads = JSON.parse(File.read(Rails.root.join("spec/data_fixtures/services/threads.json")))
+
+      expect {
+        @user.services.initialize_or_update_via_omniauth(threads)
+      }.to raise_error(RuntimeError, "Unable to exchange Threads access token: Invalid OAuth 2.0 Access Token")
     end
   end
 


### PR DESCRIPTION
Threads long-lived access tokens must be refreshed before they expire.  Once Meta considers the session expired, the refresh endpoint returns an OAuth error and the user has to reauthorize the service.

Refresh Threads services during request preparation when the token is within seven days of expiry, while leaving other providers on the existing expired token path.  Also raise provider refresh errors instead of silently ignoring a failed token update.

Require the initial Threads token exchange to succeed as well, so a short-lived OAuth token is not saved as if it were refreshable long-lived credentials.