### PR TITLE
Fix duplicate events in RaindropBookmarksAgent

### DIFF
--- a/app/models/agents/raindrop_bookmarks_agent.rb
+++ b/app/models/agents/raindrop_bookmarks_agent.rb
@@ -66,33 +66,34 @@ module Agents
 
     def check
       raindrops = fetch_raindrops
-      latest_created_at = nil
-      latest_ids = Set.new
 
-      sorted_raindrops = raindrops.sort_by do |raindrop|
+      sorted_raindrops = raindrops.sort_by { |raindrop|
         [parse_timestamp(raindrop[:created]) || Time.at(0), raindrop[:_id].to_s]
-      end
+      }
+
+      latest_created_at = parse_timestamp(memory["since"])
+      latest_ids = since_ids
 
       sorted_raindrops.each do |raindrop|
         created_at = parse_timestamp(raindrop[:created])
         next unless created_at
-        next if already_seen?(raindrop, created_at)
 
-        create_event payload: raindrop
+        id = raindrop[:_id].to_s
+        seen = latest_ids.include?(id) || (latest_created_at && created_at < latest_created_at)
 
-        case
-        when latest_created_at.nil? || created_at > latest_created_at
+        if latest_created_at.nil? || created_at > latest_created_at
           latest_created_at = created_at
-          latest_ids.clear
-          latest_ids.add(raindrop[:_id].to_s)
-        when created_at == latest_created_at
-          latest_ids.add(raindrop[:_id].to_s)
+          latest_ids = Set[id]
+        elsif created_at == latest_created_at
+          latest_ids.add(id)
         end
+
+        create_event payload: raindrop unless seen
       end
 
       return unless latest_created_at
 
-      memory["since"] = latest_created_at.iso8601
+      memory["since"] = latest_created_at.iso8601(3)
       memory["since_ids"] = latest_ids.to_a
       save!
     end
@@ -113,14 +114,6 @@ module Agents
       interpolated["limit"].presence || default_options["limit"]
     end
 
-    def already_seen?(raindrop, created_at)
-      since = parse_timestamp(memory["since"])
-      return false unless since
-      return true if created_at < since
-
-      created_at == since && since_ids.include?(raindrop[:_id].to_s)
-    end
-
     def parse_timestamp(value)
       Time.zone.parse(value) if value.present?
     rescue StandardError
@@ -128,7 +121,7 @@ module Agents
     end
 
     def since_ids
-      @since_ids ||= Set.new(Array(memory["since_ids"]))
+      Set.new(Array(memory["since_ids"]))
     end
   end
 end

--- a/spec/models/agents/raindrop_bookmarks_agent_spec.rb
+++ b/spec/models/agents/raindrop_bookmarks_agent_spec.rb
@@ -18,25 +18,41 @@ describe Agents::RaindropBookmarksAgent do
     @agent.save!
   end
 
