### PR TITLE
Add Plivo agents for SMS and voice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ gem 'slack-notifier'
 gem 'omniauth-oauth', '~> 1.2', '>= 1.2.1'
 gem 'simple_oauth'
 
+# PlivoAgent
+gem 'plivo'
+
 # TwilioAgent
 gem 'twilio-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ GEM
     hipchat (1.6.0)
       httparty
       mimemagic
+    htmlentities (4.4.2)
     httmultiparty (0.3.16)
       httparty (>= 0.7.3)
       mimemagic
@@ -533,6 +534,10 @@ GEM
       faraday
       hashie
       multi_json
+    plivo (4.63.4)
+      faraday (~> 2.7)
+      htmlentities
+      jwt
     polyglot (0.3.5)
     pp (0.6.4)
       prettyprint
@@ -869,6 +874,7 @@ DEPENDENCIES
   pdf-reader
   pg (~> 1.6, >= 1.6.3)
   pirate_weather_forecast_ruby
+  plivo
   puma
   rails (~> 8.1.3)
   rails-controller-testing

--- a/app/models/agents/plivo_agent.rb
+++ b/app/models/agents/plivo_agent.rb
@@ -1,0 +1,106 @@
+require 'securerandom'
+
+module Agents
+  class PlivoAgent < Agent
+    cannot_be_scheduled!
+    cannot_create_events!
+    no_bulk_receive!
+
+    gem_dependency_check { defined?(Plivo) }
+
+    description <<~MD
+      The Plivo Agent receives and collects events and sends them via text message (up to 1600 characters) or gives you a call when scheduled.
+
+      #{'## Include `plivo` in your Gemfile to use this Agent!' if dependencies_missing?}
+
+      It is assumed that events have a `message`, `text`, or `sms` key, the value of which is sent as the content of the text message/call. You can use the EventFormattingAgent if your event does not provide these keys.
+
+      Set `receiver_cell` to the number to receive text messages/call and `sender_cell` to the number sending them. Both must be in E.164 format.
+
+      `expected_receive_period_in_days` is maximum number of days that you would expect to pass between events being received by this agent.
+
+      If you would like to receive calls, set `receive_call` to `true`. In this case, `server_url` must be set to the URL of your
+      Huginn installation (probably "https://#{ENV['DOMAIN']}"), which must be web-accessible.  Be sure to set http/https correctly.
+    MD
+
+    def default_options
+      {
+        'auth_id' => 'MAXXXXXXXXXXXXXXXXXX',
+        'auth_token' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        'sender_cell' => 'xxxxxxxxxx',
+        'receiver_cell' => 'xxxxxxxxxx',
+        'server_url' => 'http://somename.com:3000',
+        'receive_text' => true,
+        'receive_call' => false,
+        'expected_receive_period_in_days' => 1
+      }
+    end
+
+    def validate_options
+      unless options['auth_id'].present? && options['auth_token'].present? && options['sender_cell'].present? &&
+          options['receiver_cell'].present? && options['expected_receive_period_in_days'].present? &&
+          option_provided?(options['receive_call']) && option_provided?(options['receive_text'])
+        errors.add(:base,
+                   'auth_id, auth_token, sender_cell, receiver_cell, receive_text, receive_call and expected_receive_period_in_days are all required')
+      end
+
+      %w[receive_call receive_text].each do |key|
+        if option_provided?(options[key]) && boolify(options[key]).nil?
+          errors.add(:base, "#{key} must be a boolean value")
+        end
+      end
+    end
+
+    def receive(incoming_events)
+      memory['pending_calls'] ||= {}
+      interpolate_with_each(incoming_events) do |event|
+        message = (event.payload['message'].presence || event.payload['text'].presence || event.payload['sms'].presence).to_s
+        if message.present?
+          if boolify(interpolated['receive_call'])
+            secret = SecureRandom.hex 3
+            memory['pending_calls'][secret] = message
+            make_call secret
+          end
+
+          if boolify(interpolated['receive_text'])
+            message = message.slice 0..1600
+            send_message message
+          end
+        end
+      end
+    end
+
+    def working?
+      last_receive_at && last_receive_at > interpolated['expected_receive_period_in_days'].to_i.days.ago && !recent_error_logs?
+    end
+
+    def send_message(message)
+      client.messages.create src: interpolated['sender_cell'],
+                             dst: interpolated['receiver_cell'],
+                             text: message
+    end
+
+    def make_call(secret)
+      client.calls.create interpolated['sender_cell'],
+                          [interpolated['receiver_cell']],
+                          post_url(interpolated['server_url'], secret)
+    end
+
+    def post_url(server_url, secret)
+      "#{server_url}/users/#{user.id}/web_requests/#{id}/#{secret}"
+    end
+
+    def receive_web_request(params, method, format)
+      if memory['pending_calls'].has_key? params['secret']
+        response = Plivo::XML::Response.new
+        response.addSpeak(memory['pending_calls'][params['secret']], voice: 'WOMAN')
+        memory['pending_calls'].delete params['secret']
+        [response.to_xml, 200, 'text/xml']
+      end
+    end
+
+    def client
+      @client ||= Plivo::RestClient.new interpolated['auth_id'], interpolated['auth_token']
+    end
+  end
+end

