### PR TITLE
Add signed file pointer validation

### DIFF
--- a/app/concerns/file_handling.rb
+++ b/app/concerns/file_handling.rb
@@ -2,7 +2,7 @@ module FileHandling
   extend ActiveSupport::Concern
 
   def get_file_pointer(file)
-    { file_pointer: { file: file, agent_id: id } }
+    { file_pointer: signed_file_pointer(file:, agent_id: id) }
   end
 
   def has_file_pointer?(event)
@@ -13,11 +13,28 @@ module FileHandling
 
   def get_io(event)
     return nil unless has_file_pointer?(event)
-    event.user.agents.find(event.payload['file_pointer']['agent_id']).get_io(event.payload['file_pointer']['file'])
+
+    file_pointer = event.payload['file_pointer']
+    return nil if require_signed_file_pointer? && !valid_file_pointer_signature?(file_pointer)
+
+    event.user.agents.find(file_pointer['agent_id']).get_io(file_pointer['file'])
   end
 
   def get_upload_io(event)
-    Faraday::UploadIO.new(get_io(event), MIME::Types.type_for(File.basename(event.payload['file_pointer']['file'])).first.try(:content_type))
+    io = get_io(event) or return
+
+    Faraday::UploadIO.new(
+      io,
+      MIME::Types.type_for(File.basename(event.payload['file_pointer']['file'])).first.try(:content_type)
+    )
+  end
+
+  def validate_require_signed_file_pointer_options!
+    return unless option_provided?(options['require_signed_file_pointer'])
+
+    if boolify(options['require_signed_file_pointer']).nil?
+      errors.add(:base, "if provided, require_signed_file_pointer must be a boolean value")
+    end
   end
 
   def emitting_file_handling_agent_description
@@ -27,10 +44,45 @@ module FileHandling
 
   def receiving_file_handling_agent_description
     @receiving_file_handling_agent_description ||=
-      "This agent can consume a 'file pointer' event from the following agents with no additional configuration: `#{emitting_file_handling_agents.join('`, `')}`. Read more about the concept in the [wiki](https://github.com/huginn/huginn/wiki/How-Huginn-works-with-files)."
+      "This agent can consume a 'file pointer' event from the following agents with no additional configuration: `#{emitting_file_handling_agents.join('`, `')}`. Set `require_signed_file_pointer` to `true` to treat file pointers that were not signed by a file-handling agent as invalid. Read more about the concept in the [wiki](https://github.com/huginn/huginn/wiki/How-Huginn-works-with-files)."
   end
 
   private
+
+  def signed_file_pointer(**pointer)
+    pointer.merge(signature: sign_file_pointer(pointer))
+  end
+
+  def sign_file_pointer(pointer)
+    file_pointer_verifier.generate(file_pointer_signature_payload(pointer))
+  end
+
+  def valid_file_pointer_signature?(pointer)
+    signature = pointer['signature'].presence or return false
+
+    begin
+      file_pointer_verifier.verify(signature) == file_pointer_signature_payload(pointer)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      false
+    end
+  end
+
+  def file_pointer_signature_payload(pointer)
+    pointer.with_indifferent_access.slice('agent_id', 'file')
+  end
+
+  def file_pointer_verifier
+    ActiveSupport::MessageVerifier.new(
+      Rails.application.secret_key_base,
+      digest: 'SHA256',
+      serializer: JSON,
+      url_safe: true
+    )
+  end
+
+  def require_signed_file_pointer?
+    boolify(options['require_signed_file_pointer'])
+  end
 
   def emitting_file_handling_agents
     emitting_file_handling_agents = file_handling_agents.select { |a| a.emits_file_pointer? }

--- a/app/models/agents/csv_agent.rb
+++ b/app/models/agents/csv_agent.rb
@@ -16,7 +16,8 @@ module Agents
         'output' => 'event_per_row',
         'with_header' => true,
         'data_path' => '$.data',
-        'data_key' => 'data'
+        'data_key' => 'data',
+        'require_signed_file_pointer' => true
       }
     end
 
