### PR TITLE
Limit manual event propagation to current user

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -105,7 +105,7 @@ class AgentsController < ApplicationController
   def propagate
     respond_to do |format|
       if AgentPropagateJob.can_enqueue?
-        details = Agent.receive! # Eventually this should probably be scoped to the current_user.
+        details = current_user.agents.receive!
         format.html { redirect_back "Queued propagation calls for #{details[:event_count]} event(s) on #{details[:agent_count]} agent(s)" }
         format.json { head :ok }
       else

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -419,35 +419,30 @@ class Agent < ActiveRecord::Base
       @gem_dependencies_checked && !@gem_dependencies_met
     end
 
-    # Find all Agents that have received Events since the last execution of this method.  Update those Agents with
-    # their new `last_checked_event_id` and queue each of the Agents to be called with #receive using `async_receive`.
+    # Find all Agents in the current scope that have received Events since the last execution of this method.  Update
+    # those Agents with their new `last_checked_event_id` and queue each of them to be called with #receive using
+    # `async_receive`.
     # This is called by bin/schedule.rb periodically.
-    def receive!(options = {})
+    def receive!
       Agent.transaction do
-        scope = Agent
-          .select("agents.id AS receiver_agent_id, sources.type AS source_agent_type, agents.type AS receiver_agent_type, events.id AS event_id")
+        agents_to_events = Hash.new { |hash, receiver_id| hash[receiver_id] = [] }
+
+        all
           .joins("JOIN links ON (links.receiver_id = agents.id)")
           .joins("JOIN agents AS sources ON (links.source_id = sources.id)")
           .joins("JOIN events ON (events.agent_id = sources.id AND events.id > links.event_id_at_creation)")
           .where("NOT agents.disabled AND NOT agents.deactivated AND (agents.last_checked_event_id IS NULL OR events.id > agents.last_checked_event_id)")
-        if options[:only_receivers].present?
-          scope = scope.where("agents.id in (?)", options[:only_receivers])
-        end
+          .pluck("agents.id", "sources.type", "agents.type", "events.id")
+          .each do |receiver_agent_id, source_agent_type, receiver_agent_type, event_id|
+            begin
+              Object.const_get(source_agent_type)
+              Object.const_get(receiver_agent_type)
+            rescue NameError
+              next
+            end
 
-        sql = scope.to_sql
-
-        agents_to_events = {}
-        Agent.connection.select_rows(sql).each do |receiver_agent_id, source_agent_type, receiver_agent_type, event_id|
-          begin
-            Object.const_get(source_agent_type)
-            Object.const_get(receiver_agent_type)
-          rescue NameError
-            next
+            agents_to_events[receiver_agent_id] << event_id
           end
-
-          agents_to_events[receiver_agent_id.to_i] ||= []
-          agents_to_events[receiver_agent_id.to_i] << event_id
-        end
 
         Agent.where(id: agents_to_events.keys).each do |agent|
           event_ids = agents_to_events[agent.id].uniq

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -97,8 +97,7 @@ class Event < ActiveRecord::Base
 
   def possibly_propagate
     # immediately schedule agents that want immediate updates
-    propagate_ids = agent.receivers.where(propagate_immediately: true).pluck(:id)
-    Agent.receive!(only_receivers: propagate_ids) unless propagate_ids.empty?
+    Agent.where(id: agent.receivers.where(propagate_immediately: true)).receive!
   end
 
   public def to_liquid

--- a/spec/controllers/agents_controller_spec.rb
+++ b/spec/controllers/agents_controller_spec.rb
@@ -147,8 +147,11 @@ describe AgentsController do
       sign_in users(:bob), scope: :user
     end
 
-    it "runs event propagation for all Agents" do
-      expect(Agent).to receive(:receive!).and_call_original
+    it "runs event propagation only for the current user's Agents" do
+      expect(Agent).to receive(:receive!).and_wrap_original do |method|
+        expect(Agent.current_scope.ids).to match_array(users(:bob).agents.ids)
+        method.call
+      end
       post :propagate
     end
 

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -332,6 +332,21 @@ describe Agent do
         Agent.receive!
       end
 
+      it "does not propagate for an empty scope" do
+        Agent.async_check(agents(:bob_weather_agent).id)
+        expect(Agent).not_to receive(:async_receive)
+        expect(Agent.none.receive!).to eq(agent_count: 0, event_count: 0)
+      end
+
+      it "only propagates to receivers in the scope" do
+        Agent.async_check(agents(:bob_weather_agent).id)
+        Agent.async_check(agents(:jane_weather_agent).id)
+        expect(Agent).to receive(:async_receive).with(agents(:bob_rain_notifier_agent).id, anything).once
+        expect(Agent).not_to receive(:async_receive).with(agents(:jane_rain_notifier_agent).id, anything)
+
+        users(:bob).agents.receive!
+      end
+
       it "should not propagate to disabled Agents" do
         Agent.async_check(agents(:bob_weather_agent).id)
         agents(:bob_rain_notifier_agent).update_attribute :disabled, true


### PR DESCRIPTION
- Limit manually triggered event propagation to the signed-in user's Agents.
- Make `Agent.receive!` honor Active Record scopes so callers can scope propagation through relations.
- Use the scoped API for immediate propagation and make empty scopes no-ops.