### PR TITLE
Deduplicate queued periodic runs

### DIFF
--- a/app/jobs/agent_run_schedule_job.rb
+++ b/app/jobs/agent_run_schedule_job.rb
@@ -4,4 +4,8 @@ class AgentRunScheduleJob < ActiveJob::Base
   def perform(time)
     Agent.run_schedule(time)
   end
+
+  def uniqueness_key
+    "agent_run_schedule/#{arguments.first}"
+  end
 end

--- a/config/initializers/delayed_job_uniqueness_key.rb
+++ b/config/initializers/delayed_job_uniqueness_key.rb
@@ -1,0 +1,53 @@
+module DelayedJobUniquenessKey
+  def uniqueness_key
+    job = ActiveJob::Base.deserialize(job_data)
+    return unless job.respond_to?(:uniqueness_key)
+
+    job.send(:deserialize_arguments_if_needed)
+    job.uniqueness_key
+  end
+end
+
+ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.prepend(DelayedJobUniquenessKey)
+
+module DelayedJobUniquenessKeyAdapter
+  require "active_job/enqueuing"
+
+  class DuplicateJobError < ActiveJob::EnqueueError; end
+
+  def enqueue(job, *args, **kwargs)
+    enqueue_uniquely(job) { super }
+  end
+
+  def enqueue_at(job, *args, **kwargs)
+    enqueue_uniquely(job) { super }
+  end
+
+  private
+
+  def enqueue_uniquely(job, &block)
+    uniqueness_key = job.try(:uniqueness_key)
+    return yield unless uniqueness_key
+
+    Delayed::Job.transaction(requires_new: true, &block)
+  rescue ActiveRecord::RecordNotUnique
+    raise DuplicateJobError, "duplicate uniqueness_key: #{uniqueness_key}"
+  end
+end
+
+ActiveJob::QueueAdapters::DelayedJobAdapter.prepend(DelayedJobUniquenessKeyAdapter)
+
+class DelayedJobUniquenessKeyPlugin < Delayed::Plugin
+  callbacks do |lifecycle|
+    lifecycle.before(:enqueue) do |job|
+      job.uniqueness_key = job.payload_object.try(:uniqueness_key)
+    end
+
+    lifecycle.after(:failure) do |_worker, job|
+      job.update_column(:uniqueness_key, nil) if job.persisted? && job.uniqueness_key
+    end
+  end
+end
+
+Delayed::Worker.plugins << DelayedJobUniquenessKeyPlugin
+Delayed::Worker.setup_lifecycle

--- a/db/migrate/20260811000000_add_uniqueness_key_to_delayed_jobs.rb
+++ b/db/migrate/20260811000000_add_uniqueness_key_to_delayed_jobs.rb
@@ -1,0 +1,6 @@
+class AddUniquenessKeyToDelayedJobs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :delayed_jobs, :uniqueness_key, :string
+    add_index :delayed_jobs, :uniqueness_key, unique: true
+  end
+end

--- a/lib/huginn_scheduler.rb
+++ b/lib/huginn_scheduler.rb
@@ -163,8 +163,11 @@ class HuginnScheduler < LongRunnable::Worker
 
   def run_schedule(time)
     with_mutex do
-      puts "Queuing schedule for #{time}"
-      AgentRunScheduleJob.perform_later(time)
+      if AgentRunScheduleJob.perform_later(time)
+        puts "Queued schedule for #{time}"
+      else
+        puts "Skipped schedule for #{time} (already queued)"
+      end
     end
   end
 

--- a/spec/initializers/delayed_job_uniqueness_key_spec.rb
+++ b/spec/initializers/delayed_job_uniqueness_key_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "delayed_job uniqueness_key" do
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    original_delay_jobs = Delayed::Worker.delay_jobs
+    ActiveJob::Base.queue_adapter = :delayed_job
+    Delayed::Worker.delay_jobs = true
+    example.run
+  ensure
+    ActiveJob::Base.queue_adapter = original_adapter
+    Delayed::Worker.delay_jobs = original_delay_jobs
+  end
+
+  it "stores the job's uniqueness key" do
+    AgentRunScheduleJob.perform_later("every_1m")
+
+    expect(Delayed::Job.last.uniqueness_key).to eq("agent_run_schedule/every_1m")
+  end
+
+  it "skips a duplicate job for the same schedule" do
+    expect {
+      2.times { AgentRunScheduleJob.perform_later("every_1m") }
+    }.to change(Delayed::Job, :count).by(1)
+  end
+
+  it "enqueues jobs for different schedules independently" do
+    expect {
+      AgentRunScheduleJob.perform_later("every_1m")
+      AgentRunScheduleJob.perform_later("every_1h")
+    }.to change(Delayed::Job, :count).by(2)
+  end
+
+  it "returns false and records an enqueue error for a duplicate" do
+    AgentRunScheduleJob.perform_later("every_1m")
+
+    attempted = nil
+    result = AgentRunScheduleJob.perform_later("every_1m") { |job| attempted = job }
+
+    expect(result).to be(false)
+    expect(attempted).not_to be_successfully_enqueued
+    expect(attempted.enqueue_error).to be_a(DelayedJobUniquenessKeyAdapter::DuplicateJobError)
+  end
+
+  it "does not deduplicate jobs without a uniqueness key" do
+    expect(Delayed::Job).not_to receive(:transaction)
+
+    expect {
+      2.times { AgentCleanupExpiredJob.perform_later }
+    }.to change(Delayed::Job, :count).by(2)
+  end
+
+  it "releases the key when the job permanently fails" do
+    AgentRunScheduleJob.perform_later("every_1m")
+    job = Delayed::Job.last
+
+    Delayed::Worker.lifecycle.run_callbacks(:failure, Delayed::Worker.new, job) do
+      job.fail!
+    end
+
+    expect(job.reload.uniqueness_key).to be_nil
+    expect { AgentRunScheduleJob.perform_later("every_1m") }
+      .to change(Delayed::Job, :count).by(1)
+  end
+end

--- a/spec/lib/huginn_scheduler_spec.rb
+++ b/spec/lib/huginn_scheduler_spec.rb
@@ -22,7 +22,13 @@ describe HuginnScheduler do
 
   it "should run scheduled agents" do
     expect(Agent).to receive(:run_schedule).with('every_1h')
-    expect_any_instance_of(IO).to receive(:puts).with('Queuing schedule for every_1h')
+    expect_any_instance_of(IO).to receive(:puts).with('Queued schedule for every_1h')
+    @scheduler.send(:run_schedule, 'every_1h')
+  end
+
+  it "should log when a scheduled run is already queued" do
+    expect(AgentRunScheduleJob).to receive(:perform_later).with('every_1h').and_return(false)
+    expect_any_instance_of(IO).to receive(:puts).with('Skipped schedule for every_1h (already queued)')
     @scheduler.send(:run_schedule, 'every_1h')
   end
 


### PR DESCRIPTION
Add a delayed_job uniqueness key backed by a database unique index so concurrent enqueue attempts for the same schedule are skipped.  Release keys on permanent failure and let the scheduler report skipped runs.

This resolves the issue where periodic jobs can pile up excessively when the worker is overloaded.