@@ -94,6 +95,7 @@ module Agents
     form_configurable :use_fields, type: :string
     form_configurable :output, type: :array, values: %w[event_per_row event_per_file]
     form_configurable :data_path, type: :string
+    form_configurable :require_signed_file_pointer, type: :boolean
 
     def validate_options
       if !option_provided?(options['with_header']) || ![true, false].include?(boolify(options['with_header']))
@@ -102,6 +104,7 @@ module Agents
       if options['mode'] == 'serialize' && options['data_path'].blank?
         errors.add(:base, "When mode is set to serialize data_path has to be present.")
       end
+      validate_require_signed_file_pointer_options!
     end
 
     def working?
@@ -161,7 +164,7 @@ module Agents
     def parse(incoming_events)
       incoming_events.each do |event|
         mo = interpolated(event)
-        next unless io = local_get_io(event)
+        io = local_get_io(event) or next
 
         if mo['output'] == 'event_per_row'
           parse_csv(io, mo) do |payload|
@@ -174,11 +177,8 @@ module Agents
     end
 
     def local_get_io(event)
-      if io = get_io(event)
-        io
-      else
+      get_io(event) or
         Utils.value_at(event.payload, interpolated['data_path'])
-      end
     end
 
     def parse_csv_options(mo)

--- a/app/models/agents/openai_speech_agent.rb
+++ b/app/models/agents/openai_speech_agent.rb
@@ -78,7 +78,8 @@ module Agents
         'language' => '',
         'output_mode' => 'clean',
         'request_timeout' => '60',
-        'expected_receive_period_in_days' => '1'
+        'expected_receive_period_in_days' => '1',
+        'require_signed_file_pointer' => true
       }
     end
 
@@ -113,6 +114,7 @@ module Agents
         errors.add(:base, "input_text is required for speak mode") unless options['input_text'].present?
         errors.add(:base, "voice is required for speak mode") unless options['voice'].present?
       end
+      validate_require_signed_file_pointer_options!
     end
 
     def receive(incoming_events)

--- a/app/models/agents/post_agent.rb
+++ b/app/models/agents/post_agent.rb
@@ -84,7 +84,8 @@ module Agents
         'emit_events' => false,
         'parse_body' => true,
         'no_merge' => true,
-        'output_mode' => 'clean'
+        'output_mode' => 'clean',
+        'require_signed_file_pointer' => true
       }
     end
 
@@ -153,6 +154,7 @@ module Agents
         errors.add(:base, "if provided, headers must be a hash")
       end
 
+      validate_require_signed_file_pointer_options!
       validate_web_request_options!
     end
 
@@ -188,10 +190,11 @@ module Agents
         body = nil
       when 'post', 'put', 'patch'
         params = nil
+        upload_io = get_upload_io(event) if has_file_pointer?(event)
 
         content_type =
-          if has_file_pointer?(event)
-            data[interpolated(event.payload)['upload_key'].presence || 'file'] = get_upload_io(event)
+          if upload_io
+            data[interpolated(event.payload)['upload_key'].presence || 'file'] = upload_io
             nil
           else
             interpolated(event.payload)['content_type']

--- a/app/models/agents/read_file_agent.rb
+++ b/app/models/agents/read_file_agent.rb
@@ -8,7 +8,8 @@ module Agents
 
     def default_options
       {
-        'data_key' => 'data'
+        'data_key' => 'data',
+        'require_signed_file_pointer' => true
       }
     end
 
@@ -31,11 +32,13 @@ module Agents
     MD
 
     form_configurable :data_key, type: :string
+    form_configurable :require_signed_file_pointer, type: :boolean
 
     def validate_options
       if options['data_key'].blank?
         errors.add(:base, "The 'data_key' options is required.")
       end
+      validate_require_signed_file_pointer_options!
     end
 
     def working?
@@ -44,7 +47,7 @@ module Agents
 
     def receive(incoming_events)
       incoming_events.each do |event|
-        next unless io = get_io(event)
+        io = get_io(event) or next
 
         create_event payload: { interpolated['data_key'] => io.read }
       end

