### PR TITLE
i18n: add Korean (ko) translation

### DIFF
--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,0 +1,43 @@
+# 한국어(ko) 지역화 파일입니다. 이 디렉터리에 다른 로케일 파일을 추가할 수 있습니다.
+# 시작점으로 https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale 를 참고하세요.
+
+ko:
+  devise:
+    failure:
+      deactivated_account: "관리자에 의해 계정이 비활성화되었습니다."
+  datetime:
+    distance_in_words:
+      half_a_minute: "30초"
+      less_than_x_seconds:
+        one:   "<1초"
+        other: "<%{count}초"
+      x_seconds:
+        one:   "1초"
+        other: "%{count}초"
+      less_than_x_minutes:
+        one:   "<1분"
+        other: "<%{count}분"
+      x_minutes:
+        one:   "1분"
+        other: "%{count}분"
+      about_x_hours:
+        one:   "~1시간"
+        other: "~%{count}시간"
+      x_days:
+        one:   "1일"
+        other: "%{count}일"
+      about_x_months:
+        one:   "~1개월"
+        other: "~%{count}개월"
+      x_months:
+        one:   "1개월"
+        other: "%{count}개월"
+      about_x_years:
+        one:   "~1년"
+        other: "~%{count}년"
+      over_x_years:
+        one:   ">1년"
+        other: ">%{count}년"
+      almost_x_years:
+        one:   "~1년"
+        other: "~%{count}년"


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Added `config/locales/ko.yml` (new file, 24 leaf keys) covering `devise.failure.deactivated_account` and the full `datetime.distance_in_words` set (half_a_minute, less_than_x_seconds, x_seconds, less_than_x_minutes, x_minutes, about_x_hours, x_days, about_x_months, x_months, about_x_years, over_x_years, almost_x_years), matching `config/locales/en.yml`.

## Testing

- Verified full key parity with `en.yml` programmatically (loaded both YAML files, recursively diffed leaf-key paths — 24/24 keys match, no missing/extra keys).
- Confirmed `ko.yml` is valid YAML.
- Confirmed only the new locale file is touched — no other files changed.