+  def stub_raindrops(body = File.read(Rails.root.join("spec/data_fixtures/raindrop_raindrops.json")))
+    stub_request(:get, "https://api.raindrop.io/rest/v1/raindrops/0")
+      .with(
+        query: {
+          "page" => "0",
+          "perpage" => "50",
+          "sort" => "-created",
+          "nested" => "false",
+        },
+        headers: {
+          "Authorization" => "Bearer raindrop-access-token",
+        }
+      )
+      .to_return(
+        status: 200,
+        body:,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def raindrop_item(id, created)
+    {
+      _id: id,
+      link: "https://example.com/#{id}",
+      title: "Example #{id}",
+      created:,
+      lastUpdate: created,
+      collection: { "$id": 0 },
+      tags: [],
+    }
+  end
+
   describe "#check" do
     it "creates events for raindrops returned by the Raindrop API" do
-      stub_request(:get, "https://api.raindrop.io/rest/v1/raindrops/0")
-        .with(
-          query: {
-            "page" => "0",
-            "perpage" => "50",
-            "sort" => "-created",
-            "nested" => "false",
-          },
-          headers: {
-            "Authorization" => "Bearer raindrop-access-token",
-          }
-        )
-        .to_return(
-          status: 200,
-          body: File.read(Rails.root.join("spec/data_fixtures/raindrop_raindrops.json")),
-          headers: { "Content-Type" => "application/json" }
-        )
+      stub_raindrops
 
       expect { @agent.check }.to change { Event.count }.by(2)
 
@@ -50,25 +66,43 @@ describe Agents::RaindropBookmarksAgent do
       @agent.memory["since"] = "2024-01-02T12:00:00+00:00"
       @agent.memory["since_ids"] = ["1002"]
 
-      stub_request(:get, "https://api.raindrop.io/rest/v1/raindrops/0")
-        .with(
-          query: {
-            "page" => "0",
-            "perpage" => "50",
-            "sort" => "-created",
-            "nested" => "false",
-          },
-          headers: {
-            "Authorization" => "Bearer raindrop-access-token",
-          }
-        )
-        .to_return(
-          status: 200,
-          body: File.read(Rails.root.join("spec/data_fixtures/raindrop_raindrops.json")),
-          headers: { "Content-Type" => "application/json" }
-        )
+      stub_raindrops
 
       expect { @agent.check }.not_to(change { Event.count })
+    end
+
+    it "does not emit duplicates across runs when created timestamps have fractional seconds" do
+      stub_raindrops({
+        result: true,
+        items: [raindrop_item(1003, "2024-01-03T12:00:00.500Z")],
+      }.to_json)
+
+      expect { @agent.check }.to change { Event.count }.by(1)
+      expect(Time.zone.parse(@agent.memory["since"])).to eq(Time.zone.parse("2024-01-03T12:00:00.500Z"))
+
+      fresh_agent = Agent.find(@agent.id)
+      expect { fresh_agent.check }.not_to(change { Event.count })
+    end
+
+    it "keeps previously seen ids when a new raindrop shares the latest timestamp" do
+      @agent.memory["since"] = "2024-01-02T12:00:00.000Z"
+      @agent.memory["since_ids"] = ["1002"]
+      @agent.save!
+
+      stub_raindrops({
+        result: true,
+        items: [
+          raindrop_item(1002, "2024-01-02T12:00:00.000Z"),
+          raindrop_item(1004, "2024-01-02T12:00:00.000Z"),
+        ],
+      }.to_json)
+
+      expect { @agent.check }.to change { Event.count }.by(1)
+      expect(@agent.events.last.payload["_id"]).to eq(1004)
+      expect(@agent.memory["since_ids"]).to match_array(["1002", "1004"])
+
+      fresh_agent = Agent.find(@agent.id)
+      expect { fresh_agent.check }.not_to(change { Event.count })
     end
   end
 end


### PR DESCRIPTION
## Problem

RaindropBookmarksAgent re-emitted the same raindrops on every check.  Two bugs in the dedup memory caused this:

1. **Millisecond truncation**: `memory["since"]` was saved with `Time#iso8601`, which drops sub-second precision.  Raindrop's `created` timestamps carry milliseconds (e.g. `…T12:00:00.500Z`), so on the next check the latest raindrop compared as strictly newer than `since`, failed the `already_seen?` test, and was emitted again — and `since` was saved truncated again, repeating forever.
2. **`since_ids` overwrite on shared timestamps**: when a new raindrop shared the exact `created` timestamp of an already-seen one, the seen item was skipped before the latest-id tracking ran, so `memory["since_ids"]` was rebuilt from newly emitted items only and the seen id was re-emitted on the next check.

## Fix

- Save `since` with `iso8601(3)` to keep millisecond precision.
- Seed the latest-timestamp tracking from the stored `since`/`since_ids` so already-seen ids at the latest timestamp are carried over.
- Check id membership before timestamps, so agents whose memory already holds a truncated `since` self-heal on their next check without emitting one more duplicate.
- Drop the `@since_ids` memoization, which could go stale across runs on a reused instance.

Regression specs added for both scenarios.