### PR TITLE
Fix Docker documentation for current startup flow

### DIFF
--- a/doc/docker/install.md
+++ b/doc/docker/install.md
@@ -11,7 +11,7 @@ Getting Huginn up and running using docker is quick and painless once you have d
 1. Install Docker using the [install instructions](https://docs.docker.com/get-docker/)
 * Start your Huginn container using `docker run -it -p 3000:3000 ghcr.io/huginn/huginn`
 * Open Huginn in the browser [http://localhost:3000](http://localhost:3000)
-* Log in to your Huginn instance using the username `admin` and password `password`
+* Log in to your Huginn instance using the username `admin` and the random password printed once in the container log. To choose the credentials yourself, pass `-e SEED_USERNAME=... -e SEED_PASSWORD=...` to `docker run`.
 
 ## Configuration and linking to a database container
 

--- a/doc/manual/installation.md
+++ b/doc/manual/installation.md
@@ -5,7 +5,7 @@
 
 This guide is long because it covers many cases and includes all commands you need.
 
-This installation guide was created for and tested on **Debian/Ubuntu** operating systems. Please read [doc/install/requirements.md](./requirements.md) for hardware and operating system requirements.
+This installation guide was created for and tested on **Debian/Ubuntu** operating systems. Please read [the requirements](./requirements.md) for hardware and operating system requirements.
 
 This is the official installation guide to set up a production server. To set up a **development installation** or for many other installation options please see [the getting started section of the readme](https://github.com/huginn/huginn#getting-started).
 

--- a/doc/manual/requirements.md
+++ b/doc/manual/requirements.md
@@ -27,7 +27,7 @@ Please consider using a virtual machine to run Huginn on Windows.
 
 ## Ruby versions
 
-Huginn requires Ruby (MRI) 2.2 or 2.3.
+Huginn requires Ruby (MRI) 3.4.0 or newer. The current Docker images and manual installation guide use Ruby 4.0.6.
 You will have to use the standard MRI implementation of Ruby.
 We love [JRuby](http://jruby.org/) and [Rubinius](http://rubini.us/) but Huginn needs several Gems that have native extensions.
 

--- a/docker/multi-process/README.md
+++ b/docker/multi-process/README.md
@@ -102,19 +102,19 @@ To use a separate, non-linked mysql container:
         -e HUGINN_DATABASE_PORT=3306
         ghcr.io/huginn/huginn
 
-The `docker/multi-process` folder also has a `docker-compose.yml` that allows for a sample database formation with a data volume container:
+The `docker/multi-process` folder also has a `develop.yml` Compose file that allows for a sample database setup with a data volume container:
 
     cd docker/multi-process
-    docker-compose up
+    docker-compose -f develop.yml up
 
 If you already have a MySQL 5.7 data volume, cleanly shut it down before the first MySQL 8.0 start:
 
     cd docker/multi-process
-    docker-compose stop web
-    docker-compose exec mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SET GLOBAL innodb_fast_shutdown = 0"'
-    docker-compose stop mysql
-    docker-compose pull mysql mysqldata
-    docker-compose up -d
+    docker-compose -f develop.yml stop web
+    docker-compose -f develop.yml exec mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SET GLOBAL innodb_fast_shutdown = 0"'
+    docker-compose -f develop.yml stop mysql
+    docker-compose -f develop.yml pull mysql mysqldata
+    docker-compose -f develop.yml up -d
 
 Run this while the old MySQL 5.7 container is still available.  The MySQL 8.0 Docker image automatically performs the data dictionary upgrade when it starts with the existing data volume.
 


### PR DESCRIPTION
The Docker and manual installation guides contain instructions that no longer match the current repository. The multi-process Docker README still tells users to run a removed `docker-compose.yml`, the Docker installation guide says the admin password is always `password` even though the current seeder generates a random password, and the manual guide links to a nonexistent `doc/install/requirements.md` path while its requirements page still says Ruby 2.2/2.3.

This change:

- points every multi-process Compose command at the checked-in `develop.yml` file;
- documents the generated password and the `SEED_USERNAME`/`SEED_PASSWORD` overrides in the Docker quick start;
- fixes the manual requirements link;
- aligns the documented Ruby requirement with `Gemfile` and the current 4.0.6 Docker/manual setup.

The Compose file parses successfully with Docker Compose v5, and `git diff --check` passes.

Fixes #3421
