### PR TITLE
Improve Agent type picker search

### DIFF
--- a/app/assets/javascripts/pages/agent-edit-page.js
+++ b/app/assets/javascripts/pages/agent-edit-page.js
@@ -1,5 +1,34 @@
 (function () {
-  let formatAgentForSelect = undefined;
+  const matchAgent = (params, data) => {
+    const optionIndex = data.element?.index ?? Number.MAX_SAFE_INTEGER;
+    const term = params.term?.trim();
+    if (!term) return { ...data, sortKey: [optionIndex] };
+
+    const upperTerm = term.toUpperCase();
+    const namePosition = data.text.toUpperCase().indexOf(upperTerm);
+    if (namePosition >= 0) {
+      return { ...data, sortKey: [1, namePosition, optionIndex] };
+    }
+
+    const descriptionPosition = (data.title || "")
+      .toUpperCase()
+      .indexOf(upperTerm);
+    if (descriptionPosition >= 0) {
+      return { ...data, sortKey: [2, descriptionPosition, optionIndex] };
+    }
+
+    return null;
+  };
+
+  const sortAgents = (agents) =>
+    agents.sort((left, right) => {
+      for (let index = 0; index < left.sortKey.length; index += 1) {
+        const difference = left.sortKey[index] - right.sortKey[index];
+        if (difference !== 0) return difference;
+      }
+      return 0;
+    });
+
   const Cls = (this.AgentEditPage = class AgentEditPage {
     constructor() {
       this.invokeDryRun = this.invokeDryRun.bind(this);
@@ -73,21 +102,14 @@
             if (!agent.element || !agent.title) return agent.text;
 
             return [
-              ...$(document.createElement('strong')).text(agent.text),
-              document.createElement('br'),
+              ...$(document.createElement("strong")).text(agent.text),
+              document.createElement("br"),
               ...$.parseHTML(agent.title),
             ];
           },
-          matcher: (params, data) => {
-            const term = params.term;
-            if (term == null) return data;
-            const upperTerm = term.toUpperCase();
-            return data.text.toUpperCase().indexOf(upperTerm) >= 0 ||
-              data.title.toUpperCase().indexOf(upperTerm) >= 0
-              ? data
-              : null;
-          },
-        });
+          matcher: matchAgent,
+          sorter: sortAgents,
+        }).select2("open");
       } else {
         this.enableDryRunButton();
         this.buildAce();

--- a/spec/features/create_an_agent_spec.rb
+++ b/spec/features/create_an_agent_spec.rb
@@ -121,6 +121,35 @@ describe "Creating a new agent", js: true do
            }).to have_text("Sorry, there appears to be an error in your JSON input. Please fix it before continuing.")
   end
 
+  it "opens the Agent picker and prioritizes name matches" do
+    visit new_agent_path
+
+    expect(page).to have_css(".select2-container--open")
+
+    result_order = page.evaluate_script(<<~JS)
+      (() => {
+        const { matcher, sorter } = $("#agent_type").data("select2").options.options;
+        const agents = [
+          { text: "Alpha Agent", title: "find first", element: { index: 1 } },
+          { text: "A Find Agent", title: "", element: { index: 2 } },
+          { text: "Beta Agent", title: "later find", element: { index: 3 } },
+          { text: "Find Agent", title: "", element: { index: 4 } },
+        ];
+        const matches = agents
+          .map((agent) => matcher({ term: "find" }, agent))
+          .filter(Boolean);
+        return sorter(matches).map(({ text }) => text);
+      })()
+    JS
+
+    expect(result_order).to eq([
+      "Find Agent",
+      "A Find Agent",
+      "Alpha Agent",
+      "Beta Agent",
+    ])
+  end
+
   context "displaying the correct information" do
     before(:each) do
       visit new_agent_path

--- a/spec/features/java_script_agent_spec.rb
+++ b/spec/features/java_script_agent_spec.rb
@@ -22,7 +22,7 @@ describe "JavaScriptAgent", js: true do
 
   it "creates a JavaScriptAgent with code in the ace editor" do
     visit new_agent_path
-    select2("Java Script Agent", search: "Java Script Agent", from: "Type")
+    select_agent_type("Java Script Agent", editor: ".ace-editor")
     expect(page).to have_no_css("form.agent-form.type-changing")
     expect(page).to have_css(".ace-editor")
     fill_in(:agent_name, with: "My JS Agent")

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,5 +1,5 @@
 module FeatureHelpers
-  def select_agent_type(search)
+  def select_agent_type(search, editor: ".json-editor-shell")
     agent_name = search[/\A.*?Agent\b/] || search
     page.execute_script('$("#agent_type").select2("close")')
     select2(agent_name, search:, from: "Type")
@@ -7,7 +7,7 @@ module FeatureHelpers
     expect(page).to have_no_css("form.agent-form.type-changing")
 
     # Wait for all parts of the Agent form to load:
-    expect(page).to have_css(".json-editor-shell") # Options editor
+    expect(page).to have_css(editor) # Options editor
     expect(page).to have_css(".well.description > p") # Markdown description
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,6 +1,7 @@
 module FeatureHelpers
   def select_agent_type(search)
     agent_name = search[/\A.*?Agent\b/] || search
+    page.execute_script('$("#agent_type").select2("close")')
     select2(agent_name, search:, from: "Type")
 
     expect(page).to have_no_css("form.agent-form.type-changing")


### PR DESCRIPTION
Although searching also by the Agent's description (#830) was a great addition, it has made it difficult to identify an Agent by typing just a few letters, because Agent descriptions contain many words that may accidentally match the query, and matched Agents are listed in their original order.

To solve this problem, this PR introduces scoring and sorting of matched items using Select2's matcher.  Agents with the keyword in their names are listed first, followed by those with the keyword in their descriptions.  Within each group, Agents are sorted by the position of the match.  This makes it easy to pick an Agent whose name is already known while retaining the ability to search by description.

The Agent picker is also opened on page load because native autofocus does not reach Select2.

The Select2 4 upgrade and the necessary FormConfigurable adaptation were completed separately in 2023, resolving the compatibility issue that left #1802 unfinished.

Supersedes & Closes #1802
