### PR TITLE
Raise MySQL sort_buffer_size for JSON columns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ DATABASE_PASSWORD=""
 
 # Set this to true to enable native JSON/JSONB columns for serialized fields
 # during migrations.  Leave it commented out to keep text columns.
+# MySQL only: sorting rows that contain JSON columns can exceed the default
+# sort_buffer_size (256K) and fail with "Out of sort memory" on MySQL 8, so
+# raise it to 4M or more in your server configuration when enabling this.
 #NATIVE_JSON_COLUMNS=true
 
 # MySQL only: If you are running a MySQL server >=5.5.3, you should

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -135,6 +135,11 @@ Ensure you can use the InnoDB engine which is necessary to support long indexes
     # If this fails, check your MySQL config files (e.g. `/etc/mysql/*.cnf`, `/etc/mysql/conf.d/*`)
     # for the setting "innodb = off"
 
+If you plan to enable `NATIVE_JSON_COLUMNS` in `.env`, raise `sort_buffer_size` in your MySQL config (e.g. `/etc/mysql/conf.d/huginn.cnf`).  Sorting rows that contain JSON columns can exceed the 256K default, making queries fail with "Out of sort memory" on MySQL 8:
+
+    [mysqld]
+    sort_buffer_size = 4M
+
 Grant the Huginn user necessary permissions on the database
 
     mysql> GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER, LOCK TABLES ON `huginn_production`.* TO 'huginn'@'localhost';

--- a/docker/multi-process/scripts/standalone-packages
+++ b/docker/multi-process/scripts/standalone-packages
@@ -29,6 +29,9 @@ cat >> "$MYSQLD_CNF" << EOF
 socket = /app/tmp/sockets/mysqld.sock
 pid-file = /app/tmp/pids/mysqld.pid
 user = 1001
+# Sorting rows that contain JSON columns (NATIVE_JSON_COLUMNS) can exceed the
+# 256K default and fail with "Out of sort memory" (ER 1038) on MySQL 8.
+sort_buffer_size = 4M
 EOF
 
 if mysqld --verbose --help 2>/dev/null | grep -q -- '--mysqlx-socket'; then


### PR DESCRIPTION
With `NATIVE_JSON_COLUMNS` enabled, `ORDER BY` queries on events include the JSON `payload` column in filesort rows, and MySQL 8 fails with "Out of sort memory, consider increasing server sort buffer size" (ER 1038) at the default `sort_buffer_size` of 256K.  Observed in production with `AgentReceiveJob` on a `DataOutputAgent` under MySQL 8.4: the jobs exhausted all retries and ended up as failed jobs.

- Set `sort_buffer_size = 4M` for the MySQL server bundled in the multi-process Docker image.
- Recommend the same in `.env.example` and the installation manual for self-managed MySQL servers.

`sort_buffer_size` is allocated per connection, so 4M keeps the overhead modest while leaving plenty of headroom for typical event payloads.  PostgreSQL (`jsonb`) is not affected.