--- a/spec/models/agents/ftpsite_agent_spec.rb
+++ b/spec/models/agents/ftpsite_agent_spec.rb
@@ -103,14 +103,14 @@ describe Agents::FtpsiteAgent do
           ])
         }
 
-        expect(Event.last(2).first.payload).to eq({
-          'file_pointer' => { 'file' => 'example-1.1.tar.gz', 'agent_id' => @checker.id },
+        expect_file_pointer_event(Event.last(2).first, {
+          'file' => 'example-1.1.tar.gz',
           'url' => 'ftp://ftp.example.org/pub/releases/example-1.1.tar.gz',
           'filename' => 'example-1.1.tar.gz',
           'timestamp' => '2014-04-01T10:00:00Z',
         })
 
-        expect { @checker.check }.not_to change { Event.count }
+        expect { @checker.check }.not_to(change { Event.count })
 
         allow(@checker).to receive(:each_entry) { |&block|
           block.call("example latest.tar.gz", Time.parse("2014-04-02T10:00:01Z"))
@@ -133,21 +133,21 @@ describe Agents::FtpsiteAgent do
           ])
         }
 
-        expect(Event.last(2).first.payload).to eq({
-          'file_pointer' => { 'file' => 'example-1.2.tar.gz', 'agent_id' => @checker.id },
+        expect_file_pointer_event(Event.last(2).first, {
+          'file' => 'example-1.2.tar.gz',
           'url' => 'ftp://ftp.example.org/pub/releases/example-1.2.tar.gz',
           'filename' => 'example-1.2.tar.gz',
           'timestamp' => '2014-04-02T10:00:00Z',
         })
 
-        expect(Event.last.payload).to eq({
-          'file_pointer' => { 'file' => 'example latest.tar.gz', 'agent_id' => @checker.id },
+        expect_file_pointer_event(Event.last, {
+          'file' => 'example latest.tar.gz',
           'url' => 'ftp://ftp.example.org/pub/releases/example%20latest.tar.gz',
           'filename' => 'example latest.tar.gz',
           'timestamp' => '2014-04-02T10:00:01Z',
         })
 
-        expect { @checker.check }.not_to change { Event.count }
+        expect { @checker.check }.not_to(change { Event.count })
       end
     end
 
@@ -257,5 +257,14 @@ describe Agents::FtpsiteAgent do
         @checker.receive([event])
       end
     end
+  end
+
+  def expect_file_pointer_event(event, payload)
+    expect(event.payload).to include(payload.except('file'))
+    expect(event.payload['file_pointer']).to include(
+      'file' => payload['file'],
+      'agent_id' => @checker.id
+    )
+    expect(event.payload['file_pointer']['signature']).to be_present
   end
 end

--- a/spec/models/agents/post_agent_spec.rb
+++ b/spec/models/agents/post_agent_spec.rb
@@ -178,9 +178,27 @@ describe Agents::PostAgent do
         /\A--#{qboundary}\r\nContent-Disposition: form-data; name="default"\r\n\r\nvalue\r\n--#{qboundary}\r\nContent-Disposition: form-data; name="file"; filename="local.path"\r\nContent-Length: 8\r\nContent-Type: \r\nContent-Transfer-Encoding: binary\r\n\r\ntestdata\r\n--#{qboundary}--\r\n\z/ === request.body
       }.to_return(status: 200, body: "", headers: {})
       event = Event.new(payload: { file_pointer: { agent_id: 111, file: 'test' } })
-      io_mock = double
       expect(@checker).to receive(:get_io).with(event) { StringIO.new("testdata") }
       @checker.options['no_merge'] = true
+      @checker.receive([event])
+    end
+
+    it 'does not make a multipart request for an unsigned file_pointer when verification is enabled' do
+      WebMock.reset!
+      stub_request(:post, "http://www.example.com/")
+        .with(
+          body: "default=value",
+          headers: {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => 'Huginn - https://github.com/huginn/huginn'
+          }
+        )
+        .to_return(status: 200, body: "", headers: {})
+
+      @checker.options['require_signed_file_pointer'] = true
+      @checker.options['no_merge'] = true
+      event = Event.new(payload: { file_pointer: { agent_id: 111, file: 'test' } })
+
       @checker.receive([event])
     end
   end

--- a/spec/models/agents/read_file_agent_spec.rb
+++ b/spec/models/agents/read_file_agent_spec.rb
@@ -22,6 +22,11 @@ describe Agents::ReadFileAgent do
       @checker.options['data_key'] = ''
       expect(@checker).not_to be_valid
     end
+
+    it "requires require_signed_file_pointer to be a boolean value when provided" do
+      @checker.options['require_signed_file_pointer'] = 'sometimes'
+      expect(@checker).not_to be_valid
+    end
   end
 
   context '#working' do
@@ -38,10 +43,79 @@ describe Agents::ReadFileAgent do
   context '#receive' do
     it "emits an event with the contents of the receives files" do
       event = Event.new(payload: {file_pointer: {agent_id: 111, file: 'test'}})
-      io_mock = double()
       expect(@checker).to receive(:get_io).with(event) { StringIO.new("testdata") }
       expect { @checker.receive([event]) }.to change(Event, :count).by(1)
       expect(Event.last.payload).to eq('data' => 'testdata')
+    end
+
+    context "with file pointer signature verification" do
+      let(:file_path) { Rails.root.join('tmp', 'spec', 'signed-file-pointer.txt').to_s }
+      let(:other_file_path) { Rails.root.join('tmp', 'spec', 'forged-file-pointer.txt').to_s }
+
+      before do
+        FileUtils.mkdir_p File.dirname(file_path)
+        File.write(file_path, "signed data")
+        File.write(other_file_path, "forged data")
+        @file_agent = Agents::LocalFileAgent.create!(
+          name: "file source",
+          user: @checker.user,
+          options: {
+            'mode' => 'read',
+            'watch' => 'false',
+            'append' => 'false',
+            'path' => file_path
+          }
+        )
+      end
+
+      after do
+        FileUtils.rm_f(file_path)
+        FileUtils.rm_f(other_file_path)
+      end
+
+      it "reads a file pointer emitted by a file-handling agent" do
+        @checker.options['require_signed_file_pointer'] = true
+        event = Event.new(user: @checker.user, payload: signed_payload(file_path))
+
+        expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+        expect(Event.last.payload).to eq('data' => 'signed data')
+      end
+
+      it "ignores an unsigned file pointer when verification is enabled" do
+        @checker.options['require_signed_file_pointer'] = true
+        event = Event.new(user: @checker.user, payload: forged_payload(file_path))
+
+        expect { @checker.receive([event]) }.not_to change(Event, :count)
+      end
+
+      it "ignores a tampered file pointer when verification is enabled" do
+        @checker.options['require_signed_file_pointer'] = true
+        payload = signed_payload(file_path)
+        payload['file_pointer']['file'] = other_file_path
+        event = Event.new(user: @checker.user, payload: payload)
+
+        expect { @checker.receive([event]) }.not_to change(Event, :count)
+      end
+
+      it "keeps accepting unsigned file pointers when verification is not configured" do
+        event = Event.new(user: @checker.user, payload: forged_payload(file_path))
+
+        expect { @checker.receive([event]) }.to change(Event, :count).by(1)
+        expect(Event.last.payload).to eq('data' => 'signed data')
+      end
+
+      def signed_payload(file)
+        JSON.parse(@file_agent.get_file_pointer(file).to_json)
+      end
+
+      def forged_payload(file)
+        {
+          'file_pointer' => {
+            'agent_id' => @file_agent.id,
+            'file' => file
+          }
+        }
+      end
     end
   end
 end

--- a/spec/models/agents/s3_agent_spec.rb
+++ b/spec/models/agents/s3_agent_spec.rb
@@ -98,7 +98,7 @@ describe Agents::S3Agent do
       it "emits an event for every file" do
         expect(@checker).to receive(:get_bucket_contents) { {"test"=>"231232", "test2"=>"4564545"} }
         expect { @checker.check }.to change(Event, :count).by(2)
-        expect(Event.last.payload).to eq({"file_pointer" => {"file"=>"test2", "agent_id"=> @checker.id}})
+        expect_file_pointer_event("test2")
       end
     end
 
@@ -126,20 +126,20 @@ describe Agents::S3Agent do
           contents = {"test"=>"231232"}
           expect(@checker).to receive(:get_bucket_contents) { contents }
           expect { @checker.check }.to change(Event, :count).by(1)
-          expect(Event.last.payload).to eq({"file_pointer" => {"file" => "test2", "agent_id"=> @checker.id}, "event_type" => "removed"})
+          expect_file_pointer_event("test2", "removed")
         end
 
         it "emits events for modified files" do
           contents = {"test"=>"231232", "test2"=>"changed"}
           expect(@checker).to receive(:get_bucket_contents) { contents }
           expect { @checker.check }.to change(Event, :count).by(1)
-          expect(Event.last.payload).to eq({"file_pointer" => {"file" => "test2", "agent_id"=> @checker.id}, "event_type" => "modified"})
+          expect_file_pointer_event("test2", "modified")
         end
         it "emits events for added files" do
           contents = {"test"=>"231232", "test2"=>"4564545", "test3" => "31231231"}
           expect(@checker).to receive(:get_bucket_contents) { contents }
           expect { @checker.check }.to change(Event, :count).by(1)
-          expect(Event.last.payload).to eq({"file_pointer" => {"file" => "test3", "agent_id"=> @checker.id}, "event_type" => "added"})
+          expect_file_pointer_event("test3", "added")
         end
       end
 
@@ -226,5 +226,14 @@ describe Agents::S3Agent do
       event = Event.new(payload: {'data' => 'hello world!'})
       @checker.receive([event])
     end
+  end
+
+  def expect_file_pointer_event(file, event_type = nil)
+    expect(Event.last.payload["file_pointer"]).to include(
+      "file" => file,
+      "agent_id" => @checker.id
+    )
+    expect(Event.last.payload["file_pointer"]["signature"]).to be_present
+    expect(Event.last.payload["event_type"]).to eq(event_type) if event_type
   end
 end

--- a/spec/support/shared_examples/file_handling_consumer.rb
+++ b/spec/support/shared_examples/file_handling_consumer.rb
@@ -4,7 +4,10 @@ shared_examples_for 'FileHandlingConsumer' do
   let(:event) { Event.new(user: @checker.user, payload: {'file_pointer' => {'file' => 'text.txt', 'agent_id' => @checker.id}}) }
 
   it 'returns a file pointer' do
-    expect(@checker.get_file_pointer('testfile')).to eq(file_pointer: { file: "testfile", agent_id: @checker.id})
+    file_pointer = @checker.get_file_pointer('testfile')[:file_pointer]
+
+    expect(file_pointer).to include(file: "testfile", agent_id: @checker.id)
+    expect(file_pointer[:signature]).to be_present
   end
 
   it 'get_io raises an exception when trying to access an agent of a different user' do
@@ -26,7 +29,6 @@ shared_examples_for 'FileHandlingConsumer' do
   end
 
   it '#get_upload_io returns a Faraday::UploadIO instance' do
-    io_mock = double()
     expect(@checker).to receive(:get_io).with(event) { StringIO.new("testdata") }
 
     upload_io = @checker.get_upload_io(event)


### PR DESCRIPTION
Sign all file pointers emitted by FileHandling agents and add `require_signed_file_pointer` for consumers that need to reject forged pointers.

New default options require signed file pointers for `ReadFileAgent`, `CsvAgent`, `PostAgent`, and `OpenaiSpeechAgent`.  Existing agents without the option keep accepting legacy unsigned pointers, avoiding breakage for queued or retained events from older workflows.

This preserves compatibility while allowing file-consuming workflows to treat file pointers not signed by a file-handling agent as invalid.