### PR TITLE
Serialize concurrent Agent execution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,6 +140,7 @@ gem 'spectrum-rails'
 gem 'sprockets'
 gem 'terser'
 gem 'typhoeus'
+gem 'with_advisory_lock', '~> 7.5'
 
 group :development, :test do
   gem 'debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -784,6 +784,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_advisory_lock (7.6.0)
+      activerecord (>= 7.2)
     xmpp4r (0.5.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -899,6 +901,7 @@ DEPENDENCIES
   tzinfo-data
   vcr
   webmock
+  with_advisory_lock (~> 7.5)
   xmpp4r
 
 RUBY VERSION

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -33,7 +33,10 @@ class AgentsController < ApplicationController
   def handle_details_post
     @agent = current_user.agents.find(params[:id])
     if @agent.respond_to?(:handle_details_post)
-      render :json => @agent.handle_details_post(params) || {}
+      result = Agent.with_execution_lock(@agent.id) { |agent|
+        agent.handle_details_post(params)
+      } || {}
+      render json: result
     else
       @agent.error "#handle_details_post called on an instance of #{@agent.class} that does not define it."
       head 500

--- a/app/jobs/agent_check_job.rb
+++ b/app/jobs/agent_check_job.rb
@@ -1,9 +1,9 @@
 class AgentCheckJob < ActiveJob::Base
   # Given an Agent id, load the Agent, call #check on it, and then save it with an updated `last_check_at` timestamp.
   def perform(agent_id)
-    agent = Agent.find(agent_id)
-    begin
-      return if agent.unavailable?
+    Agent.with_execution_lock(agent_id) do |agent|
+      next if agent.unavailable?
+
       agent.check
       agent.last_check_at = Time.now
       agent.save!

--- a/app/jobs/agent_receive_job.rb
+++ b/app/jobs/agent_receive_job.rb
@@ -2,9 +2,9 @@ class AgentReceiveJob < ActiveJob::Base
   # Given an Agent id and an array of Event ids, load the Agent, call #receive on it with the Event objects, and then
   # save it with an updated `last_receive_at` timestamp.
   def perform(agent_id, event_ids)
-    agent = Agent.find(agent_id)
-    begin
-      return if agent.unavailable?
+    Agent.with_execution_lock(agent_id) do |agent|
+      next if agent.unavailable?
+
       agent.receive(Event.where(:id => event_ids).order(:id))
       agent.last_receive_at = Time.now
       agent.save!

--- a/app/jobs/agent_reemit_job.rb
+++ b/app/jobs/agent_reemit_job.rb
@@ -1,10 +1,12 @@
 class AgentReemitJob < ActiveJob::Base
   # Given an Agent, re-emit all of agent's events up to (and including) `most_recent_event_id`
   def perform(agent, most_recent_event_id, delete_old_events = false)
-    # `find_each` orders by PK, so events get re-created in the same order
-    agent.events.where("id <= ?", most_recent_event_id).find_each do |event|
-      event.reemit!
-      event.destroy if delete_old_events
+    Agent.with_execution_lock(agent.id) do |locked_agent|
+      # `find_each` orders by PK, so events get re-created in the same order
+      locked_agent.events.where("id <= ?", most_recent_event_id).find_each do |event|
+        event.reemit!
+        event.destroy if delete_old_events
+      end
     end
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -4,6 +4,8 @@ require 'utils'
 # be sub-classed for many different purposes.  Agents can emit Events, as well as receive them and react in many different ways.
 # The basic Agent API is detailed on the Huginn wiki: https://github.com/huginn/huginn/wiki/Creating-a-new-agent
 class Agent < ActiveRecord::Base
+  EXECUTION_LOCK_PREFIX = "huginn:agent:execution:".freeze
+
   include AssignableTypes
   include MarkdownClassAttributes
   include JsonSerializedField
@@ -92,6 +94,19 @@ class Agent < ActiveRecord::Base
     type.demodulize
   end
 
+  def self.with_execution_lock(agent_id)
+    with_advisory_lock!("#{EXECUTION_LOCK_PREFIX}#{agent_id}", disable_query_cache: true) do
+      yield find(agent_id)
+    end
+  end
+
+  def with_execution_lock
+    self.class.with_advisory_lock!("#{EXECUTION_LOCK_PREFIX}#{id}", disable_query_cache: true) do
+      reload
+      yield self
+    end
+  end
+
   def check
     # Implement me in your subclass of Agent.
   end
@@ -168,6 +183,12 @@ class Agent < ActiveRecord::Base
   end
 
   def trigger_web_request(request)
+    with_execution_lock do |agent|
+      agent.send(:perform_web_request, request)
+    end
+  end
+
+  private def perform_web_request(request)
     params = request.params.except(:action, :controller, :agent_id, :user_id, :format)
     if respond_to?(:receive_webhook)
       Rails.logger.warn "DEPRECATED: The .receive_webhook method is deprecated, please switch your Agent to use .receive_web_request."

--- a/app/models/agents/jabber_agent.rb
+++ b/app/models/agents/jabber_agent.rb
@@ -124,7 +124,9 @@ module Agents
         time, nick, message = normalize_args(event, args)
 
         AgentRunner.with_connection do
-          agent.create_event(payload: { event:, time:, nick:, message: })
+          Agent.with_execution_lock(agent.id) do |locked_agent|
+            locked_agent.create_event(payload: { event:, time:, nick:, message: })
+          end
         end
       end
 

--- a/app/models/agents/local_file_agent.rb
+++ b/app/models/agents/local_file_agent.rb
@@ -175,12 +175,14 @@ module Agents
 
       def callback(*changes)
         AgentRunner.with_connection do
-          changes.zip([:modified, :added, :removed]).each do |files, event_type|
-            files.each do |file|
-              agent.create_event payload: agent.get_file_pointer(file).merge(event_type:)
+          Agent.with_execution_lock(agent.id) do |locked_agent|
+            changes.zip([:modified, :added, :removed]).each do |files, event_type|
+              files.each do |file|
+                locked_agent.create_event payload: locked_agent.get_file_pointer(file).merge(event_type:)
+              end
             end
+            locked_agent.touch(:last_check_at)
           end
-          agent.touch(:last_check_at)
         end
       end
 

--- a/app/models/agents/twitter_stream_agent.rb
+++ b/app/models/agents/twitter_stream_agent.rb
@@ -296,7 +296,7 @@ module Agents
           @filter_to_agent_map[filter].each do |agent|
             puts "(#{Time.now}) #{agent.name} received: #{status[:text]}"
             AgentRunner.with_connection do
-              agent.process_tweet(filter, status)
+              Agent.with_execution_lock(agent.id) { |locked_agent| locked_agent.process_tweet(filter, status) }
             end
           end
         end

--- a/lib/huginn_scheduler.rb
+++ b/lib/huginn_scheduler.rb
@@ -61,7 +61,7 @@ class Rufus::Scheduler
         job.scheduler_agent_id = agent_id
 
         if scheduler_agent = job.scheduler_agent
-          scheduler_agent.control!
+          Agent.with_execution_lock(scheduler_agent.id) { |agent| agent.control! }
         else
           puts "Unscheduling SchedulerAgent##{job.scheduler_agent_id} (disabled or deleted)"
           job.unschedule

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1,7 +1,46 @@
 require 'rails_helper'
+require 'timeout'
 
 describe Agent do
   it_behaves_like WorkingHelpers
+
+  describe ".with_execution_lock" do
+    it "serializes execution of the same Agent" do
+      agent = agents(:bob_weather_agent)
+      first_entered = Queue.new
+      release_first = Queue.new
+      second_entered = Queue.new
+      holder_connection = Agent.connection_db_config.new_connection
+      holder_connection.pool = Agent.connection_pool
+      lock_name = "#{Agent::EXECUTION_LOCK_PREFIX}#{agent.id}"
+
+      first_thread = Thread.new do
+        holder_connection.with_advisory_lock_if_needed(lock_name, disable_query_cache: true) do
+          first_entered << agent.id
+          release_first.pop
+        end
+      end
+      expect(Timeout.timeout(2) { first_entered.pop }).to eq(agent.id)
+
+      second_thread = Thread.new do
+        Agent.with_execution_lock(agent.id) { |locked_agent| second_entered << locked_agent.id }
+      end
+
+      expect { Timeout.timeout(0.2) { second_entered.pop } }.to raise_error(Timeout::Error)
+      release_first << true
+      expect(Timeout.timeout(2) { second_entered.pop }).to eq(agent.id)
+      [first_thread, second_thread].each(&:value)
+    ensure
+      release_first&.push(true)
+      [first_thread, second_thread].compact.each do |thread|
+        next if thread.join(2)
+
+        thread.kill
+        thread.join
+      end
+      holder_connection&.disconnect!
+    end
+  end
 
   describe '.active/inactive' do
     let(:agent) { agents(:jane_website_agent) }

--- a/spec/models/agents/twitter_stream_agent_spec.rb
+++ b/spec/models/agents/twitter_stream_agent_spec.rb
@@ -167,7 +167,7 @@ describe Agents::TwitterStreamAgent do
 
   describe Agents::TwitterStreamAgent::Worker do
     before(:each) do
-      @mock_agent = double
+      @mock_agent = double(id: @agent.id)
       @config = { agent: @agent, config: { filter_to_agent_map: { 'agent' => [@mock_agent] } } }
       @worker = Agents::TwitterStreamAgent::Worker.new(@config)
       @worker.instance_variable_set(:@recent_tweets, [])
@@ -327,6 +327,7 @@ describe Agents::TwitterStreamAgent do
 
       it "calls the agent to process the tweet" do
         expect(@mock_agent).to receive(:name) { 'mock' }
+        expect(Agent).to receive(:with_execution_lock).with(@agent.id).and_yield(@mock_agent)
         expect(@mock_agent).to receive(:process_tweet).with('agent',
                                                             { text: 'agent', id: 123, id_str: '123', user: { name: 'Mock User' }, expanded_text: 'agent' })
         expect(@worker).to receive(:puts).with(a_string_matching(/received/))


### PR DESCRIPTION
Serializes each Agent's execution with a database advisory lock, covering jobs, web requests, scheduler agents, and long-running callbacks.