### PR TITLE
Improve agent search with type matching

### DIFF
--- a/app/assets/javascripts/components/search.js
+++ b/app/assets/javascripts/components/search.js
@@ -26,19 +26,58 @@ $(function () {
     }
   });
 
-  // substring matcher for typeahead
-  const substringMatcher = function (strings) {
-    let findMatches;
-    return (findMatches = function (query, callback) {
+  const substringMatcher = function (items) {
+    return function (query, callback) {
+      const term = query.trim().toUpperCase();
       const matches = [];
-      const substrRegex = new RegExp(query, "i");
-      $.each(strings, function (i, str) {
-        if (substrRegex.test(str)) {
-          return matches.push({ value: str });
+      $.each(items, function (index, item) {
+        const namePosition = item.value.toUpperCase().indexOf(term);
+        if (namePosition >= 0) {
+          matches.push({
+            ...item,
+            sortKey: [1, namePosition, index],
+          });
+          return;
+        }
+
+        const typePosition = (item.agentType || "")
+          .toUpperCase()
+          .indexOf(term);
+        if (typePosition >= 0) {
+          matches.push({
+            ...item,
+            sortKey: [2, typePosition, index],
+          });
         }
       });
+
+      matches.sort(function (left, right) {
+        for (let index = 0; index < left.sortKey.length; index += 1) {
+          const difference = left.sortKey[index] - right.sortKey[index];
+          if (difference !== 0) return difference;
+        }
+        return 0;
+      });
+
       return callback(matches.slice(0, 6));
-    });
+    };
+  };
+
+  const suggestionTemplate = function (item) {
+    const suggestion = document.createElement("p");
+    const name = document.createElement("span");
+    name.className = "agent-search-name";
+    name.appendChild(document.createTextNode(item.value));
+    suggestion.appendChild(name);
+
+    if (item.agentType) {
+      const type = document.createElement("small");
+      type.className = "agent-search-type";
+      type.appendChild(document.createTextNode(item.agentType));
+      suggestion.appendChild(type);
+    }
+
+    return suggestion;
   };
 
   return $agentNavigate.typeahead(
@@ -46,6 +85,10 @@ $(function () {
       minLength: 1,
       highlight: true,
     },
-    { source: substringMatcher(window.agentNames) }
+    {
+      displayKey: "value",
+      source: substringMatcher(window.agentSearchItems),
+      templates: { suggestion: suggestionTemplate },
+    }
   );
 });

--- a/app/assets/stylesheets/typeahead.scss
+++ b/app/assets/stylesheets/typeahead.scss
@@ -47,3 +47,12 @@
 .tt-suggestion p {
   margin: 0;
 }
+
+.agent-search-type {
+  display: block;
+  color: #777;
+}
+
+.tt-suggestion.tt-cursor .agent-search-type {
+  color: inherit;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,9 +51,12 @@
 
     <script>
       window.agentPaths = {};
-      window.agentNames = [];
+      window.agentSearchItems = [];
       <% if current_user.present? -%>
-        var myAgents = <%= Utils.jsonify(current_user.agents.pluck(:name, :id).inject({}) {|m, a| next if a.last.nil?; m[a.first] = agent_path(a.last); m }) %>;
+        var myAgents = <%= Utils.jsonify(current_user.agents.pluck(:name, :type, :id).each_with_object({}) { |(name, type, id), agents|
+          next if id.nil?
+          agents[name] = { url: agent_path(id), agent_type: agent_type_to_human(type) }
+        }) %>;
         var myScenarios = <%= Utils.jsonify(current_user.scenarios.pluck(:name, :id).inject({}) {|m, s| m[s.first + " Scenario"] = scenario_path(s.last); m }) %>;
         $.extend(window.agentPaths, myAgents);
         $.extend(window.agentPaths, myScenarios);
@@ -64,7 +67,12 @@
         window.agentPaths["View Agent Diagram"] = <%= Utils.jsonify diagram_path %>;
         window.agentPaths["Run Event Propagation"] = { url: <%= Utils.jsonify propagate_agents_path %>, method: 'POST' };
 
-        $.each(window.agentPaths, function(name, v) { window.agentNames.push(name); });
+        $.each(window.agentPaths, function(value, navigationData) {
+          window.agentSearchItems.push({
+            value: value,
+            agentType: navigationData.agent_type
+          });
+        });
       <% end -%>
     </script>
   </body>

--- a/spec/features/agent_search_spec.rb
+++ b/spec/features/agent_search_spec.rb
@@ -1,0 +1,27 @@
+require "capybara_helper"
+
+describe "Searching for an Agent", js: true do
+  before do
+    login_as(users(:bob))
+  end
+
+  it "shows Agent types and prioritizes name matches" do
+    agents(:bob_weather_agent).dup.tap do |agent|
+      agent.name = "Alpha"
+      agent.guid = SecureRandom.hex
+      agent.save!
+    end
+
+    visit root_path
+    find("#agent-navigate").set("Weather")
+
+    expect(page).to have_css(".tt-suggestion .agent-search-name", text: "Alpha")
+    suggestions = page.all(".tt-suggestion")
+    names = suggestions.map { |suggestion| suggestion.find(".agent-search-name").text }
+    alpha_index = names.index("Alpha")
+    name_match_indexes = names.each_index.select { |index| names[index].downcase.include?("weather") }
+
+    expect(alpha_index).to be > name_match_indexes.max
+    expect(suggestions[alpha_index]).to have_text("Weather Agent")
+  end
+end


### PR DESCRIPTION
Agent search currently only shows and matches the user-defined Agent name.

This adds the Agent type name (such as `Event Formatting Agent`) beneath each Agent name and includes it in search.  Results rank name matches before Agent type matches, with earlier substring matches ranked first within each group.