--- a/app/models/agents/plivo_receive_text_agent.rb
+++ b/app/models/agents/plivo_receive_text_agent.rb
@@ -1,0 +1,97 @@
+module Agents
+  class PlivoReceiveTextAgent < Agent
+    cannot_be_scheduled!
+    cannot_receive_events!
+
+    gem_dependency_check { defined?(Plivo) }
+
+    description do
+      <<~MD
+        The Plivo Receive Text Agent receives text messages from Plivo and emits them as events.
+
+        #{'## Include `plivo` in your Gemfile to use this Agent!' if dependencies_missing?}
+
+        In order to create events with this agent, set the Message URL of your Plivo number (or application) to send POST requests to:
+
+        ```
+        #{post_url}
+        ```
+
+        #{'The placeholder symbols above will be replaced by their values once the agent is saved.' unless id}
+
+        Options:
+
+        * `server_url` must be set to the URL of your
+        Huginn installation (probably "https://#{ENV['DOMAIN']}"), which must be web-accessible.  Be sure to set http/https correctly.
+
+        * `auth_id` and `auth_token` are your Plivo account credentials. `auth_token` is used to validate the `X-Plivo-Signature-V3` header on incoming requests.
+
+        * If `reply_text` is set, its contents will be sent back to the sender as a confirmation text.
+
+        * `expected_receive_period_in_days` - How often you expect to receive events this way. Used to determine if the agent is working.
+      MD
+    end
+
+    def default_options
+      {
+        'auth_id' => 'MAXXXXXXXXXXXXXXXXXX',
+        'auth_token' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        'server_url' => "https://#{ENV['DOMAIN'].presence || 'example.com'}",
+        'reply_text' => '',
+        'expected_receive_period_in_days' => 1
+      }
+    end
+
+    def validate_options
+      unless options['auth_id'].present? && options['auth_token'].present? && options['server_url'].present? && options['expected_receive_period_in_days'].present?
+        errors.add(:base, 'auth_id, auth_token, server_url, and expected_receive_period_in_days are all required')
+      end
+    end
+
+    def working?
+      event_created_within?(interpolated['expected_receive_period_in_days']) && !recent_error_logs?
+    end
+
+    def post_url
+      if interpolated['server_url'].present?
+        "#{interpolated['server_url']}/users/#{user.id}/web_requests/#{id || ':id'}/sms-endpoint"
+      else
+        "https://#{ENV['DOMAIN']}/users/#{user.id}/web_requests/#{id || ':id'}/sms-endpoint"
+      end
+    end
+
+    def receive_web_request(request)
+      params = request.params.except(:action, :controller, :agent_id, :user_id, :format)
+      method = request.method_symbol.to_s
+      headers = request.headers
+
+      # check the last url param: 'secret'
+      secret = params.delete('secret')
+      return ['Not Authorized', 401] unless secret == 'sms-endpoint'
+
+      signature = headers['HTTP_X_PLIVO_SIGNATURE_V3']
+      nonce = headers['HTTP_X_PLIVO_SIGNATURE_V3_NONCE']
+
+      # validate the request came from Plivo (V3 signature over the URL + nonce)
+      unless Plivo::Utils.valid_signatureV3?(post_url, nonce, signature, interpolated['auth_token'], method, params)
+        error("Plivo Signature Failed to Validate\n\n" +
+          "URL: #{post_url}\n\n" +
+          "POST params: #{params.inspect}\n\n" +
+          "Signature: #{signature}")
+        return ['Not authorized', 401]
+      end
+
+      if create_event(payload: params)
+        response = Plivo::XML::Response.new
+        if interpolated['reply_text'].present?
+          # Plivo's <Message> element needs an explicit sender and recipient:
+          # reply from our number (the inbound `To`) back to the sender (`From`).
+          response.addMessage(interpolated['reply_text'], src: params['To'], dst: params['From'])
+        end
+        [response.to_xml, 200, 'text/xml']
+      else
+        ['Bad request', 400]
+      end
+    end
+  end
+end

