### PR TITLE
Serialize event propagation scans

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -5,6 +5,7 @@ require 'utils'
 # The basic Agent API is detailed on the Huginn wiki: https://github.com/huginn/huginn/wiki/Creating-a-new-agent
 class Agent < ActiveRecord::Base
   EXECUTION_LOCK_PREFIX = "huginn:agent:execution:".freeze
+  PROPAGATION_LOCK_NAME = "huginn:agent:propagation".freeze
 
   include AssignableTypes
   include MarkdownClassAttributes
@@ -424,41 +425,43 @@ class Agent < ActiveRecord::Base
     # `async_receive`.
     # This is called by bin/schedule.rb periodically.
     def receive!
-      Agent.transaction do
-        agents_to_events = Hash.new { |hash, receiver_id| hash[receiver_id] = [] }
+      with_advisory_lock!(PROPAGATION_LOCK_NAME, disable_query_cache: true) do
+        Agent.transaction do
+          agents_to_events = Hash.new { |hash, receiver_id| hash[receiver_id] = [] }
 
-        all
-          .joins("JOIN links ON (links.receiver_id = agents.id)")
-          .joins("JOIN agents AS sources ON (links.source_id = sources.id)")
-          .joins("JOIN events ON (events.agent_id = sources.id AND events.id > links.event_id_at_creation)")
-          .where("NOT agents.disabled AND NOT agents.deactivated AND (agents.last_checked_event_id IS NULL OR events.id > agents.last_checked_event_id)")
-          .pluck("agents.id", "sources.type", "agents.type", "events.id")
-          .each do |receiver_agent_id, source_agent_type, receiver_agent_type, event_id|
-            begin
-              Object.const_get(source_agent_type)
-              Object.const_get(receiver_agent_type)
-            rescue NameError
-              next
+          all
+            .joins("JOIN links ON (links.receiver_id = agents.id)")
+            .joins("JOIN agents AS sources ON (links.source_id = sources.id)")
+            .joins("JOIN events ON (events.agent_id = sources.id AND events.id > links.event_id_at_creation)")
+            .where("NOT agents.disabled AND NOT agents.deactivated AND (agents.last_checked_event_id IS NULL OR events.id > agents.last_checked_event_id)")
+            .pluck("agents.id", "sources.type", "agents.type", "events.id")
+            .each do |receiver_agent_id, source_agent_type, receiver_agent_type, event_id|
+              begin
+                Object.const_get(source_agent_type)
+                Object.const_get(receiver_agent_type)
+              rescue NameError
+                next
+              end
+
+              agents_to_events[receiver_agent_id] << event_id
             end
 
-            agents_to_events[receiver_agent_id] << event_id
+          Agent.where(id: agents_to_events.keys).each do |agent|
+            event_ids = agents_to_events[agent.id].uniq
+            agent.update_attribute :last_checked_event_id, event_ids.max
+
+            if agent.no_bulk_receive?
+              event_ids.each { |event_id| Agent.async_receive(agent.id, [event_id]) }
+            else
+              Agent.async_receive(agent.id, event_ids)
+            end
           end
 
-        Agent.where(id: agents_to_events.keys).each do |agent|
-          event_ids = agents_to_events[agent.id].uniq
-          agent.update_attribute :last_checked_event_id, event_ids.max
-
-          if agent.no_bulk_receive?
-            event_ids.each { |event_id| Agent.async_receive(agent.id, [event_id]) }
-          else
-            Agent.async_receive(agent.id, event_ids)
-          end
+          {
+            agent_count: agents_to_events.keys.length,
+            event_count: agents_to_events.values.flatten.uniq.compact.length
+          }
         end
-
-        {
-          agent_count: agents_to_events.keys.length,
-          event_count: agents_to_events.values.flatten.uniq.compact.length
-        }
       end
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,7 +24,7 @@ class Event < ActiveRecord::Base
   }
 
   after_create :update_agent_last_event_at
-  after_create :possibly_propagate
+  after_create_commit :possibly_propagate
 
   scope :expired, lambda {
     where("expires_at IS NOT NULL AND expires_at < ?", Time.now)
@@ -97,7 +97,8 @@ class Event < ActiveRecord::Base
 
   def possibly_propagate
     # immediately schedule agents that want immediate updates
-    Agent.where(id: agent.receivers.where(propagate_immediately: true)).receive!
+    receivers = Agent.where(id: agent.receivers.where(propagate_immediately: true))
+    receivers.receive! if receivers.exists?
   end
 
   public def to_liquid

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -326,6 +326,41 @@ describe Agent do
                                                 status: 200)
       end
 
+      it "serializes event selection and enqueueing" do
+        first_entered = Queue.new
+        release_first = Queue.new
+        second_finished = Queue.new
+        holder_connection = Agent.connection_db_config.new_connection
+        holder_connection.pool = Agent.connection_pool
+
+        first_thread = Thread.new do
+          holder_connection.with_advisory_lock_if_needed(Agent::PROPAGATION_LOCK_NAME, disable_query_cache: true) do
+            first_entered << true
+            release_first.pop
+          end
+        end
+        expect(Timeout.timeout(2) { first_entered.pop }).to be(true)
+
+        second_thread = Thread.new do
+          Agent.none.receive!
+          second_finished << true
+        end
+
+        expect { Timeout.timeout(0.2) { second_finished.pop } }.to raise_error(Timeout::Error)
+        release_first << true
+        expect(Timeout.timeout(2) { second_finished.pop }).to be(true)
+        [first_thread, second_thread].each(&:value)
+      ensure
+        release_first&.push(true)
+        [first_thread, second_thread].compact.each do |thread|
+          next if thread.join(2)
+
+          thread.kill
+          thread.join
+        end
+        holder_connection&.disconnect!
+      end
+
       it "should use available events" do
         Agent.async_check(agents(:bob_weather_agent).id)
         expect(Agent).to receive(:async_receive).with(agents(:bob_rain_notifier_agent).id, anything).once

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -548,7 +548,7 @@ describe Agent do
     end
 
     describe "creating agents with propagate_immediately = true" do
-      it "should schedule subagent events immediately" do
+      it "schedules subagent events after the event transaction commits" do
         Event.delete_all
         sender = Agents::SomethingSource.new(name: "Sending Agent")
         sender.user = users(:bob)
@@ -562,10 +562,23 @@ describe Agent do
         receiver.sources << sender
         receiver.save!
 
-        sender.create_event payload: { "message" => "new payload" }
+        Agent.transaction do
+          sender.create_event payload: { "message" => "new payload" }
+          expect(receiver.events.count).to eq(0)
+        end
+
         expect(sender.events.count).to eq(1)
         expect(receiver.events.count).to eq(1)
         # should be true without calling Agent.receive!
+      end
+
+      it "does not scan for propagation without immediate receivers" do
+        sender = Agents::SomethingSource.new(name: "Sending Agent")
+        sender.user = users(:bob)
+        sender.save!
+
+        expect(Agent).not_to receive(:with_advisory_lock!)
+        sender.create_event payload: { "message" => "new payload" }
       end
 
       it "should only schedule receiving agents that are set to propagate_immediately" do


### PR DESCRIPTION
Protect event selection, receiver cursor updates, and receive-job enqueueing with a database advisory lock so concurrent propagation calls cannot enqueue the same events twice.