--- a/spec/models/agents/plivo_agent_spec.rb
+++ b/spec/models/agents/plivo_agent_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+describe Agents::PlivoAgent do
+  before do
+    @checker = Agents::PlivoAgent.new(:name => 'somename',
+                                      :options => { :auth_id => 'x',
+                                                    :auth_token => 'x',
+                                                    :sender_cell => 'x',
+                                                    :receiver_cell => '{{to}}',
+                                                    :server_url    => 'http://somename.com:3000',
+                                                    :receive_text  => 'true',
+                                                    :receive_call  => 'true',
+                                                    :expected_receive_period_in_days => '1' })
+    @checker.user = users(:bob)
+    @checker.save!
+
+    @event = Event.new
+    @event.agent = agents(:bob_weather_agent)
+    @event.payload = { message: 'Looks like its going to rain', to: 54321 }
+    @event.save!
+
+    @messages = []
+    @calls = []
+
+    allow(Plivo::RestClient).to receive(:new) do
+      instance_double(Plivo::RestClient).tap { |c|
+        allow(c).to receive(:calls) do
+          double.tap { |l|
+            allow(l).to receive(:create) do |*args, **kwargs|
+              @calls << (kwargs.empty? ? args : kwargs)
+            end
+          }
+        end
+        allow(c).to receive(:messages) do
+          double.tap { |l|
+            allow(l).to receive(:create) do |*args, **kwargs|
+              @messages << (kwargs.empty? ? args.first : kwargs)
+            end
+          }
+        end
+      }
+    end
+  end
+
+  describe '#receive' do
+    it 'should make sure multiple events are being received' do
+      event1 = Event.new
+      event1.agent = agents(:bob_rain_notifier_agent)
+      event1.payload = { message: 'Some message', to: 12345 }
+      event1.save!
+
+      event2 = Event.new
+      event2.agent = agents(:bob_weather_agent)
+      event2.payload = { message: 'Some other message', to: 987654 }
+      event2.save!
+
+      @checker.receive([@event, event1, event2])
+      expect(@messages).to eq [
+        { src: "x", dst: "54321", text: "Looks like its going to rain" },
+        { src: "x", dst: "12345", text: "Some message" },
+        { src: "x", dst: "987654", text: "Some other message" }
+      ]
+    end
+
+    it 'should check if receive_text is working fine' do
+      @checker.options[:receive_text] = 'false'
+      @checker.receive([@event])
+      expect(@messages).to be_empty
+    end
+
+    it 'should check if receive_call is working fine' do
+      @checker.options[:receive_call] = 'true'
+      @checker.receive([@event])
+      expect(@checker.memory[:pending_calls]).not_to eq({})
+    end
+  end
+
+  describe '#working?' do
+    it 'checks if events have been received within the expected receive period' do
+      expect(@checker).not_to be_working # No events received
+      Agents::PlivoAgent.async_receive @checker.id, [@event.id]
+      expect(@checker.reload).to be_working # Just received events
+      two_days_from_now = 2.days.from_now
+      allow(Time).to receive(:now) { two_days_from_now }
+      expect(@checker.reload).not_to be_working # More time has passed than the expected receive period without any new events
+    end
+  end
+
+  describe "validation" do
+    before do
+      expect(@checker).to be_valid
+    end
+
+    it "accepts boolean receive flags" do
+      @checker.options[:receive_text] = false
+      @checker.options[:receive_call] = true
+      expect(@checker).to be_valid
+    end
+
+    it "should validate presence of auth_id" do
+      @checker.options[:auth_id] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of auth_token" do
+      @checker.options[:auth_token] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of receiver_cell" do
+      @checker.options[:receiver_cell] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of sender_cell" do
+      @checker.options[:sender_cell] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should make sure filling server_url is not necessary" do
+      @checker.options[:server_url] = ""
+      expect(@checker).to be_valid
+    end
+  end
+end

--- a/spec/models/agents/plivo_receive_text_agent_spec.rb
+++ b/spec/models/agents/plivo_receive_text_agent_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+# Plivo inbound message params
+# https://www.plivo.com/docs/sms/api/message#receive-a-message
+describe Agents::PlivoReceiveTextAgent do
+  before do
+    # Skip the real V3 signature check in tests.
+    allow(Plivo::Utils).to receive(:valid_signatureV3?) { true }
+  end
+
+  let(:payload) {
+    {
+      "From" => "+12485551111",
+      "To" => "+1347555555",
+      "Text" => "Hy",
+      "Type" => "sms",
+      "MessageUUID" => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      "TotalAmount" => "0",
+      "TotalRate" => "0",
+      "Units" => "1"
+    }
+  }
+
+  describe 'receive_plivo_text_message' do
+    before do
+      @agent = Agents::PlivoReceiveTextAgent.new(
+        :name => 'plivoreceive',
+        :options => { :auth_id => 'x',
+                      :auth_token => 'x',
+                      :server_url => 'http://example.com',
+                      :expected_receive_period_in_days => 1 }
+      )
+      @agent.user = users(:bob)
+      @agent.save!
+    end
+
+    it 'should create event upon receiving request' do
+      request = ActionDispatch::Request.new({
+        'action_dispatch.request.request_parameters' => payload.merge({ "secret" => "sms-endpoint" }),
+        'REQUEST_METHOD' => "POST",
+        'HTTP_ACCEPT' => 'application/xml',
+        'HTTP_X_PLIVO_SIGNATURE_V3' => "dummy-signature",
+        'HTTP_X_PLIVO_SIGNATURE_V3_NONCE' => "dummy-nonce"
+      })
+
+      out = nil
+      expect {
+        out = @agent.receive_web_request(request)
+      }.to change { Event.count }.by(1)
+      expect(out[1]).to eq(200)
+      expect(out[2]).to eq("text/xml")
+      expect(out[0]).to include("Response")
+      expect(Event.last.payload).to eq(payload)
+    end
+  end
+
+  describe 'receive_plivo_text_message and send a response' do
+    before do
+      @agent = Agents::PlivoReceiveTextAgent.new(
+        :name => 'plivoreceive',
+        :options => { :auth_id => 'x',
+                      :auth_token => 'x',
+                      :server_url => 'http://example.com',
+                      :reply_text => "thanks!",
+                      :expected_receive_period_in_days => 1 }
+      )
+      @agent.user = users(:bob)
+      @agent.save!
+    end
+
+    it 'should create event and include the reply in the XML response if reply_text is set' do
+      request = ActionDispatch::Request.new({
+        'action_dispatch.request.request_parameters' => payload.merge({ "secret" => "sms-endpoint" }),
+        'REQUEST_METHOD' => "POST",
+        'HTTP_ACCEPT' => 'application/xml',
+        'HTTP_X_PLIVO_SIGNATURE_V3' => "dummy-signature",
+        'HTTP_X_PLIVO_SIGNATURE_V3_NONCE' => "dummy-nonce"
+      })
+      out = nil
+      expect {
+        out = @agent.receive_web_request(request)
+      }.to change { Event.count }.by(1)
+      expect(out[1]).to eq(200)
+      expect(out[0]).to include("thanks!")
+      expect(out[0]).to include("Message")
+      expect(Event.last.payload).to eq(payload)
+    end
+  end
+end


### PR DESCRIPTION
This adds two new agents for Plivo, following Huginn's existing agent conventions.

`PlivoAgent` sends an SMS or places a call when it receives an event, using Plivo's Messages and Call APIs, with the call speaking the message through Plivo XML. `PlivoReceiveTextAgent` receives inbound texts at a web request endpoint, validates the `X-Plivo-Signature-V3` header, emits each message as an event, and can optionally send a reply.

Both agents are auto-discovered like the other agents, add the `plivo` gem, and come with specs. The new specs pass under Huginn's Docker test harness.

Closes #3710